### PR TITLE
Fix insights anchor, login item semantics, and diagnostic logging

### DIFF
--- a/Sources/Quickey/Protocols/UsageTracking.swift
+++ b/Sources/Quickey/Protocols/UsageTracking.swift
@@ -1,7 +1,21 @@
 import Foundation
 
 protocol UsageTracking: Sendable {
-    func usageCounts(days: Int) async -> [UUID: Int]
-    func dailyCounts(days: Int) async -> [String: [(date: String, count: Int)]]
-    func totalSwitches(days: Int) async -> Int
+    func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int]
+    func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]]
+    func totalSwitches(days: Int, relativeTo now: Date) async -> Int
+}
+
+extension UsageTracking {
+    func usageCounts(days: Int) async -> [UUID: Int] {
+        await usageCounts(days: days, relativeTo: Date())
+    }
+
+    func dailyCounts(days: Int) async -> [String: [(date: String, count: Int)]] {
+        await dailyCounts(days: days, relativeTo: Date())
+    }
+
+    func totalSwitches(days: Int) async -> Int {
+        await totalSwitches(days: days, relativeTo: Date())
+    }
 }

--- a/Sources/Quickey/Services/DiagnosticLog.swift
+++ b/Sources/Quickey/Services/DiagnosticLog.swift
@@ -8,42 +8,14 @@ enum DiagnosticLog: Sendable {
 
     private static let logURL: URL = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".config/Quickey/debug.log")
