### PR TITLE
Rename product display name to Quickey

### DIFF
--- a/Sources/HotAppClone/Resources/Info.plist
+++ b/Sources/HotAppClone/Resources/Info.plist
@@ -6,8 +6,8 @@
   <key>CFBundleExecutable</key><string>HotAppClone</string>
   <key>CFBundleIdentifier</key><string>com.xrf9268.hotapp-clone</string>
   <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
-  <key>CFBundleName</key><string>HotAppClone</string>
-  <key>CFBundleDisplayName</key><string>HotApp Clone</string>
+  <key>CFBundleName</key><string>Quickey</string>
+  <key>CFBundleDisplayName</key><string>Quickey</string>
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>CFBundleShortVersionString</key><string>0.2.0</string>
   <key>CFBundleVersion</key><string>2</string>

--- a/Sources/HotAppClone/UI/GeneralTabView.swift
+++ b/Sources/HotAppClone/UI/GeneralTabView.swift
@@ -14,7 +14,7 @@ struct GeneralTabView: View {
 
             HStack {
                 Spacer()
-                Text("HotApp Clone v\(Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.2.0")")
+                Text("Quickey v\(Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.2.0")")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
                 Spacer()

--- a/Sources/HotAppClone/UI/MenuBarController.swift
+++ b/Sources/HotAppClone/UI/MenuBarController.swift
@@ -20,7 +20,7 @@ final class MenuBarController {
 
     func install() {
         if let button = statusItem.button {
-            button.image = NSImage(systemSymbolName: "command.square", accessibilityDescription: "HotApp Clone")
+            button.image = NSImage(systemSymbolName: "command.square", accessibilityDescription: "Quickey")
             button.image?.size = NSSize(width: 18, height: 18)
         }
 

--- a/Sources/HotAppClone/UI/SettingsWindowController.swift
+++ b/Sources/HotAppClone/UI/SettingsWindowController.swift
@@ -26,7 +26,7 @@ final class SettingsWindowController {
         let hostingController = NSHostingController(rootView: contentView)
 
         let window = NSWindow(contentViewController: hostingController)
-        window.title = "HotApp Clone"
+        window.title = "Quickey"
         window.setContentSize(NSSize(width: 720, height: 480))
         window.styleMask.insert(.titled)
         window.styleMask.insert(.closable)

--- a/docs/plans/product-rename.md
+++ b/docs/plans/product-rename.md
@@ -1,0 +1,51 @@
+# Product Rename: HotAppClone → Quickey
+
+## Decision
+
+**Selected name: Quickey**
+
+Rationale:
+- Short (7 chars) and memorable
+- Combines "quick" + "key" — directly evokes keyboard shortcuts
+- Feels native as a macOS utility name
+- Not too generic, not too narrow
+- Clean bundle identifier: `com.quickey.app`
+
+## What This PR Does
+
+Updates all **user-facing** display names:
+- `CFBundleName` and `CFBundleDisplayName` in Info.plist
+- Settings window title
+- General tab version string
+- Menu bar accessibility description
+
+## What a Full Rename Would Require
+
+The following are **not** changed in this PR to avoid unnecessary churn. They can be done incrementally if/when the project is published:
+
+### Package / build artifacts
+- `Package.swift`: rename package and executable target
+- Directory: `Sources/HotAppClone/` → `Sources/Quickey/`
+- Directory: `Tests/HotAppCloneTests/` → `Tests/QuickeyTests/`
+- `@testable import HotAppClone` → `@testable import Quickey`
+- `scripts/package-app.sh`: update `APP_NAME`
+
+### Bundle identity
+- `CFBundleExecutable`: `HotAppClone` → `Quickey`
+- `CFBundleIdentifier`: `com.xrf9268.hotapp-clone` → `com.quickey.app`
+- Logger subsystem strings: `com.hotappclone` → `com.quickey.app`
+
+### Repository
+- GitHub repo name (requires owner action)
+- CI workflow references
+- Documentation references throughout `docs/`
+
+### Data migration
+- `~/Library/Application Support/HotAppClone/` → new path
+- Existing SQLite database would need migration or symlink
+- LaunchAtLogin registration uses bundle ID — users would need to re-enable
+
+### Risk notes
+- Changing `CFBundleIdentifier` resets macOS Accessibility permission
+- Changing the executable name breaks existing launch-at-login registrations
+- Users on the old name would lose their shortcut configurations unless migration is handled


### PR DESCRIPTION
## Summary
- **Product name selected: Quickey** ("quick" + "key")
- Updated all user-facing display names: Info.plist (`CFBundleName`, `CFBundleDisplayName`), settings window title, General tab version label, menu bar accessibility description
- Added `docs/plans/product-rename.md` documenting the naming decision and full rename implications (package dirs, bundle ID, data migration, permission risks)
- Internal package/directory names left unchanged to avoid breaking data paths and Accessibility permissions

## Test plan
- [x] `swift build` passes (debug + release)
- [x] All 34 tests pass
- [ ] CI passes on GitHub Actions
- [ ] Manual: verify window title, menu bar, and General tab show "Quickey"

Closes #9