### PR TITLE
Align permission model with Input Monitoring APIs

### DIFF
--- a/Sources/HotAppClone/Services/AccessibilityPermissionService.swift
+++ b/Sources/HotAppClone/Services/AccessibilityPermissionService.swift
@@ -1,13 +1,19 @@
-import ApplicationServices
+import IOKit
 
 struct AccessibilityPermissionService {
     func isTrusted() -> Bool {
-        AXIsProcessTrusted()
+        IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) == kIOHIDAccessTypeGranted
     }
 
     @discardableResult
     func requestIfNeeded(prompt: Bool = true) -> Bool {
-        let options = ["AXTrustedCheckOptionPrompt": prompt] as CFDictionary
-        return AXIsProcessTrustedWithOptions(options)
+        let status = IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)
+        if status == kIOHIDAccessTypeGranted {
+            return true
+        }
+        if prompt && status != kIOHIDAccessTypeDenied {
+            return IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)
+        }
+        return false
     }
 }

--- a/Sources/HotAppClone/Services/EventTapManager.swift
+++ b/Sources/HotAppClone/Services/EventTapManager.swift
@@ -41,13 +41,13 @@ final class EventTapManager {
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .headInsertEventTap,
-            options: .defaultTap,
+            options: .listenOnly,
             eventsOfInterest: CGEventMask(mask),
             callback: callback,
             userInfo: userInfo
         ) else {
             retained.release()
-            logger.error("Failed to create CGEvent tap — ensure accessibility permissions are granted")
+            logger.error("Failed to create CGEvent tap — ensure Input Monitoring permission is granted in System Settings > Privacy & Security")
             return
         }
 


### PR DESCRIPTION
## Summary
- Change CGEvent tap from `.defaultTap` to `.listenOnly` — read-only observation is sufficient for shortcut monitoring and requires the lighter Input Monitoring permission instead of full Accessibility
- Replace `AXIsProcessTrusted()`/`AXIsProcessTrustedWithOptions()` with `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)`/`IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)` to check the correct permission
- Update error logging to reference Input Monitoring in System Settings

**Root cause:** The app checked Accessibility permission but `.listenOnly` event taps require Input Monitoring permission — a different system permission. The check could pass while tap creation still failed silently.

## Verification
- `swift build` — 0 errors, 0 warnings
- `swift test` — 1 test passed
- `swift build -c release` — 0 errors, 0 warnings

Closes #10