### PR TITLE
Add Hyper Key UI support with symbol display and badge

### DIFF
--- a/Sources/HotAppClone/Models/RecordedShortcut.swift
+++ b/Sources/HotAppClone/Models/RecordedShortcut.swift
@@ -4,6 +4,11 @@ struct RecordedShortcut: Equatable {
     var keyEquivalent: String
     var modifierFlags: [String]
 
+    var isHyper: Bool {
+        let normalized = Set(modifierFlags.map { $0.lowercased() })
+        return normalized.isSuperset(of: ["command", "option", "control", "shift"])
+    }
+
     var displayText: String {
         let modifiers = modifierFlags.map(Self.symbol(for:)).joined()
         return modifiers + keyEquivalent.uppercased()
@@ -18,5 +23,26 @@ struct RecordedShortcut: Equatable {
         case "function": return "fn"
         default: return modifier
         }
+    }
+}
+
+extension AppShortcut {
+    var isHyper: Bool {
+        let normalized = Set(modifierFlags.map { $0.lowercased() })
+        return normalized.isSuperset(of: ["command", "option", "control", "shift"])
+    }
+
+    var displayText: String {
+        let symbols = modifierFlags.map { mod -> String in
+            switch mod.lowercased() {
+            case "command": return "⌘"
+            case "option": return "⌥"
+            case "control": return "⌃"
+            case "shift": return "⇧"
+            case "function": return "fn"
+            default: return mod
+            }
+        }.joined()
+        return symbols + keyEquivalent.uppercased()
     }
 }

--- a/Sources/HotAppClone/UI/SettingsView.swift
+++ b/Sources/HotAppClone/UI/SettingsView.swift
@@ -46,8 +46,19 @@ struct SettingsView: View {
                     .frame(width: 240, height: 28)
 
                     if let recordedShortcut = viewModel.recordedShortcut {
-                        Text(recordedShortcut.displayText)
-                            .font(.system(.body, design: .monospaced))
+                        HStack(spacing: 4) {
+                            Text(recordedShortcut.displayText)
+                                .font(.system(.body, design: .monospaced))
+                            if recordedShortcut.isHyper {
+                                Text("Hyper")
+                                    .font(.caption2.bold())
+                                    .padding(.horizontal, 4)
+                                    .padding(.vertical, 1)
+                                    .background(.purple.opacity(0.2))
+                                    .foregroundStyle(.purple)
+                                    .clipShape(RoundedRectangle(cornerRadius: 3))
+                            }
+                        }
                     } else if viewModel.isRecordingShortcut {
                         Text("Listening…")
                             .foregroundStyle(.secondary)
@@ -81,8 +92,19 @@ struct SettingsView: View {
                                 .foregroundStyle(.secondary)
                         }
                         Spacer()
-                        Text(shortcut.modifierFlags.joined(separator: "+") + "+" + shortcut.keyEquivalent.uppercased())
-                            .font(.system(.body, design: .monospaced))
+                        HStack(spacing: 4) {
+                            Text(shortcut.displayText)
+                                .font(.system(.body, design: .monospaced))
+                            if shortcut.isHyper {
+                                Text("Hyper")
+                                    .font(.caption2.bold())
+                                    .padding(.horizontal, 4)
+                                    .padding(.vertical, 1)
+                                    .background(.purple.opacity(0.2))
+                                    .foregroundStyle(.purple)
+                                    .clipShape(RoundedRectangle(cornerRadius: 3))
+                            }
+                        }
                         Button(role: .destructive) {
                             viewModel.removeShortcut(id: shortcut.id)
                         } label: {


### PR DESCRIPTION
## Summary
- Add `isHyper` computed property to both `RecordedShortcut` and `AppShortcut` — detects when all 4 modifiers (⌃⌥⇧⌘) are present
- Add `displayText` to `AppShortcut` for consistent symbol rendering across the app
- Replace raw modifier names (`control+option+shift+command+H`) with proper macOS symbols (`⌃⌥⇧⌘H`) in the shortcut list
- Show a purple "Hyper" badge next to Hyper-style shortcuts in both the recorder preview and shortcut list

## Visual changes
| Before | After |
|--------|-------|
| `control+option+shift+command+H` | `⌃⌥⇧⌘H` **Hyper** |
| No visual distinction for 4-modifier combos | Purple badge for power users |

## Checklist from issue
- [x] Recorder captures ⌃⌥⇧⌘ correctly (already worked, validated in PR #33)
- [x] Symbol display with proper alignment
- [x] Global listening triggers correctly (validated in PR #33)
- [x] Persistence works (Codable round-trip, no changes needed)
- [x] "Hyper" badge for visual feedback

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 30/30 tests pass
- [x] `swift build -c release` passes
- [ ] Manual: record ⌃⌥⇧⌘+key, verify badge appears in recorder and list

Closes #35