### PR TITLE
Build Insights tab with trend chart and app ranking

### DIFF
--- a/Sources/HotAppClone/UI/BarChartView.swift
+++ b/Sources/HotAppClone/UI/BarChartView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct BarChartView: View {
+    let bars: [DailyBar]
+
+    var body: some View {
+        let maxCount = bars.map(\.count).max() ?? 1
+        let ceiling = max(maxCount, 1)
+
+        GeometryReader { geo in
+            HStack(alignment: .bottom, spacing: 2) {
+                ForEach(bars) { bar in
+                    VStack(spacing: 4) {
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(bar.count > 0 ? Color.accentColor : Color.secondary.opacity(0.2))
+                            .frame(height: max(geo.size.height * 0.05, geo.size.height * 0.85 * CGFloat(bar.count) / CGFloat(ceiling)))
+
+                        Text(bar.label)
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            }
+        }
+    }
+}

--- a/Sources/HotAppClone/UI/InsightsTabView.swift
+++ b/Sources/HotAppClone/UI/InsightsTabView.swift
@@ -1,14 +1,67 @@
 import SwiftUI
 
 struct InsightsTabView: View {
+    @ObservedObject var viewModel: InsightsViewModel
+
     var body: some View {
-        VStack {
-            Spacer()
-            Text("Insights coming soon")
-                .font(.title3)
-                .foregroundStyle(.secondary)
-            Spacer()
+        VStack(spacing: 20) {
+            // Period picker
+            Picker("", selection: $viewModel.period) {
+                ForEach(InsightsPeriod.allCases, id: \.self) { period in
+                    Text(period.rawValue).tag(period)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 180)
+
+            // Headline
+            VStack(spacing: 4) {
+                Text(viewModel.period.label)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Text("\(viewModel.totalCount)")
+                    .font(.system(size: 48, weight: .bold, design: .rounded))
+                Text("app switches")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Trend chart (week/month only)
+            if viewModel.period != .day {
+                if viewModel.bars.allSatisfy({ $0.count == 0 }) {
+                    Text("No usage data yet")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .frame(height: 120)
+                } else {
+                    BarChartView(bars: viewModel.bars)
+                        .frame(height: 120)
+                }
+            }
+
+            // Ranking
+            if viewModel.ranking.isEmpty {
+                Spacer()
+                Text("No shortcuts used in this period")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                Spacer()
+            } else {
+                List(viewModel.ranking) { item in
+                    HStack {
+                        Text("#\(item.rank)")
+                            .font(.system(.body, design: .rounded).bold())
+                            .foregroundStyle(.secondary)
+                            .frame(width: 32, alignment: .leading)
+                        Text(item.appName)
+                        Spacer()
+                        Text("\(item.count)×")
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
         }
-        .frame(maxWidth: .infinity)
+        .task { await viewModel.refresh() }
     }
 }

--- a/Sources/HotAppClone/UI/InsightsViewModel.swift
+++ b/Sources/HotAppClone/UI/InsightsViewModel.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+enum InsightsPeriod: String, CaseIterable {
+    case day = "D"
+    case week = "W"
+    case month = "M"
+
+    var days: Int {
+        switch self {
+        case .day: 1
+        case .week: 7
+        case .month: 30
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .day: "Today"
+        case .week: "Past 7 Days"
+        case .month: "Past 30 Days"
+        }
+    }
+}
+
+struct DailyBar: Identifiable {
+    let id: String // date string
+    let label: String
+    let count: Int
+}
+
+struct RankedShortcut: Identifiable {
+    let id: UUID
+    let appName: String
+    let count: Int
+    let rank: Int
+}
+
+@MainActor
+final class InsightsViewModel: ObservableObject {
+    @Published var period: InsightsPeriod = .week {
+        didSet { Task { await refresh() } }
+    }
+    @Published var totalCount: Int = 0
+    @Published var bars: [DailyBar] = []
+    @Published var ranking: [RankedShortcut] = []
+
+    private let usageTracker: UsageTracker?
+    private let shortcutStore: ShortcutStore
+
+    init(usageTracker: UsageTracker?, shortcutStore: ShortcutStore) {
+        self.usageTracker = usageTracker
+        self.shortcutStore = shortcutStore
+    }
+
+    func refresh() async {
+        guard let usageTracker else { return }
+
+        let days = period.days
+        totalCount = await usageTracker.totalSwitches(days: days)
+
+        // Build bars (zero-filled) for week/month
+        if period != .day {
+            let rawDaily = await usageTracker.dailyCounts(days: days)
+            bars = buildBars(rawDaily: rawDaily, days: days)
+        } else {
+            bars = []
+        }
+
+        // Build ranking
+        let counts = await usageTracker.usageCounts(days: days)
+        let shortcuts = shortcutStore.shortcuts
+        let shortcutMap = Dictionary(uniqueKeysWithValues: shortcuts.map { ($0.id, $0) })
+
+        var ranked: [RankedShortcut] = []
+        for (id, count) in counts {
+            guard let shortcut = shortcutMap[id] else { continue }
+            ranked.append(RankedShortcut(id: id, appName: shortcut.appName, count: count, rank: 0))
+        }
+        ranked.sort { $0.count > $1.count }
+        ranking = ranked.enumerated().map {
+            RankedShortcut(id: $1.id, appName: $1.appName, count: $1.count, rank: $0 + 1)
+        }
+    }
+
+    private func buildBars(rawDaily: [String: [(date: String, count: Int)]], days: Int) -> [DailyBar] {
+        // Aggregate across all shortcuts per date
+        var dateTotals: [String: Int] = [:]
+        for (_, entries) in rawDaily {
+            for entry in entries {
+                dateTotals[entry.date, default: 0] += entry.count
+            }
+        }
+
+        // Generate zero-filled date range
+        let calendar = Calendar.current
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = .current
+
+        let labelFormatter = DateFormatter()
+        labelFormatter.dateFormat = days <= 7 ? "EEE" : "M/d"
+        labelFormatter.timeZone = .current
+
+        var result: [DailyBar] = []
+        let today = Date()
+        for i in stride(from: days - 1, through: 0, by: -1) {
+            guard let date = calendar.date(byAdding: .day, value: -i, to: today) else { continue }
+            let dateStr = formatter.string(from: date)
+            let label = labelFormatter.string(from: date)
+            let count = dateTotals[dateStr] ?? 0
+            result.append(DailyBar(id: dateStr, label: label, count: count))
+        }
+        return result
+    }
+}

--- a/Sources/HotAppClone/UI/SettingsView.swift
+++ b/Sources/HotAppClone/UI/SettingsView.swift
@@ -8,6 +8,7 @@ enum SettingsTab: String, CaseIterable {
 
 struct SettingsView: View {
     @ObservedObject var viewModel: SettingsViewModel
+    @ObservedObject var insightsViewModel: InsightsViewModel
     @State private var selectedTab: SettingsTab = .shortcuts
 
     var body: some View {
@@ -25,10 +26,15 @@ struct SettingsView: View {
             case .general:
                 GeneralTabView(viewModel: viewModel)
             case .insights:
-                InsightsTabView()
+                InsightsTabView(viewModel: insightsViewModel)
             }
         }
         .padding(20)
         .frame(minWidth: 680, minHeight: 420)
+        .onChange(of: selectedTab) { _, newTab in
+            if newTab == .insights {
+                Task { await insightsViewModel.refresh() }
+            }
+        }
     }
 }

--- a/Sources/HotAppClone/UI/SettingsWindowController.swift
+++ b/Sources/HotAppClone/UI/SettingsWindowController.swift
@@ -21,7 +21,8 @@ final class SettingsWindowController {
         }
 
         let viewModel = SettingsViewModel(shortcutStore: shortcutStore, shortcutManager: shortcutManager, usageTracker: usageTracker)
-        let contentView = SettingsView(viewModel: viewModel)
+        let insightsViewModel = InsightsViewModel(usageTracker: usageTracker, shortcutStore: shortcutStore)
+        let contentView = SettingsView(viewModel: viewModel, insightsViewModel: insightsViewModel)
         let hostingController = NSHostingController(rootView: contentView)
 
         let window = NSWindow(contentViewController: hostingController)


### PR DESCRIPTION
## Summary
- New `InsightsViewModel` with D/W/M period switching, zero-filled daily bars, and ranked shortcut list
- New `BarChartView` — lightweight native SwiftUI bar chart (no third-party deps)
- `InsightsTabView` upgraded from placeholder to full UI: headline total, period picker, trend chart (W/M), ranking list
- `SettingsView` passes `InsightsViewModel` and refreshes on tab activation
- `SettingsWindowController` creates and injects `InsightsViewModel`

## Test plan
- [x] `swift build` passes (debug + release)
- [x] All 34 tests pass
- [ ] CI passes on GitHub Actions
- [ ] Manual: verify D/W/M switching, bar chart rendering, ranking list, empty states

Closes #43