### PR TITLE
Add UsageTracker service with SQLite daily aggregation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,8 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "HotAppClone",
-            path: "Sources/HotAppClone"
+            path: "Sources/HotAppClone",
+            linkerSettings: [.linkedLibrary("sqlite3")]
         ),
         .testTarget(
             name: "HotAppCloneTests",

--- a/Sources/HotAppClone/AppController.swift
+++ b/Sources/HotAppClone/AppController.swift
@@ -4,11 +4,13 @@ import AppKit
 final class AppController {
     private let shortcutStore = ShortcutStore()
     private let persistenceService = PersistenceService()
+    private let usageTracker = UsageTracker()
     private lazy var appSwitcher = AppSwitcher()
     private lazy var shortcutManager = ShortcutManager(
         shortcutStore: shortcutStore,
         persistenceService: persistenceService,
-        appSwitcher: appSwitcher
+        appSwitcher: appSwitcher,
+        usageTracker: usageTracker
     )
     private lazy var menuBarController = MenuBarController(
         onOpenSettings: { [weak self] in self?.openSettings() },
@@ -16,7 +18,8 @@ final class AppController {
     )
     private lazy var settingsWindowController = SettingsWindowController(
         shortcutStore: shortcutStore,
-        shortcutManager: shortcutManager
+        shortcutManager: shortcutManager,
+        usageTracker: usageTracker
     )
 
     func start() {

--- a/Sources/HotAppClone/Services/ShortcutManager.swift
+++ b/Sources/HotAppClone/Services/ShortcutManager.swift
@@ -10,6 +10,7 @@ final class ShortcutManager {
     private let appSwitcher: AppSwitcher
     private let eventTapManager: EventTapManager
     private let permissionService: AccessibilityPermissionService
+    private let usageTracker: UsageTracker?
     private let keyMatcher = KeyMatcher()
     private var triggerIndex: [ShortcutTrigger: AppShortcut] = [:]
     private var permissionTimer: Timer?
@@ -20,13 +21,15 @@ final class ShortcutManager {
         persistenceService: PersistenceService,
         appSwitcher: AppSwitcher,
         eventTapManager: EventTapManager = EventTapManager(),
-        permissionService: AccessibilityPermissionService = AccessibilityPermissionService()
+        permissionService: AccessibilityPermissionService = AccessibilityPermissionService(),
+        usageTracker: UsageTracker? = nil
     ) {
         self.shortcutStore = shortcutStore
         self.persistenceService = persistenceService
         self.appSwitcher = appSwitcher
         self.eventTapManager = eventTapManager
         self.permissionService = permissionService
+        self.usageTracker = usageTracker
     }
 
     func start() {
@@ -49,7 +52,11 @@ final class ShortcutManager {
 
     @discardableResult
     func trigger(_ shortcut: AppShortcut) -> Bool {
-        appSwitcher.toggleApplication(for: shortcut)
+        let success = appSwitcher.toggleApplication(for: shortcut)
+        if success, let usageTracker {
+            Task { await usageTracker.recordUsage(shortcutId: shortcut.id) }
+        }
+        return success
     }
 
     func hasAccessibilityAccess() -> Bool {

--- a/Sources/HotAppClone/Services/UsageTracker.swift
+++ b/Sources/HotAppClone/Services/UsageTracker.swift
@@ -1,0 +1,183 @@
+import Foundation
+import SQLite3
+import os.log
+
+private let logger = Logger(subsystem: "com.hotappclone", category: "UsageTracker")
+
+actor UsageTracker {
+    private nonisolated(unsafe) let db: OpaquePointer?
+
+    init() {
+        db = Self.openDatabase(path: Self.defaultDatabasePath())
+        if let db {
+            Self.createTable(db: db)
+        }
+    }
+
+    init(databasePath: String) {
+        db = Self.openDatabase(path: databasePath)
+        if let db {
+            Self.createTable(db: db)
+        }
+    }
+
+    deinit {
+        if let db { sqlite3_close(db) }
+    }
+
+    // MARK: - Write
+
+    func recordUsage(shortcutId: UUID) {
+        let sql = """
+            INSERT INTO daily_usage (shortcut_id, date, count)
+            VALUES (?, ?, 1)
+            ON CONFLICT(shortcut_id, date) DO UPDATE SET count = count + 1
+            """
+        guard let stmt = prepare(sql) else { return }
+        defer { sqlite3_finalize(stmt) }
+
+        let idString = shortcutId.uuidString
+        sqlite3_bind_text(stmt, 1, (idString as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(stmt, 2, (todayString() as NSString).utf8String, -1, nil)
+
+        if sqlite3_step(stmt) != SQLITE_DONE {
+            logger.error("Failed to record usage: \(String(cString: sqlite3_errmsg(self.db!)))")
+        }
+    }
+
+    func deleteUsage(shortcutId: UUID) {
+        let sql = "DELETE FROM daily_usage WHERE shortcut_id = ?"
+        guard let stmt = prepare(sql) else { return }
+        defer { sqlite3_finalize(stmt) }
+
+        let idString = shortcutId.uuidString
+        sqlite3_bind_text(stmt, 1, (idString as NSString).utf8String, -1, nil)
+
+        if sqlite3_step(stmt) != SQLITE_DONE {
+            logger.error("Failed to delete usage: \(String(cString: sqlite3_errmsg(self.db!)))")
+        }
+    }
+
+    // MARK: - Read
+
+    func usageCounts(days: Int) -> [UUID: Int] {
+        let sql = "SELECT shortcut_id, SUM(count) FROM daily_usage WHERE date >= ? GROUP BY shortcut_id"
+        guard let stmt = prepare(sql) else { return [:] }
+        defer { sqlite3_finalize(stmt) }
+
+        let cutoff = dateString(daysAgo: days)
+        sqlite3_bind_text(stmt, 1, (cutoff as NSString).utf8String, -1, nil)
+
+        var result: [UUID: Int] = [:]
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let idPtr = sqlite3_column_text(stmt, 0),
+                  let id = UUID(uuidString: String(cString: idPtr)) else { continue }
+            let count = Int(sqlite3_column_int64(stmt, 1))
+            result[id] = count
+        }
+        return result
+    }
+
+    func dailyCounts(days: Int) -> [String: [(date: String, count: Int)]] {
+        let sql = "SELECT shortcut_id, date, count FROM daily_usage WHERE date >= ? ORDER BY date"
+        guard let stmt = prepare(sql) else { return [:] }
+        defer { sqlite3_finalize(stmt) }
+
+        let cutoff = dateString(daysAgo: days)
+        sqlite3_bind_text(stmt, 1, (cutoff as NSString).utf8String, -1, nil)
+
+        var result: [String: [(date: String, count: Int)]] = [:]
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let idPtr = sqlite3_column_text(stmt, 0),
+                  let datePtr = sqlite3_column_text(stmt, 1) else { continue }
+            let id = String(cString: idPtr)
+            let date = String(cString: datePtr)
+            let count = Int(sqlite3_column_int64(stmt, 2))
+            result[id, default: []].append((date: date, count: count))
+        }
+        return result
+    }
+
+    func totalSwitches(days: Int) -> Int {
+        let sql = "SELECT COALESCE(SUM(count), 0) FROM daily_usage WHERE date >= ?"
+        guard let stmt = prepare(sql) else { return 0 }
+        defer { sqlite3_finalize(stmt) }
+
+        let cutoff = dateString(daysAgo: days)
+        sqlite3_bind_text(stmt, 1, (cutoff as NSString).utf8String, -1, nil)
+
+        if sqlite3_step(stmt) == SQLITE_ROW {
+            return Int(sqlite3_column_int64(stmt, 0))
+        }
+        return 0
+    }
+
+    // MARK: - Database setup
+
+    private static func defaultDatabasePath() -> String {
+        let fm = FileManager.default
+        guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return ":memory:"
+        }
+
+        let directory = appSupport.appendingPathComponent("HotAppClone", isDirectory: true)
+        if !fm.fileExists(atPath: directory.path) {
+            try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        return directory.appendingPathComponent("usage.db").path
+    }
+
+    private static func openDatabase(path: String) -> OpaquePointer? {
+        var db: OpaquePointer?
+        if sqlite3_open(path, &db) != SQLITE_OK {
+            logger.error("Failed to open database at \(path)")
+            return nil
+        }
+        return db
+    }
+
+    private static func createTable(db: OpaquePointer) {
+        let sql = """
+            CREATE TABLE IF NOT EXISTS daily_usage (
+                shortcut_id TEXT NOT NULL,
+                date        TEXT NOT NULL,
+                count       INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (shortcut_id, date)
+            )
+            """
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            logger.error("SQL prepare failed for CREATE TABLE")
+            return
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        if sqlite3_step(stmt) != SQLITE_DONE {
+            logger.error("Failed to create table: \(String(cString: sqlite3_errmsg(db)))")
+        }
+    }
+
+    private func prepare(_ sql: String) -> OpaquePointer? {
+        guard let db else { return nil }
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) != SQLITE_OK {
+            logger.error("SQL prepare failed: \(String(cString: sqlite3_errmsg(db)))")
+            return nil
+        }
+        return stmt
+    }
+
+    // MARK: - Date helpers
+
+    private func todayString() -> String {
+        dateString(daysAgo: 0)
+    }
+
+    private func dateString(daysAgo days: Int) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = .current
+        let date = Calendar.current.date(byAdding: .day, value: -days, to: Date()) ?? Date()
+        return formatter.string(from: date)
+    }
+}

--- a/Sources/HotAppClone/UI/SettingsViewModel.swift
+++ b/Sources/HotAppClone/UI/SettingsViewModel.swift
@@ -13,12 +13,14 @@ final class SettingsViewModel: ObservableObject {
 
     private let shortcutStore: ShortcutStore
     private let shortcutManager: ShortcutManager
+    private let usageTracker: UsageTracker?
     private let appBundleLocator = AppBundleLocator()
     private let shortcutValidator = ShortcutValidator()
 
-    init(shortcutStore: ShortcutStore, shortcutManager: ShortcutManager) {
+    init(shortcutStore: ShortcutStore, shortcutManager: ShortcutManager, usageTracker: UsageTracker? = nil) {
         self.shortcutStore = shortcutStore
         self.shortcutManager = shortcutManager
+        self.usageTracker = usageTracker
         self.shortcuts = shortcutStore.shortcuts
         self.accessibilityGranted = shortcutManager.hasAccessibilityAccess()
     }
@@ -54,6 +56,9 @@ final class SettingsViewModel: ObservableObject {
         let updated = shortcuts.filter { $0.id != id }
         shortcuts = updated
         shortcutManager.save(shortcuts: updated)
+        if let usageTracker {
+            Task { await usageTracker.deleteUsage(shortcutId: id) }
+        }
     }
 
     func chooseApplication() {

--- a/Sources/HotAppClone/UI/SettingsWindowController.swift
+++ b/Sources/HotAppClone/UI/SettingsWindowController.swift
@@ -5,11 +5,13 @@ import SwiftUI
 final class SettingsWindowController {
     private let shortcutStore: ShortcutStore
     private let shortcutManager: ShortcutManager
+    private let usageTracker: UsageTracker?
     private var window: NSWindow?
 
-    init(shortcutStore: ShortcutStore, shortcutManager: ShortcutManager) {
+    init(shortcutStore: ShortcutStore, shortcutManager: ShortcutManager, usageTracker: UsageTracker? = nil) {
         self.shortcutStore = shortcutStore
         self.shortcutManager = shortcutManager
+        self.usageTracker = usageTracker
     }
 
     func show() {
@@ -18,7 +20,7 @@ final class SettingsWindowController {
             return
         }
 
-        let viewModel = SettingsViewModel(shortcutStore: shortcutStore, shortcutManager: shortcutManager)
+        let viewModel = SettingsViewModel(shortcutStore: shortcutStore, shortcutManager: shortcutManager, usageTracker: usageTracker)
         let contentView = SettingsView(viewModel: viewModel)
         let hostingController = NSHostingController(rootView: contentView)
 

--- a/Tests/HotAppCloneTests/HotAppCloneTests.swift
+++ b/Tests/HotAppCloneTests/HotAppCloneTests.swift
@@ -308,3 +308,59 @@ struct KeySymbolMapperTests {
         }
     }
 }
+
+// MARK: - UsageTracker
+
+@Suite("UsageTracker")
+struct UsageTrackerTests {
+    @Test
+    func recordAndQueryUsage() async {
+        let tracker = UsageTracker(databasePath: ":memory:")
+        let id = UUID()
+
+        await tracker.recordUsage(shortcutId: id)
+        await tracker.recordUsage(shortcutId: id)
+
+        let counts = await tracker.usageCounts(days: 1)
+        #expect(counts[id] == 2)
+    }
+
+    @Test
+    func totalSwitchesAggregatesAll() async {
+        let tracker = UsageTracker(databasePath: ":memory:")
+        let id1 = UUID()
+        let id2 = UUID()
+
+        await tracker.recordUsage(shortcutId: id1)
+        await tracker.recordUsage(shortcutId: id1)
+        await tracker.recordUsage(shortcutId: id2)
+
+        let total = await tracker.totalSwitches(days: 1)
+        #expect(total == 3)
+    }
+
+    @Test
+    func deleteRemovesUsage() async {
+        let tracker = UsageTracker(databasePath: ":memory:")
+        let id = UUID()
+
+        await tracker.recordUsage(shortcutId: id)
+        await tracker.deleteUsage(shortcutId: id)
+
+        let counts = await tracker.usageCounts(days: 1)
+        #expect(counts[id] == nil)
+    }
+
+    @Test
+    func dailyCountsReturnsPerDayBreakdown() async {
+        let tracker = UsageTracker(databasePath: ":memory:")
+        let id = UUID()
+
+        await tracker.recordUsage(shortcutId: id)
+
+        let daily = await tracker.dailyCounts(days: 1)
+        let entries = daily[id.uuidString]
+        #expect(entries != nil)
+        #expect(entries?.isEmpty == false)
+    }
+}


### PR DESCRIPTION
## Summary
- New `UsageTracker` actor with SQLite-backed daily usage aggregation
- UPSERT pattern for efficient per-shortcut daily counting
- Batch query APIs: `usageCounts(days:)`, `dailyCounts(days:)`, `totalSwitches(days:)`
- Wired into `ShortcutManager` (records on successful toggle) and `SettingsViewModel` (deletes stats on shortcut removal)
- 4 unit tests using in-memory SQLite for isolation

## Architecture
```
AppController
  ├── UsageTracker (actor, owns SQLite db)
  ├── ShortcutManager ← usageTracker (records usage)
  └── SettingsWindowController → SettingsViewModel ← usageTracker (deletes usage)
```

## Schema
```sql
CREATE TABLE daily_usage (
    shortcut_id TEXT NOT NULL,
    date        TEXT NOT NULL,
    count       INTEGER NOT NULL DEFAULT 0,
    PRIMARY KEY (shortcut_id, date)
);
```

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 34/34 tests pass (4 new)
- [x] `swift build -c release` passes

Closes #40