### PR TITLE
Add inline usage stats to Shortcuts tab

### DIFF
--- a/Sources/HotAppClone/UI/SettingsViewModel.swift
+++ b/Sources/HotAppClone/UI/SettingsViewModel.swift
@@ -11,6 +11,7 @@ final class SettingsViewModel: ObservableObject {
     @Published var accessibilityGranted: Bool = false
     @Published var conflictMessage: String?
     @Published var launchAtLoginEnabled: Bool = false
+    @Published var usageCounts: [UUID: Int] = [:]
 
     private let shortcutStore: ShortcutStore
     private let shortcutManager: ShortcutManager
@@ -26,6 +27,7 @@ final class SettingsViewModel: ObservableObject {
         self.shortcuts = shortcutStore.shortcuts
         self.accessibilityGranted = shortcutManager.hasAccessibilityAccess()
         self.launchAtLoginEnabled = launchAtLoginService.isEnabled
+        Task { await refreshUsageCounts() }
     }
 
     func addShortcut() {
@@ -53,6 +55,7 @@ final class SettingsViewModel: ObservableObject {
         shortcutManager.save(shortcuts: updated)
         conflictMessage = nil
         resetDraft()
+        Task { await refreshUsageCounts() }
     }
 
     func removeShortcut(id: UUID) {
@@ -60,7 +63,10 @@ final class SettingsViewModel: ObservableObject {
         shortcuts = updated
         shortcutManager.save(shortcuts: updated)
         if let usageTracker {
-            Task { await usageTracker.deleteUsage(shortcutId: id) }
+            Task {
+                await usageTracker.deleteUsage(shortcutId: id)
+                await refreshUsageCounts()
+            }
         }
     }
 
@@ -96,6 +102,11 @@ final class SettingsViewModel: ObservableObject {
     func setLaunchAtLogin(_ enabled: Bool) {
         launchAtLoginService.setEnabled(enabled)
         launchAtLoginEnabled = launchAtLoginService.isEnabled
+    }
+
+    func refreshUsageCounts() async {
+        guard let usageTracker else { return }
+        usageCounts = await usageTracker.usageCounts(days: 7)
     }
 
     func clearRecordedShortcut() {

--- a/Sources/HotAppClone/UI/ShortcutsTabView.swift
+++ b/Sources/HotAppClone/UI/ShortcutsTabView.swift
@@ -86,6 +86,9 @@ struct ShortcutsTabView: View {
                             Text(shortcut.bundleIdentifier)
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
+                            Text("\(viewModel.usageCounts[shortcut.id, default: 0])× past 7 days")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
                         }
                         Spacer()
                         HStack(spacing: 4) {


### PR DESCRIPTION
## Summary
- Add `usageCounts: [UUID: Int]` to `SettingsViewModel`, loaded via batched `UsageTracker.usageCounts(days: 7)`
- Show `"{count}× past 7 days"` as a tertiary caption line under each shortcut row
- Counts refresh on init, after adding a shortcut, and after deleting one
- No N+1 queries — single batch fetch per refresh

## Test plan
- [x] `swift build` passes (debug + release)
- [x] All 34 tests pass
- [ ] CI passes on GitHub Actions
- [ ] Manual: verify usage count line appears under each shortcut row

Closes #42