### PR TITLE
Polish bundle metadata, menu bar icon, and version display

### DIFF
--- a/Sources/HotAppClone/Resources/Info.plist
+++ b/Sources/HotAppClone/Resources/Info.plist
@@ -7,9 +7,13 @@
   <key>CFBundleIdentifier</key><string>com.xrf9268.hotapp-clone</string>
   <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
   <key>CFBundleName</key><string>HotAppClone</string>
+  <key>CFBundleDisplayName</key><string>HotApp Clone</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.1.0</string>
-  <key>CFBundleVersion</key><string>1</string>
+  <key>CFBundleShortVersionString</key><string>0.2.0</string>
+  <key>CFBundleVersion</key><string>2</string>
   <key>LSUIElement</key><true/>
+  <key>LSMinimumSystemVersion</key><string>14.0</string>
+  <key>NSHumanReadableCopyright</key><string>Copyright © 2026. All rights reserved.</string>
+  <key>NSHighResolutionCapable</key><true/>
 </dict>
 </plist>

--- a/Sources/HotAppClone/UI/GeneralTabView.swift
+++ b/Sources/HotAppClone/UI/GeneralTabView.swift
@@ -11,6 +11,14 @@ struct GeneralTabView: View {
             ))
 
             Spacer()
+
+            HStack {
+                Spacer()
+                Text("HotApp Clone v\(Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.2.0")")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                Spacer()
+            }
         }
     }
 }

--- a/Sources/HotAppClone/UI/MenuBarController.swift
+++ b/Sources/HotAppClone/UI/MenuBarController.swift
@@ -20,7 +20,8 @@ final class MenuBarController {
 
     func install() {
         if let button = statusItem.button {
-            button.title = "HotApp"
+            button.image = NSImage(systemSymbolName: "command.square", accessibilityDescription: "HotApp Clone")
+            button.image?.size = NSSize(width: 18, height: 18)
         }
 
         let menu = NSMenu()


### PR DESCRIPTION
## Summary
- **Info.plist**: add `CFBundleDisplayName`, `LSMinimumSystemVersion` (14.0), `NSHumanReadableCopyright`, `NSHighResolutionCapable`; bump version to 0.2.0
- **Menu bar**: replace plain text "HotApp" with SF Symbol `command.square` icon
- **General tab**: display version string at bottom of the tab

## Test plan
- [x] `swift build` passes (debug + release)
- [x] All 34 tests pass
- [ ] CI passes on GitHub Actions
- [ ] Manual: verify menu bar icon renders, General tab shows version

Closes #15