### PR TITLE
Refactor SettingsView into tabbed layout

### DIFF
--- a/Sources/HotAppClone/UI/GeneralTabView.swift
+++ b/Sources/HotAppClone/UI/GeneralTabView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct GeneralTabView: View {
+    @ObservedObject var viewModel: SettingsViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Toggle("Launch at Login", isOn: Binding(
+                get: { viewModel.launchAtLoginEnabled },
+                set: { viewModel.setLaunchAtLogin($0) }
+            ))
+
+            Spacer()
+        }
+    }
+}

--- a/Sources/HotAppClone/UI/InsightsTabView.swift
+++ b/Sources/HotAppClone/UI/InsightsTabView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct InsightsTabView: View {
+    var body: some View {
+        VStack {
+            Spacer()
+            Text("Insights coming soon")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/Sources/HotAppClone/UI/SettingsView.swift
+++ b/Sources/HotAppClone/UI/SettingsView.swift
@@ -1,118 +1,31 @@
 import SwiftUI
 
+enum SettingsTab: String, CaseIterable {
+    case shortcuts = "Shortcuts"
+    case general = "General"
+    case insights = "Insights"
+}
+
 struct SettingsView: View {
     @ObservedObject var viewModel: SettingsViewModel
+    @State private var selectedTab: SettingsTab = .shortcuts
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("App Shortcuts")
-                .font(.title2)
-                .bold()
-
-            HStack(spacing: 12) {
-                Circle()
-                    .fill(viewModel.accessibilityGranted ? Color.green : Color.orange)
-                    .frame(width: 10, height: 10)
-                Text(viewModel.accessibilityGranted ? "Accessibility granted" : "Accessibility required for global shortcuts")
-                    .foregroundStyle(.secondary)
-                Button("Refresh") {
-                    viewModel.refreshPermissions()
-                }
-                Spacer()
-            }
-
-            HStack(spacing: 12) {
-                Button("Choose App") {
-                    viewModel.chooseApplication()
-                }
-                if !viewModel.selectedBundleIdentifier.isEmpty {
-                    Button("Reveal App") {
-                        viewModel.revealApplication()
-                    }
-                }
-                Text(viewModel.selectedAppName.isEmpty ? "No app selected" : viewModel.selectedAppName)
-                    .foregroundStyle(.secondary)
-                Spacer()
-            }
-
-            VStack(alignment: .leading, spacing: 8) {
-                TextField("Bundle Identifier", text: $viewModel.selectedBundleIdentifier)
-
-                HStack(spacing: 12) {
-                    ShortcutRecorderView(
-                        recordedShortcut: $viewModel.recordedShortcut,
-                        isRecording: $viewModel.isRecordingShortcut
-                    )
-                    .frame(width: 240, height: 28)
-
-                    if let recordedShortcut = viewModel.recordedShortcut {
-                        HStack(spacing: 4) {
-                            Text(recordedShortcut.displayText)
-                                .font(.system(.body, design: .monospaced))
-                            if recordedShortcut.isHyper {
-                                Text("Hyper")
-                                    .font(.caption2.bold())
-                                    .padding(.horizontal, 4)
-                                    .padding(.vertical, 1)
-                                    .background(.purple.opacity(0.2))
-                                    .foregroundStyle(.purple)
-                                    .clipShape(RoundedRectangle(cornerRadius: 3))
-                            }
-                        }
-                    } else if viewModel.isRecordingShortcut {
-                        Text("Listening…")
-                            .foregroundStyle(.secondary)
-                    }
-
-                    Button("Clear") {
-                        viewModel.clearRecordedShortcut()
-                    }
-                    .disabled(viewModel.recordedShortcut == nil && !viewModel.isRecordingShortcut)
+        VStack(spacing: 16) {
+            Picker("", selection: $selectedTab) {
+                ForEach(SettingsTab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
                 }
             }
+            .pickerStyle(.segmented)
 
-            if let conflictMessage = viewModel.conflictMessage {
-                Text(conflictMessage)
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
-
-            Button("Add Shortcut") {
-                viewModel.addShortcut()
-            }
-            .disabled(viewModel.selectedBundleIdentifier.isEmpty || viewModel.recordedShortcut == nil)
-
-            List {
-                ForEach(viewModel.shortcuts) { shortcut in
-                    HStack {
-                        VStack(alignment: .leading) {
-                            Text(shortcut.appName)
-                            Text(shortcut.bundleIdentifier)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                        Spacer()
-                        HStack(spacing: 4) {
-                            Text(shortcut.displayText)
-                                .font(.system(.body, design: .monospaced))
-                            if shortcut.isHyper {
-                                Text("Hyper")
-                                    .font(.caption2.bold())
-                                    .padding(.horizontal, 4)
-                                    .padding(.vertical, 1)
-                                    .background(.purple.opacity(0.2))
-                                    .foregroundStyle(.purple)
-                                    .clipShape(RoundedRectangle(cornerRadius: 3))
-                            }
-                        }
-                        Button(role: .destructive) {
-                            viewModel.removeShortcut(id: shortcut.id)
-                        } label: {
-                            Image(systemName: "trash")
-                        }
-                        .buttonStyle(.borderless)
-                    }
-                }
+            switch selectedTab {
+            case .shortcuts:
+                ShortcutsTabView(viewModel: viewModel)
+            case .general:
+                GeneralTabView(viewModel: viewModel)
+            case .insights:
+                InsightsTabView()
             }
         }
         .padding(20)

--- a/Sources/HotAppClone/UI/SettingsViewModel.swift
+++ b/Sources/HotAppClone/UI/SettingsViewModel.swift
@@ -10,12 +10,14 @@ final class SettingsViewModel: ObservableObject {
     @Published var isRecordingShortcut: Bool = false
     @Published var accessibilityGranted: Bool = false
     @Published var conflictMessage: String?
+    @Published var launchAtLoginEnabled: Bool = false
 
     private let shortcutStore: ShortcutStore
     private let shortcutManager: ShortcutManager
     private let usageTracker: UsageTracker?
     private let appBundleLocator = AppBundleLocator()
     private let shortcutValidator = ShortcutValidator()
+    private let launchAtLoginService = LaunchAtLoginService()
 
     init(shortcutStore: ShortcutStore, shortcutManager: ShortcutManager, usageTracker: UsageTracker? = nil) {
         self.shortcutStore = shortcutStore
@@ -23,6 +25,7 @@ final class SettingsViewModel: ObservableObject {
         self.usageTracker = usageTracker
         self.shortcuts = shortcutStore.shortcuts
         self.accessibilityGranted = shortcutManager.hasAccessibilityAccess()
+        self.launchAtLoginEnabled = launchAtLoginService.isEnabled
     }
 
     func addShortcut() {
@@ -88,6 +91,11 @@ final class SettingsViewModel: ObservableObject {
 
     func refreshPermissions() {
         accessibilityGranted = shortcutManager.hasAccessibilityAccess()
+    }
+
+    func setLaunchAtLogin(_ enabled: Bool) {
+        launchAtLoginService.setEnabled(enabled)
+        launchAtLoginEnabled = launchAtLoginService.isEnabled
     }
 
     func clearRecordedShortcut() {

--- a/Sources/HotAppClone/UI/ShortcutsTabView.swift
+++ b/Sources/HotAppClone/UI/ShortcutsTabView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+struct ShortcutsTabView: View {
+    @ObservedObject var viewModel: SettingsViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(viewModel.accessibilityGranted ? Color.green : Color.orange)
+                    .frame(width: 10, height: 10)
+                Text(viewModel.accessibilityGranted ? "Accessibility granted" : "Accessibility required for global shortcuts")
+                    .foregroundStyle(.secondary)
+                Button("Refresh") {
+                    viewModel.refreshPermissions()
+                }
+                Spacer()
+            }
+
+            HStack(spacing: 12) {
+                Button("Choose App") {
+                    viewModel.chooseApplication()
+                }
+                if !viewModel.selectedBundleIdentifier.isEmpty {
+                    Button("Reveal App") {
+                        viewModel.revealApplication()
+                    }
+                }
+                Text(viewModel.selectedAppName.isEmpty ? "No app selected" : viewModel.selectedAppName)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("Bundle Identifier", text: $viewModel.selectedBundleIdentifier)
+
+                HStack(spacing: 12) {
+                    ShortcutRecorderView(
+                        recordedShortcut: $viewModel.recordedShortcut,
+                        isRecording: $viewModel.isRecordingShortcut
+                    )
+                    .frame(width: 240, height: 28)
+
+                    if let recordedShortcut = viewModel.recordedShortcut {
+                        HStack(spacing: 4) {
+                            Text(recordedShortcut.displayText)
+                                .font(.system(.body, design: .monospaced))
+                            if recordedShortcut.isHyper {
+                                Text("Hyper")
+                                    .font(.caption2.bold())
+                                    .padding(.horizontal, 4)
+                                    .padding(.vertical, 1)
+                                    .background(.purple.opacity(0.2))
+                                    .foregroundStyle(.purple)
+                                    .clipShape(RoundedRectangle(cornerRadius: 3))
+                            }
+                        }
+                    } else if viewModel.isRecordingShortcut {
+                        Text("Listening…")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Button("Clear") {
+                        viewModel.clearRecordedShortcut()
+                    }
+                    .disabled(viewModel.recordedShortcut == nil && !viewModel.isRecordingShortcut)
+                }
+            }
+
+            if let conflictMessage = viewModel.conflictMessage {
+                Text(conflictMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            Button("Add Shortcut") {
+                viewModel.addShortcut()
+            }
+            .disabled(viewModel.selectedBundleIdentifier.isEmpty || viewModel.recordedShortcut == nil)
+
+            List {
+                ForEach(viewModel.shortcuts) { shortcut in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(shortcut.appName)
+                            Text(shortcut.bundleIdentifier)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        HStack(spacing: 4) {
+                            Text(shortcut.displayText)
+                                .font(.system(.body, design: .monospaced))
+                            if shortcut.isHyper {
+                                Text("Hyper")
+                                    .font(.caption2.bold())
+                                    .padding(.horizontal, 4)
+                                    .padding(.vertical, 1)
+                                    .background(.purple.opacity(0.2))
+                                    .foregroundStyle(.purple)
+                                    .clipShape(RoundedRectangle(cornerRadius: 3))
+                            }
+                        }
+                        Button(role: .destructive) {
+                            viewModel.removeShortcut(id: shortcut.id)
+                        } label: {
+                            Image(systemName: "trash")
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extract existing shortcut UI into `ShortcutsTabView`
- Add `GeneralTabView` with Launch at Login toggle (via `LaunchAtLoginService`)
- Add `InsightsTabView` with placeholder content for future issue #42/#43
- `SettingsView` uses segmented `Picker` to switch between three tabs
- Add `launchAtLoginEnabled` / `setLaunchAtLogin()` to `SettingsViewModel`

## Test plan
- [x] `swift build` passes (debug + release)
- [x] All 34 tests pass
- [ ] CI passes on GitHub Actions
- [ ] Manual: verify tab switching works, shortcuts tab retains all existing functionality

Closes #41