### PR TITLE
Polish shortcut recorder UX and unsupported-key handling

### DIFF
--- a/Sources/HotAppClone/UI/ShortcutRecorderView.swift
+++ b/Sources/HotAppClone/UI/ShortcutRecorderView.swift
@@ -14,19 +14,23 @@ struct ShortcutRecorderView: NSViewRepresentable {
         field.onRecordingChange = { recording in
             isRecording = recording
         }
+        field.onCancel = {
+            isRecording = false
+        }
         return field
     }
 
     func updateNSView(_ nsView: RecorderField, context: Context) {
-        nsView.placeholderString = isRecording ? "Press shortcut" : "Click to record shortcut"
-        nsView.stringValue = recordedShortcut?.displayText ?? ""
+        nsView.updateRecordingState(isRecording: isRecording, shortcut: recordedShortcut)
     }
 }
 
 final class RecorderField: NSTextField {
     var onCapture: ((RecordedShortcut) -> Void)?
     var onRecordingChange: ((Bool) -> Void)?
+    var onCancel: (() -> Void)?
     private let keySymbolMapper = KeySymbolMapper()
+    private var isRecording = false
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -41,21 +45,61 @@ final class RecorderField: NSTextField {
         fatalError("init(coder:) has not been implemented")
     }
 
+    func updateRecordingState(isRecording: Bool, shortcut: RecordedShortcut?) {
+        self.isRecording = isRecording
+        if isRecording {
+            placeholderString = "Press shortcut (Esc to cancel)"
+            stringValue = ""
+            textColor = .controlAccentColor
+        } else {
+            placeholderString = "Click to record shortcut"
+            stringValue = shortcut?.displayText ?? ""
+            textColor = .labelColor
+        }
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
     override func mouseDown(with event: NSEvent) {
         window?.makeFirstResponder(self)
         onRecordingChange?(true)
     }
 
     override func keyDown(with event: NSEvent) {
-        let modifiers = normalizedModifiers(from: event.modifierFlags)
-        guard !modifiers.isEmpty,
-              let keyEquivalent = keySymbolMapper.keyEquivalent(for: CGKeyCode(event.keyCode)) else {
-            NSSound.beep()
+        guard isRecording else { return }
+
+        // Escape cancels recording
+        if event.keyCode == 53 {
+            onCancel?()
             return
         }
 
-        onCapture?(RecordedShortcut(keyEquivalent: keyEquivalent, modifierFlags: modifiers))
-        stringValue = RecordedShortcut(keyEquivalent: keyEquivalent, modifierFlags: modifiers).displayText
+        let modifiers = normalizedModifiers(from: event.modifierFlags)
+        let keyEquivalent = keySymbolMapper.keyEquivalent(for: CGKeyCode(event.keyCode))
+
+        if modifiers.isEmpty {
+            stringValue = "Requires at least one modifier (⌘⌥⌃⇧)"
+            textColor = .systemOrange
+            return
+        }
+
+        guard let keyEquivalent else {
+            stringValue = "Unsupported key — try a letter, number, or F-key"
+            textColor = .systemOrange
+            return
+        }
+
+        let shortcut = RecordedShortcut(keyEquivalent: keyEquivalent, modifierFlags: modifiers)
+        onCapture?(shortcut)
+        stringValue = shortcut.displayText
+        textColor = .labelColor
+    }
+
+    override func resignFirstResponder() -> Bool {
+        if isRecording {
+            onCancel?()
+        }
+        return super.resignFirstResponder()
     }
 
     private func normalizedModifiers(from flags: NSEvent.ModifierFlags) -> [String] {


### PR DESCRIPTION
## Summary
- Show descriptive inline messages for unsupported keys and missing modifiers instead of silent beeps
- Add Escape key to cancel recording
- Cancel recording when field loses focus (resignFirstResponder)
- Use accent color text during recording state for visual distinction
- Show "(Esc to cancel)" hint in placeholder during recording

## UX improvements
| Scenario | Before | After |
|----------|--------|-------|
| Press bare key (no modifier) | Beep | "Requires at least one modifier (⌘⌥⌃⇧)" |
| Press unsupported key (e.g. §) | Beep | "Unsupported key — try a letter, number, or F-key" |
| Want to cancel recording | Click elsewhere | Press Escape or click elsewhere |
| Recording state | Same appearance | Accent color text + "(Esc to cancel)" hint |

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 30/30 tests pass
- [x] `swift build -c release` passes
- [ ] Manual: click recorder, press bare key, verify message
- [ ] Manual: click recorder, press Escape, verify cancel
- [ ] Manual: click recorder, press unsupported key, verify message

Closes #3