-
-    private static let logPath: String = logURL.path
-
-    private static let maxFileSize: UInt64 = 512 * 1024 // 512 KB
-
-    private nonisolated(unsafe) static let formatter: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        return f
-    }()
-
-    private nonisolated(unsafe) static var directoryEnsured = false
+    private static let writer = DiagnosticLogWriter(fileURL: logURL)
 
     static func log(_ message: String) {
-        let line = "\(formatter.string(from: Date())) \(message)\n"
-        guard let data = line.data(using: .utf8) else { return }
-        if !directoryEnsured {
-            try? FileManager.default.createDirectory(
-                at: logURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-            directoryEnsured = true
-        }
-        if let handle = FileHandle(forWritingAtPath: logPath) {
-            handle.seekToEndOfFile()
-            handle.write(data)
-            handle.closeFile()
-        } else {
-            FileManager.default.createFile(atPath: logPath, contents: data)
-        }
+        writer.log(message)
     }
 
     static func rotateIfNeeded() {
-        guard let attrs = try? FileManager.default.attributesOfItem(atPath: logPath),
-              let size = attrs[.size] as? UInt64,
-              size > maxFileSize else { return }
-        let backup = logPath + ".1"
-        try? FileManager.default.removeItem(atPath: backup)
-        try? FileManager.default.moveItem(atPath: logPath, toPath: backup)
+        writer.rotateIfNeeded()
     }
 
     static func logFileURL() -> URL { logURL }

--- a/Sources/Quickey/Services/DiagnosticLogWriter.swift
+++ b/Sources/Quickey/Services/DiagnosticLogWriter.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+final class DiagnosticLogWriter: @unchecked Sendable {
+    private let fileURL: URL
+    private let logPath: String
+    private let formatter: ISO8601DateFormatter
+    private let maxFileSize: UInt64
+    private let queue: DispatchQueue
+    private var directoryEnsured = false
+
+    init(
+        fileURL: URL,
+        formatter: ISO8601DateFormatter = ISO8601DateFormatter(),
+        maxFileSize: UInt64 = 512 * 1024,
+        queue: DispatchQueue = DispatchQueue(label: "com.quickey.diagnostic-log")
+    ) {
+        self.fileURL = fileURL
+        self.logPath = fileURL.path
+        self.formatter = formatter
+        self.maxFileSize = maxFileSize
+        self.queue = queue
+    }
+
+    func log(_ message: String) {
+        queue.sync {
+            let line = "\(formatter.string(from: Date())) \(message)\n"
+            guard let data = line.data(using: .utf8) else { return }
+            if !directoryEnsured {
+                try? FileManager.default.createDirectory(
+                    at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+                directoryEnsured = true
+            }
+            if let handle = FileHandle(forWritingAtPath: logPath) {
+                handle.seekToEndOfFile()
+                handle.write(data)
+                handle.closeFile()
+            } else {
+                FileManager.default.createFile(atPath: logPath, contents: data)
+            }
+        }
+    }
+
+    func rotateIfNeeded() {
+        queue.sync {
+            guard let attrs = try? FileManager.default.attributesOfItem(atPath: logPath),
+                  let size = attrs[.size] as? UInt64,
+                  size > maxFileSize else { return }
+            let backup = logPath + ".1"
+            try? FileManager.default.removeItem(atPath: backup)
+            try? FileManager.default.moveItem(atPath: logPath, toPath: backup)
+        }
+    }
+}

--- a/Sources/Quickey/Services/LaunchAtLoginService.swift
+++ b/Sources/Quickey/Services/LaunchAtLoginService.swift
@@ -10,7 +10,7 @@ enum LaunchAtLoginStatus: Equatable {
     case notFound
 
     var isEnabled: Bool {
-        self == .enabled || self == .requiresApproval
+        self == .enabled
     }
 }
 

--- a/Sources/Quickey/UI/InsightsViewModel.swift
+++ b/Sources/Quickey/UI/InsightsViewModel.swift
@@ -68,6 +68,8 @@ final class InsightsViewModel {
     }
 
     func refresh(for period: InsightsPeriod) async {
+        let now = Date()
+
         guard let usageTracker else {
             guard self.period == period else { return }
             totalCount = 0
@@ -77,9 +79,9 @@ final class InsightsViewModel {
         }
 
         let days = period.days
-        async let totalCountResult = usageTracker.totalSwitches(days: days)
-        async let rawDailyResult = usageTracker.dailyCounts(days: days)
-        async let countsResult = usageTracker.usageCounts(days: days)
+        async let totalCountResult = usageTracker.totalSwitches(days: days, relativeTo: now)
+        async let rawDailyResult = usageTracker.dailyCounts(days: days, relativeTo: now)
+        async let countsResult = usageTracker.usageCounts(days: days, relativeTo: now)
 
         let totalCount = await totalCountResult
         let rawDaily = await rawDailyResult
@@ -91,7 +93,7 @@ final class InsightsViewModel {
         guard self.period == period else { return }
 
         self.totalCount = totalCount
-        bars = period == .day ? [] : buildBars(rawDaily: rawDaily, days: days)
+        bars = period == .day ? [] : buildBars(rawDaily: rawDaily, days: days, relativeTo: now)
 
         var ranked: [RankedShortcut] = []
         for (id, count) in counts {
@@ -104,7 +106,11 @@ final class InsightsViewModel {
         }
     }
 
-    private func buildBars(rawDaily: [String: [(date: String, count: Int)]], days: Int) -> [DailyBar] {
+    private func buildBars(
+        rawDaily: [String: [(date: String, count: Int)]],
+        days: Int,
+        relativeTo now: Date
+    ) -> [DailyBar] {
         // Aggregate across all shortcuts per date
         var dateTotals: [String: Int] = [:]
         for (_, entries) in rawDaily {
@@ -124,9 +130,8 @@ final class InsightsViewModel {
         labelFormatter.timeZone = .current
 
         var result: [DailyBar] = []
-        let today = Date()
         for i in stride(from: days - 1, through: 0, by: -1) {
-            guard let date = calendar.date(byAdding: .day, value: -i, to: today) else { continue }
+            guard let date = calendar.date(byAdding: .day, value: -i, to: now) else { continue }
             let dateStr = formatter.string(from: date)
             let label = labelFormatter.string(from: date)
             let count = dateTotals[dateStr] ?? 0

--- a/Tests/QuickeyTests/DiagnosticLogTests.swift
+++ b/Tests/QuickeyTests/DiagnosticLogTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import Quickey
+
+@Test
+func concurrentWritesProduceOneLinePerMessage() async throws {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let fileURL = directory.appendingPathComponent("debug.log")
+    let writer = DiagnosticLogWriter(fileURL: fileURL, maxFileSize: .max)
+    let messageCount = 300
+
+    await withTaskGroup(of: Void.self) { group in
+        for index in 0..<messageCount {
+            group.addTask {
+                writer.log("message-\(index)-" + String(repeating: "x", count: 256))
+            }
+        }
+    }
+
+    let contents = try String(contentsOf: fileURL, encoding: .utf8)
+    let lines = contents.split(separator: "\n")
+
+    #expect(lines.count == messageCount)
+    #expect(lines.contains { $0.contains("message-0-") })
+    #expect(lines.contains { $0.contains("message-299-") })
+}

--- a/Tests/QuickeyTests/InsightsViewModelTests.swift
+++ b/Tests/QuickeyTests/InsightsViewModelTests.swift
@@ -23,6 +23,50 @@ actor DelayedUsageTracker: UsageTracking {
         try? await Task.sleep(for: .milliseconds(days == 30 ? 80 : 5))
         return days
     }
+
+    func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] {
+        await usageCounts(days: days)
+    }
+
+    func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] {
+        await dailyCounts(days: days)
+    }
+
+    func totalSwitches(days: Int, relativeTo now: Date) async -> Int {
+        await totalSwitches(days: days)
+    }
+}
+
+actor BoundaryCrossingUsageTracker: UsageTracking {
+    let shortcutId: UUID
+
+    init(shortcutId: UUID) {
+        self.shortcutId = shortcutId
+    }
+
+    func usageCounts(days: Int) async -> [UUID: Int] {
+        [shortcutId: 1]
+    }
+
+    func dailyCounts(days: Int) async -> [String: [(date: String, count: Int)]] {
+        [shortcutId.uuidString: [(date: dateString(for: Date().addingTimeInterval(86_400)), count: 1)]]
+    }
+
+    func totalSwitches(days: Int) async -> Int {
+        1
+    }
+
+    func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] {
+        [shortcutId: 1]
+    }
+
+    func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] {
+        [shortcutId.uuidString: [(date: dateString(for: now), count: 1)]]
+    }
+
+    func totalSwitches(days: Int, relativeTo now: Date) async -> Int {
+        1
+    }
 }
 
 @Test @MainActor
@@ -53,4 +97,38 @@ func latestPeriodWinsWhenRefreshesOverlap() async {
     #expect(viewModel.totalCount == 1)
     #expect(viewModel.ranking.first?.id == shortcutId)
     #expect(viewModel.ranking.first?.count == 1)
+}
+
+@Test @MainActor
+func refreshUsesOneAnchorDateForQueriesAndBars() async {
+    let shortcutId = UUID()
+    let store = ShortcutStore()
+    store.replaceAll(with: [
+        AppShortcut(
+            id: shortcutId,
+            appName: "Terminal",
+            bundleIdentifier: "com.apple.Terminal",
+            keyEquivalent: "t",
+            modifierFlags: ["command"]
+        )
+    ])
+
+    let viewModel = InsightsViewModel(
+        usageTracker: BoundaryCrossingUsageTracker(shortcutId: shortcutId),
+        shortcutStore: store
+    )
+
+    await viewModel.refresh(for: .week)
+
+    #expect(viewModel.totalCount == 1)
+    #expect(viewModel.ranking.first?.count == 1)
+    #expect(viewModel.bars.reduce(0) { $0 + $1.count } == 1)
+    #expect(viewModel.bars.last?.count == 1)
+}
+
+private func dateString(for date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+    formatter.timeZone = .current
+    return formatter.string(from: date)
 }

--- a/Tests/QuickeyTests/LaunchAtLoginServiceTests.swift
+++ b/Tests/QuickeyTests/LaunchAtLoginServiceTests.swift
@@ -15,13 +15,6 @@ func requiresApprovalMapsToApprovalNeededState() {
 }
 
 @Test
-func isEnabledIsTrueWhenApprovalIsStillPending() {
-    let service = LaunchAtLoginService(client: .init(
-        status: { .requiresApproval },
-        register: {},
-        unregister: {},
-        openSystemSettingsLoginItems: {}
-    ))
-
-    #expect(service.isEnabled)
+func requiresApprovalIsNotTreatedAsFullyEnabled() {
+    #expect(LaunchAtLoginStatus.requiresApproval.isEnabled == false)
 }


### PR DESCRIPTION
## Summary
- use a single anchor date per Insights refresh so totals, ranking, and bars stay in the same reporting window
- keep `SMAppService.Status.requiresApproval` distinct from fully enabled so launch-at-login state stays truthful
- serialize file-backed diagnostic log writes and add concurrency regression coverage

## Test Plan
- [x] `swift test --filter requiresApprovalIsNotTreatedAsFullyEnabled`
- [x] `swift test --filter LaunchAtLoginServiceTests`
- [x] `swift test --filter InsightsViewModelTests`
- [x] `swift test --filter UsageTrackerWindowTests`
- [x] `swift test --filter DiagnosticLogTests`
- [x] `swift test`
- [x] `swift build`
- [x] `swift build -c release`
- [ ] manual macOS validation for launch-at-login approval flow
- [ ] manual macOS validation for permission-sensitive runtime behavior in packaged app
