### PR TITLE
Automate .app packaging end to end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.build/
+build/
+.swiftpm/
+.DS_Store
+*.xcodeproj/xcuserdata/

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -3,16 +3,39 @@ set -euo pipefail
 
 APP_NAME="HotAppClone"
 BUNDLE_ID="com.xrf9268.hotapp-clone"
-BUILD_DIR="$(pwd)/build"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$PROJECT_DIR/build"
 APP_DIR="$BUILD_DIR/${APP_NAME}.app"
 CONTENTS_DIR="$APP_DIR/Contents"
 MACOS_DIR="$CONTENTS_DIR/MacOS"
 RESOURCES_DIR="$CONTENTS_DIR/Resources"
+INFO_PLIST="$PROJECT_DIR/Sources/HotAppClone/Resources/Info.plist"
 
+echo "==> Building release binary..."
+swift build -c release --package-path "$PROJECT_DIR"
+
+BINARY="$PROJECT_DIR/.build/release/${APP_NAME}"
+if [ ! -f "$BINARY" ]; then
+    echo "Error: release binary not found at $BINARY" >&2
+    exit 1
+fi
+
+echo "==> Creating app bundle..."
 rm -rf "$APP_DIR"
 mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
 
-cat > "$CONTENTS_DIR/Info.plist" <<PLIST
+# Copy binary
+cp "$BINARY" "$MACOS_DIR/${APP_NAME}"
+chmod +x "$MACOS_DIR/${APP_NAME}"
+
+# Copy Info.plist from canonical source
+if [ -f "$INFO_PLIST" ]; then
+    cp "$INFO_PLIST" "$CONTENTS_DIR/Info.plist"
+    echo "    Info.plist copied from Sources/HotAppClone/Resources/Info.plist"
+else
+    echo "Warning: Info.plist not found at $INFO_PLIST, generating default" >&2
+    cat > "$CONTENTS_DIR/Info.plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -29,7 +52,7 @@ cat > "$CONTENTS_DIR/Info.plist" <<PLIST
 </dict>
 </plist>
 PLIST
+fi
 
-echo "Build the executable first with: swift build -c release"
-echo "Then copy .build/release/${APP_NAME} to ${MACOS_DIR}/${APP_NAME}"
-echo "App bundle scaffold created at: ${APP_DIR}"
+echo "==> Done: $APP_DIR"
+echo "    Run with: open $APP_DIR"


### PR DESCRIPTION
## Summary
- Rewrite `scripts/package-app.sh` to fully automate build + bundle in one command
- Builds release binary via `swift build -c release`
- Copies binary to `build/HotAppClone.app/Contents/MacOS/`
- Uses canonical `Info.plist` from `Sources/HotAppClone/Resources/` (falls back to inline generation)
- Add `.gitignore` for `.build/`, `build/`, `.swiftpm/`, `.DS_Store`

## Before vs After
| Before | After |
|--------|-------|
| Script only scaffolds bundle, prints manual instructions | `bash scripts/package-app.sh` produces runnable `.app` |
| Info.plist generated inline (could drift from source) | Copies canonical Info.plist from Resources |
| No .gitignore | Build artifacts excluded |

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 30/30 tests pass
- [x] `swift build -c release` passes
- [x] `bash scripts/package-app.sh` produces valid Mach-O arm64 app bundle
- [x] Bundle structure verified: `Contents/{Info.plist,MacOS/HotAppClone,Resources/}`

Closes #6