### PR TITLE
Reduce MainActor pressure with Sendable conformances

### DIFF
--- a/Sources/HotAppClone/Services/AccessibilityPermissionService.swift
+++ b/Sources/HotAppClone/Services/AccessibilityPermissionService.swift
@@ -1,6 +1,6 @@
 import IOKit
 
-struct AccessibilityPermissionService {
+struct AccessibilityPermissionService: Sendable {
     func isTrusted() -> Bool {
         IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) == kIOHIDAccessTypeGranted
     }

--- a/Sources/HotAppClone/Services/EventTapManager.swift
+++ b/Sources/HotAppClone/Services/EventTapManager.swift
@@ -9,7 +9,7 @@ private let logger = Logger(subsystem: "com.hotappclone", category: "EventTapMan
 final class EventTapManager {
     typealias ShortcutHandler = (KeyPress) -> Void
 
-    struct KeyPress: Equatable {
+    struct KeyPress: Equatable, Sendable {
         let keyCode: CGKeyCode
         let modifiers: NSEvent.ModifierFlags
     }

--- a/Sources/HotAppClone/Services/KeyMatcher.swift
+++ b/Sources/HotAppClone/Services/KeyMatcher.swift
@@ -1,7 +1,7 @@
 import AppKit
 import Carbon.HIToolbox
 
-struct ShortcutTrigger: Hashable {
+struct ShortcutTrigger: Hashable, Sendable {
     let keyCode: CGKeyCode
     let modifierMask: UInt
 }

--- a/Sources/HotAppClone/Services/PersistenceService.swift
+++ b/Sources/HotAppClone/Services/PersistenceService.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-struct PersistenceService {
-    private let fileManager = FileManager.default
+struct PersistenceService: Sendable {
     private let fileName = "shortcuts.json"
 
     func load() -> [AppShortcut] {
@@ -27,13 +26,14 @@ struct PersistenceService {
     }
 
     private func storageURL() -> URL? {
-        guard let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+        let fm = FileManager.default
+        guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             return nil
         }
 
         let directory = appSupport.appendingPathComponent("HotAppClone", isDirectory: true)
-        if !fileManager.fileExists(atPath: directory.path) {
-            try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        if !fm.fileExists(atPath: directory.path) {
+            try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
         }
         return directory.appendingPathComponent(fileName)
     }


### PR DESCRIPTION
## Summary
- Add `Sendable` to `ShortcutTrigger`, `EventTapManager.KeyPress`, `AccessibilityPermissionService`, and `PersistenceService`
- Remove stored `FileManager` property from `PersistenceService` (use local `FileManager.default` instead) to enable `Sendable`
- Document actor isolation decisions: runtime services stay `@MainActor` (AppKit requirement), pure logic types are non-isolated

## Actor boundary analysis
| Type | Isolation | Reason |
|------|-----------|--------|
| EventTapManager | `@MainActor` | CGEvent tap on main run loop |
| ShortcutManager | `@MainActor` | Owns EventTapManager, Timer |
| AppSwitcher | `@MainActor` | NSRunningApplication APIs |
| FrontmostApplicationTracker | `@MainActor` | NSWorkspace APIs |
| ShortcutStore | `@MainActor` | Shared mutable state |
| KeyMatcher | none (struct) | Pure logic, now with `Sendable` trigger type |
| ShortcutValidator | none (struct) | Pure logic |
| AccessibilityPermissionService | none + `Sendable` | Stateless IOKit calls |
| PersistenceService | none + `Sendable` | Stateless file I/O |

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 23/23 tests pass
- [x] `swift build -c release` passes

Closes #13