### PR TITLE
Fix code review issues: SQLite memory safety, shared storage, validat…

### DIFF
--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -1,4 +1,7 @@
 import AppKit
+import os.log
+
+private let logger = Logger(subsystem: "com.quickey.app", category: "AppSwitcher")
 
 @MainActor
 final class AppSwitcher {
@@ -15,7 +18,11 @@ final class AppSwitcher {
             if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: shortcut.bundleIdentifier) {
                 frontmostTracker.noteCurrentFrontmostApp(excluding: shortcut.bundleIdentifier)
                 let configuration = NSWorkspace.OpenConfiguration()
-                NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { _, _ in }
+                NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { app, error in
+                    if let error {
+                        logger.error("Failed to launch \(shortcut.bundleIdentifier): \(error.localizedDescription)")
+                    }
+                }
                 return true
             }
             return false

--- a/Sources/Quickey/Services/PersistenceService.swift
+++ b/Sources/Quickey/Services/PersistenceService.swift
@@ -26,15 +26,6 @@ struct PersistenceService: Sendable {
     }
 
     private func storageURL() -> URL? {
-        let fm = FileManager.default
-        guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            return nil
-        }
-
-        let directory = appSupport.appendingPathComponent("Quickey", isDirectory: true)
-        if !fm.fileExists(atPath: directory.path) {
-            try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
-        }
-        return directory.appendingPathComponent(fileName)
+        StoragePaths.appSupportDirectory()?.appendingPathComponent(fileName)
     }
 }

