### PR TITLE
Fix compilation errors for Swift 6 strict concurrency

### DIFF
--- a/Sources/HotAppClone/Services/AccessibilityPermissionService.swift
+++ b/Sources/HotAppClone/Services/AccessibilityPermissionService.swift
@@ -7,7 +7,7 @@ struct AccessibilityPermissionService {
 
     @discardableResult
     func requestIfNeeded(prompt: Bool = true) -> Bool {
-        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: prompt] as CFDictionary
+        let options = ["AXTrustedCheckOptionPrompt": prompt] as CFDictionary
         return AXIsProcessTrustedWithOptions(options)
     }
 }

--- a/Sources/HotAppClone/Services/EventTapManager.swift
+++ b/Sources/HotAppClone/Services/EventTapManager.swift
@@ -65,9 +65,9 @@ final class EventTapManager {
     }
 
     private func handle(event: CGEvent) {
-        let flags = NSEvent.ModifierFlags(cgEventFlags: event.flags)
+        let flags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
         let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
-        onKeyPress?(KeyPress(keyCode: keyCode, modifiers: flags.intersection(.deviceIndependentFlagsMask)))
+        onKeyPress?(KeyPress(keyCode: keyCode, modifiers: flags.intersection(NSEvent.ModifierFlags.deviceIndependentFlagsMask)))
     }
 }
 

--- a/Sources/HotAppClone/main.swift
+++ b/Sources/HotAppClone/main.swift
@@ -1,12 +1,7 @@
 import AppKit
 
-@main
-struct HotAppCloneMain {
-    static func main() {
-        let app = NSApplication.shared
-        let delegate = AppDelegate()
-        app.delegate = delegate
-        app.setActivationPolicy(.accessory)
-        app.run()
-    }
-}
+let app = NSApplication.shared
+let delegate = AppDelegate()
+app.delegate = delegate
+app.setActivationPolicy(.accessory)
+app.run()


### PR DESCRIPTION
## Summary
- Remove `@main` attribute from `main.swift` — conflicts with top-level code designation of `main.swift`
- Fix `NSEvent.ModifierFlags` init from `CGEventFlags` using `rawValue` conversion instead of non-existent `cgEventFlags:` label
- Replace `kAXTrustedCheckOptionPrompt` global var access with string literal `"AXTrustedCheckOptionPrompt"` for Swift 6 concurrency safety

## Verification
- `swift build` ✅
- `swift test` ✅ (1 test passed)
- `swift build -c release` ✅

Closes #1