### PR TITLE
Add launch-at-login support via SMAppService

### DIFF
--- a/Sources/HotAppClone/Services/LaunchAtLoginService.swift
+++ b/Sources/HotAppClone/Services/LaunchAtLoginService.swift
@@ -1,0 +1,26 @@
+import ServiceManagement
+import os.log
+
+private let logger = Logger(subsystem: "com.hotappclone", category: "LaunchAtLogin")
+
+struct LaunchAtLoginService {
+    private let service = SMAppService.mainApp
+
+    var isEnabled: Bool {
+        service.status == .enabled
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        do {
+            if enabled {
+                try service.register()
+                logger.info("Registered as login item")
+            } else {
+                try service.unregister()
+                logger.info("Unregistered as login item")
+            }
+        } catch {
+            logger.error("Failed to \(enabled ? "register" : "unregister") login item: \(error)")
+        }
+    }
+}

--- a/Sources/HotAppClone/UI/MenuBarController.swift
+++ b/Sources/HotAppClone/UI/MenuBarController.swift
@@ -5,10 +5,17 @@ final class MenuBarController {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private let onOpenSettings: () -> Void
     private let onQuit: () -> Void
+    private let launchAtLoginService: LaunchAtLoginService
+    private var launchAtLoginItem: NSMenuItem?
 
-    init(onOpenSettings: @escaping () -> Void, onQuit: @escaping () -> Void) {
+    init(
+        onOpenSettings: @escaping () -> Void,
+        onQuit: @escaping () -> Void,
+        launchAtLoginService: LaunchAtLoginService = LaunchAtLoginService()
+    ) {
         self.onOpenSettings = onOpenSettings
         self.onQuit = onQuit
+        self.launchAtLoginService = launchAtLoginService
     }
 
     func install() {
@@ -19,6 +26,13 @@ final class MenuBarController {
         let menu = NSMenu()
         menu.addItem(NSMenuItem(title: "Settings", action: #selector(openSettings), keyEquivalent: ","))
         menu.addItem(.separator())
+
+        let loginItem = NSMenuItem(title: "Launch at Login", action: #selector(toggleLaunchAtLogin), keyEquivalent: "")
+        loginItem.state = launchAtLoginService.isEnabled ? .on : .off
+        launchAtLoginItem = loginItem
+        menu.addItem(loginItem)
+
+        menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
         menu.items.forEach { $0.target = self }
         statusItem.menu = menu
@@ -27,6 +41,13 @@ final class MenuBarController {
     @objc
     private func openSettings() {
         onOpenSettings()
+    }
+
+    @objc
+    private func toggleLaunchAtLogin() {
+        let newState = !launchAtLoginService.isEnabled
+        launchAtLoginService.setEnabled(newState)
+        launchAtLoginItem?.state = launchAtLoginService.isEnabled ? .on : .off
     }
 
     @objc


### PR DESCRIPTION
## Summary
- Add `LaunchAtLoginService` wrapping `SMAppService.mainApp` for macOS 14+ login item registration
- Add "Launch at Login" toggle in menu bar with checkmark state indicator
- Uses system-managed login item persistence (no UserDefaults needed)

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 23/23 tests pass
- [x] `swift build -c release` passes
- [ ] Manual: toggle "Launch at Login" in menu bar, verify app appears in System Settings > Login Items

Closes #14