### PR TITLE
Recover shortcut monitoring after permission changes

### DIFF
--- a/Sources/HotAppClone/Services/ShortcutManager.swift
+++ b/Sources/HotAppClone/Services/ShortcutManager.swift
@@ -1,4 +1,7 @@
 import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.hotappclone", category: "ShortcutManager")
 
 @MainActor
 final class ShortcutManager {
@@ -9,6 +12,8 @@ final class ShortcutManager {
     private let permissionService: AccessibilityPermissionService
     private let keyMatcher = KeyMatcher()
     private var triggerIndex: [ShortcutTrigger: AppShortcut] = [:]
+    private var permissionTimer: Timer?
+    private var lastPermissionState: Bool = false
 
     init(
         shortcutStore: ShortcutStore,
@@ -25,18 +30,14 @@ final class ShortcutManager {
     }
 
     func start() {
-        guard permissionService.requestIfNeeded(prompt: true) else {
-            return
-        }
-
-        rebuildIndex()
-
-        eventTapManager.start { [weak self] keyPress in
-            self?.handleKeyPress(keyPress)
-        }
+        permissionService.requestIfNeeded(prompt: true)
+        startPermissionMonitoring()
+        attemptStartIfPermitted()
     }
 
     func stop() {
+        permissionTimer?.invalidate()
+        permissionTimer = nil
         eventTapManager.stop()
     }
 
@@ -54,6 +55,43 @@ final class ShortcutManager {
     func hasAccessibilityAccess() -> Bool {
         permissionService.isTrusted()
     }
+
+    // MARK: - Permission monitoring
+
+    private func startPermissionMonitoring() {
+        lastPermissionState = permissionService.isTrusted()
+        permissionTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.checkPermissionChange()
+            }
+        }
+    }
+
+    private func checkPermissionChange() {
+        let granted = permissionService.isTrusted()
+        guard granted != lastPermissionState else { return }
+        lastPermissionState = granted
+
+        if granted {
+            logger.info("Input Monitoring permission granted — starting event tap")
+            attemptStartIfPermitted()
+        } else {
+            logger.warning("Input Monitoring permission revoked — stopping event tap")
+            eventTapManager.stop()
+        }
+    }
+
+    private func attemptStartIfPermitted() {
+        guard permissionService.isTrusted() else { return }
+        guard !eventTapManager.isRunning else { return }
+
+        rebuildIndex()
+        eventTapManager.start { [weak self] keyPress in
+            self?.handleKeyPress(keyPress)
+        }
+    }
+
+    // MARK: - Key handling
 
     private func rebuildIndex() {
         triggerIndex = keyMatcher.buildIndex(for: shortcutStore.shortcuts)


### PR DESCRIPTION
## Summary
- Add periodic permission polling (every 3 seconds) via `Timer` in ShortcutManager
- **Permission granted at runtime**: automatically start the event tap without relaunch
- **Permission revoked at runtime**: gracefully stop the event tap
- Log permission state transitions via `os.log` for debugging
- Clean up timer in `stop()` to prevent resource leaks

**Root cause:** `start()` previously checked permission once — if denied, monitoring never started even after the user later granted Input Monitoring access in System Settings.

## Recovery flow
```
App launch → permission denied → timer polls every 3s
    → user grants permission in System Settings
    → next poll detects change → starts event tap automatically
```

## Verification
- `swift build` — 0 errors, 0 warnings
- `swift test` — 3 tests passed
- `swift build -c release` — 0 errors, 0 warnings

Closes #17