### PR TITLE
Fix EventTap memory leak, silent failure, and deprecation warnings

### DIFF
--- a/Sources/HotAppClone/Services/AppSwitcher.swift
+++ b/Sources/HotAppClone/Services/AppSwitcher.swift
@@ -27,6 +27,6 @@ final class AppSwitcher {
         }
 
         frontmostTracker.noteCurrentFrontmostApp(excluding: shortcut.bundleIdentifier)
-        return runningApp.activate(options: [.activateIgnoringOtherApps])
+        return runningApp.activate()
     }
 }

--- a/Sources/HotAppClone/Services/EventTapManager.swift
+++ b/Sources/HotAppClone/Services/EventTapManager.swift
@@ -1,6 +1,9 @@
 import AppKit
 import ApplicationServices
 import Carbon.HIToolbox
+import os.log
+
+private let logger = Logger(subsystem: "com.hotappclone", category: "EventTapManager")
 
 @MainActor
 final class EventTapManager {
@@ -13,6 +16,7 @@ final class EventTapManager {
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
+    private var retainedBox: Unmanaged<EventTapBox>?
     private var onKeyPress: ShortcutHandler?
 
     func start(onKeyPress: @escaping ShortcutHandler) {
@@ -31,7 +35,8 @@ final class EventTapManager {
         }
 
         let box = EventTapBox(manager: self)
-        let userInfo = UnsafeMutableRawPointer(Unmanaged.passRetained(box).toOpaque())
+        let retained = Unmanaged.passRetained(box)
+        let userInfo = UnsafeMutableRawPointer(retained.toOpaque())
 
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
@@ -41,8 +46,12 @@ final class EventTapManager {
             callback: callback,
             userInfo: userInfo
         ) else {
+            retained.release()
+            logger.error("Failed to create CGEvent tap — ensure accessibility permissions are granted")
             return
         }
+
+        retainedBox = retained
 
         let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
         CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
@@ -59,6 +68,8 @@ final class EventTapManager {
         if let source = runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
         }
+        retainedBox?.release()
+        retainedBox = nil
         eventTap = nil
         runLoopSource = nil
         onKeyPress = nil

--- a/Sources/HotAppClone/Services/FrontmostApplicationTracker.swift
+++ b/Sources/HotAppClone/Services/FrontmostApplicationTracker.swift
@@ -21,6 +21,6 @@ final class FrontmostApplicationTracker {
               let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first else {
             return false
         }
-        return app.activate(options: [.activateIgnoringOtherApps])
+        return app.activate()
     }
 }


### PR DESCRIPTION
## Summary
- **EventTap memory leak**: `Unmanaged.passRetained(box)` was never released in `stop()`. Now stored as `retainedBox` property and explicitly released on stop/failure.
- **Silent tap creation failure**: Added `os.log` error message when `CGEvent.tapCreate` returns nil, pointing to accessibility permissions as likely cause.
- **Deprecation warnings**: Replaced `activateIgnoringOtherApps` (deprecated macOS 14) with `activate()` in AppSwitcher and FrontmostApplicationTracker.

Note: Carbon.HIToolbox usage in KeySymbolMapper/KeyMatcher is intentional — no modern alternative exists for `kVK_*` key code constants. NSHostingController lifecycle in SettingsWindowController is correct — `NSWindow(contentViewController:)` retains the controller.

## Verification
- `swift build` — 0 errors, 0 warnings
- `swift test` — 1 test passed
- `swift build -c release` — 0 errors, 0 warnings

Closes #2