--- a/Sources/Quickey/Services/ShortcutValidator.swift
+++ b/Sources/Quickey/Services/ShortcutValidator.swift
@@ -1,19 +1,16 @@
 import Foundation
 
 struct ShortcutValidator {
+    private let keyMatcher = KeyMatcher()
+
     func conflict(for candidate: AppShortcut, in shortcuts: [AppShortcut]) -> ShortcutConflict? {
+        let candidateTrigger = keyMatcher.trigger(for: candidate)
         guard let existing = shortcuts.first(where: {
-            $0.id != candidate.id
-            && $0.keyEquivalent.caseInsensitiveCompare(candidate.keyEquivalent) == .orderedSame
-            && Set($0.modifierFlags.map { $0.lowercased() }) == Set(candidate.modifierFlags.map { $0.lowercased() })
+            $0.id != candidate.id && keyMatcher.trigger(for: $0) == candidateTrigger
         }) else {
             return nil
         }
 
         return ShortcutConflict(existingShortcut: existing, attemptedShortcut: candidate)
-    }
-
-    func normalizedKey(_ key: String) -> String {
-        key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }

--- a/Sources/Quickey/Services/StoragePaths.swift
+++ b/Sources/Quickey/Services/StoragePaths.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum StoragePaths {
+    static let appDirectoryName = "Quickey"
+
+    static func appSupportDirectory() -> URL? {
+        let fm = FileManager.default
+        guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            return nil
+        }
+
+        let directory = appSupport.appendingPathComponent(appDirectoryName, isDirectory: true)
+        if !fm.fileExists(atPath: directory.path) {
+            try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        return directory
+    }
+}

--- a/Sources/Quickey/Services/UsageTracker.swift
+++ b/Sources/Quickey/Services/UsageTracker.swift
@@ -5,7 +5,21 @@ import os.log
 private let logger = Logger(subsystem: "com.quickey.app", category: "UsageTracker")
 
 actor UsageTracker {
+    // Safety: db is only accessed from actor-isolated methods and deinit.
+    // nonisolated(unsafe) is required because OpaquePointer is not Sendable,
+    // but the actor serializes all access. Do not add nonisolated methods that touch db.
     private nonisolated(unsafe) let db: OpaquePointer?
+
+    /// Destructor constant that tells SQLite to copy bound text immediately,
+    /// preventing use-after-free when the source NSString buffer is deallocated.
+    private static let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = .current
+        return formatter
+    }()
 
     init() {
         db = Self.openDatabase(path: Self.defaultDatabasePath())
@@ -37,8 +51,8 @@ actor UsageTracker {
         defer { sqlite3_finalize(stmt) }
 
         let idString = shortcutId.uuidString
-        sqlite3_bind_text(stmt, 1, (idString as NSString).utf8String, -1, nil)
-        sqlite3_bind_text(stmt, 2, (todayString() as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(stmt, 1, (idString as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, (todayString() as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
 
         if sqlite3_step(stmt) != SQLITE_DONE {
             logger.error("Failed to record usage: \(String(cString: sqlite3_errmsg(self.db!)))")
@@ -51,7 +65,7 @@ actor UsageTracker {
         defer { sqlite3_finalize(stmt) }
 
         let idString = shortcutId.uuidString
-        sqlite3_bind_text(stmt, 1, (idString as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(stmt, 1, (idString as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
 
         if sqlite3_step(stmt) != SQLITE_DONE {
             logger.error("Failed to delete usage: \(String(cString: sqlite3_errmsg(self.db!)))")
@@ -66,7 +80,7 @@ actor UsageTracker {
         defer { sqlite3_finalize(stmt) }
 
         let cutoff = dateString(daysAgo: days)
-        sqlite3_bind_text(stmt, 1, (cutoff as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(stmt, 1, (cutoff as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
 
         var result: [UUID: Int] = [:]
         while sqlite3_step(stmt) == SQLITE_ROW {
@@ -84,7 +98,7 @@ actor UsageTracker {
         defer { sqlite3_finalize(stmt) }
 
         let cutoff = dateString(daysAgo: days)
-        sqlite3_bind_text(stmt, 1, (cutoff as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(stmt, 1, (cutoff as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
 
         var result: [String: [(date: String, count: Int)]] = [:]
         while sqlite3_step(stmt) == SQLITE_ROW {
@@ -104,7 +118,7 @@ actor UsageTracker {
         defer { sqlite3_finalize(stmt) }
 
         let cutoff = dateString(daysAgo: days)
-        sqlite3_bind_text(stmt, 1, (cutoff as NSString).utf8String, -1, nil)
+        sqlite3_bind_text(stmt, 1, (cutoff as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
 
         if sqlite3_step(stmt) == SQLITE_ROW {
             return Int(sqlite3_column_int64(stmt, 0))
@@ -115,14 +129,8 @@ actor UsageTracker {
     // MARK: - Database setup
 
     private static func defaultDatabasePath() -> String {
-        let fm = FileManager.default
-        guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+        guard let directory = StoragePaths.appSupportDirectory() else {
             return ":memory:"
-        }
-
-        let directory = appSupport.appendingPathComponent("Quickey", isDirectory: true)
-        if !fm.fileExists(atPath: directory.path) {
-            try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
         }
         return directory.appendingPathComponent("usage.db").path
     }
@@ -174,10 +182,7 @@ actor UsageTracker {
     }
 
     private func dateString(daysAgo days: Int) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = .current
         let date = Calendar.current.date(byAdding: .day, value: -days, to: Date()) ?? Date()
-        return formatter.string(from: date)
+        return Self.dateFormatter.string(from: date)
     }
 }

--- a/Tests/QuickeyTests/QuickeyTests.swift
+++ b/Tests/QuickeyTests/QuickeyTests.swift
@@ -309,6 +309,80 @@ struct KeySymbolMapperTests {
     }
 }
 
+// MARK: - PersistenceService
+
+@Suite("PersistenceService")
+struct PersistenceServiceTests {
+    @Test
+    func roundTripEncodesAndDecodesShortcuts() {
+        let shortcuts = [
+            AppShortcut(appName: "Safari", bundleIdentifier: "com.apple.Safari", keyEquivalent: "s", modifierFlags: ["command", "option"]),
+            AppShortcut(appName: "Terminal", bundleIdentifier: "com.apple.Terminal", keyEquivalent: "t", modifierFlags: ["command", "control", "shift"]),
+        ]
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try! encoder.encode(shortcuts)
+        let decoded = try! JSONDecoder().decode([AppShortcut].self, from: data)
+
+        #expect(decoded.count == 2)
+        #expect(decoded[0].bundleIdentifier == "com.apple.Safari")
+        #expect(decoded[0].keyEquivalent == "s")
+        #expect(decoded[0].modifierFlags == ["command", "option"])
+        #expect(decoded[1].bundleIdentifier == "com.apple.Terminal")
+        #expect(decoded[1].appName == "Terminal")
+    }
+
+    @Test
+    func decodesEmptyArrayFromEmptyJSON() {
+        let data = "[]".data(using: .utf8)!
+        let decoded = try! JSONDecoder().decode([AppShortcut].self, from: data)
+        #expect(decoded.isEmpty)
+    }
+
+    @Test
+    func preservesUUIDThroughRoundTrip() {
+        let original = AppShortcut(appName: "Test", bundleIdentifier: "com.test", keyEquivalent: "a", modifierFlags: ["command"])
+        let data = try! JSONEncoder().encode([original])
+        let decoded = try! JSONDecoder().decode([AppShortcut].self, from: data)
+        #expect(decoded.first?.id == original.id)
+    }
+
+    @Test
+    func hyperShortcutRoundTrips() {
+        let shortcut = AppShortcut(
+            appName: "Hyper", bundleIdentifier: "com.hyper",
+            keyEquivalent: "h", modifierFlags: ["command", "option", "control", "shift"]
+        )
+        let data = try! JSONEncoder().encode([shortcut])
+        let decoded = try! JSONDecoder().decode([AppShortcut].self, from: data)
+        #expect(decoded.first?.modifierFlags == ["command", "option", "control", "shift"])
+        #expect(decoded.first?.isHyper == true)
+    }
+}
+
+// MARK: - ShortcutValidator with KeyMatcher unification
+
+@Suite("ShortcutValidator alias handling")
+struct ShortcutValidatorAliasTests {
+    let validator = ShortcutValidator()
+
+    @Test
+    func enterAndReturnAreConsideredEquivalent() {
+        let existing = AppShortcut(appName: "A", bundleIdentifier: "com.a", keyEquivalent: "return", modifierFlags: ["command"])
+        let candidate = AppShortcut(appName: "B", bundleIdentifier: "com.b", keyEquivalent: "enter", modifierFlags: ["command"])
+        // With unified KeyMatcher-based validation, "enter" and "return" map to the same key code
+        #expect(validator.conflict(for: candidate, in: [existing]) != nil)
+    }
+
+    @Test
+    func escAndEscapeAreConsideredEquivalent() {
+        let existing = AppShortcut(appName: "A", bundleIdentifier: "com.a", keyEquivalent: "escape", modifierFlags: ["command"])
+        let candidate = AppShortcut(appName: "B", bundleIdentifier: "com.b", keyEquivalent: "esc", modifierFlags: ["command"])
+        #expect(validator.conflict(for: candidate, in: [existing]) != nil)
+    }
+}
+
 // MARK: - UsageTracker
 
 @Suite("UsageTracker")


### PR DESCRIPTION
…or unification

- Use SQLITE_TRANSIENT in all sqlite3_bind_text calls to prevent potential use-after-free when NSString buffers are deallocated before SQLite reads them
- Cache DateFormatter as a static property in UsageTracker instead of creating a new instance on every dateString() call
- Extract duplicated ~/Library/Application Support/Quickey/ directory logic from PersistenceService and UsageTracker into shared StoragePaths enum
- Add error logging to AppSwitcher.openApplication completion handler
- Unify ShortcutValidator to use KeyMatcher.trigger() for conflict detection, ensuring alias keys (enter/return, esc/escape) are correctly treated as conflicts and matching logic stays consistent with runtime key handling
- Add PersistenceService round-trip tests and ShortcutValidator alias tests
- Add safety comment for nonisolated(unsafe) db property in UsageTracker

https://claude.ai/code/session_01B67Ydc8BigVk6KmTuzWjc8