### PR TITLE
Add system service seams and modernize activation fallback

### DIFF
--- a/Sources/Quickey/Services/AccessibilityPermissionService.swift
+++ b/Sources/Quickey/Services/AccessibilityPermissionService.swift
@@ -2,39 +2,68 @@ import ApplicationServices
 import Foundation
 
 struct AccessibilityPermissionService: PermissionServicing {
+    struct Client: Sendable {
+        let isAccessibilityTrusted: @Sendable () -> Bool
+        let isInputMonitoringTrusted: @Sendable () -> Bool
+        let requestAccessibilityPermission: @Sendable (Bool) -> Bool
+        let requestInputMonitoringAccess: @Sendable () -> Bool
+    }
+
+    private let client: Client
+
+    init(client: Client = .live) {
+        self.client = client
+    }
+
     /// Checks if both Accessibility and Input Monitoring permissions are granted.
     /// - Accessibility: needed for AX API (app activation via SkyLight)
     /// - Input Monitoring: needed for CGEvent tap (global hotkey capture)
     func isTrusted() -> Bool {
-        AXIsProcessTrusted() && CGPreflightListenEventAccess()
+        client.isAccessibilityTrusted() && client.isInputMonitoringTrusted()
     }
 
     /// Returns true only if Accessibility permission is granted.
     func isAccessibilityTrusted() -> Bool {
-        AXIsProcessTrusted()
+        client.isAccessibilityTrusted()
     }
 
     /// Returns true only if Input Monitoring permission is granted.
     func isInputMonitoringTrusted() -> Bool {
-        CGPreflightListenEventAccess()
+        client.isInputMonitoringTrusted()
     }
 
     @discardableResult
     func requestIfNeeded(prompt: Bool = true) -> Bool {
-        // Request Accessibility permission (shows dialog reliably)
-        let key = "AXTrustedCheckOptionPrompt" as CFString
-        let axGranted = AXIsProcessTrustedWithOptions([key: prompt] as CFDictionary)
+        let axGranted = client.requestAccessibilityPermission(prompt)
 
         // Request Input Monitoring permission
         let imGranted: Bool
-        if CGPreflightListenEventAccess() {
+        if client.isInputMonitoringTrusted() {
             imGranted = true
         } else if prompt {
-            imGranted = CGRequestListenEventAccess()
+            imGranted = client.requestInputMonitoringAccess()
         } else {
             imGranted = false
         }
 
         return axGranted && imGranted
     }
+}
+
+extension AccessibilityPermissionService.Client {
+    static let live = AccessibilityPermissionService.Client(
+        isAccessibilityTrusted: {
+            AXIsProcessTrusted()
+        },
+        isInputMonitoringTrusted: {
+            CGPreflightListenEventAccess()
+        },
+        requestAccessibilityPermission: { prompt in
+            let key = "AXTrustedCheckOptionPrompt" as CFString
+            return AXIsProcessTrustedWithOptions([key: prompt] as CFDictionary)
+        },
+        requestInputMonitoringAccess: {
+            CGRequestListenEventAccess()
+        }
+    )
 }

--- a/Sources/Quickey/Services/AppListProvider.swift
+++ b/Sources/Quickey/Services/AppListProvider.swift
@@ -12,9 +12,24 @@ struct AppEntry: Identifiable, Hashable {
     var bundleIdentifier: String { id }
 }
 
+struct RunningApplicationSnapshot: Sendable {
+    let bundleIdentifier: String?
+    let localizedName: String?
+    let bundleURL: URL?
+}
+
 @MainActor
 @Observable
 final class AppListProvider {
+    struct Client: Sendable {
+        let now: @Sendable () -> Date
+        let scanInstalledApps: @Sendable () async -> [AppEntry]
+        let runningApplications: @MainActor () -> [RunningApplicationSnapshot]
+        let loadRecents: @Sendable () -> [String]?
+        let saveRecents: @Sendable ([String]) -> Void
+        let mainBundleIdentifier: @Sendable () -> String?
+    }
+
     private(set) var allApps: [AppEntry] = []
     private(set) var recentBundleIDs: [String] = []
     private var lastScanTime: Date?
@@ -25,33 +40,27 @@ final class AppListProvider {
     }
 
     private var isScanning = false
+    private let client: Client
+    private var refreshTask: Task<Void, Never>?
+
+    init(client: Client = .live) {
+        self.client = client
+    }
 
     func refreshIfNeeded() {
-        if let lastScan = lastScanTime, Date().timeIntervalSince(lastScan) < 60 {
+        if let lastScan = lastScanTime, client.now().timeIntervalSince(lastScan) < 60 {
             return
         }
         guard !isScanning else { return }
         isScanning = true
-        Task.detached {
-            let scanned = Self.scanInstalledApps()
-            await MainActor.run { [self] in
-                var entries = scanned
-                var seen = Set(entries.map(\.id))
-                // Running apps must be queried on main thread
-                for app in NSWorkspace.shared.runningApplications {
-                    guard let bid = app.bundleIdentifier,
-                          !seen.contains(bid),
-                          let url = app.bundleURL else { continue }
-                    let name = app.localizedName ?? url.deletingPathExtension().lastPathComponent
-                    entries.append(AppEntry(id: bid, name: name, url: url))
-                    seen.insert(bid)
-                }
-                entries.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-                self.allApps = entries
-                self.lastScanTime = Date()
-                self.loadRecents()
-                self.isScanning = false
-            }
+        refreshTask = Task { [client] in
+            let scanned = await client.scanInstalledApps()
+            let runningApplications = client.runningApplications()
+            applyRefresh(
+                scanned: scanned,
+                runningApplications: runningApplications,
+                now: client.now()
+            )
         }
     }
 
@@ -62,6 +71,10 @@ final class AppListProvider {
             recentBundleIDs = Array(recentBundleIDs.prefix(10))
         }
         saveRecents()
+    }
+
+    func waitForRefreshForTesting() async {
+        await refreshTask?.value
     }
 
     func filteredApps(query: String) -> [AppEntry] {
@@ -93,6 +106,31 @@ final class AppListProvider {
         return entries
     }
 
+    private func applyRefresh(
+        scanned: [AppEntry],
+        runningApplications: [RunningApplicationSnapshot],
+        now: Date
+    ) {
+        var entries = scanned
+        var seen = Set(entries.map(\.id))
+
+        for app in runningApplications {
+            guard let bid = app.bundleIdentifier,
+                  !seen.contains(bid),
+                  let url = app.bundleURL else { continue }
+            let name = app.localizedName ?? url.deletingPathExtension().lastPathComponent
+            entries.append(AppEntry(id: bid, name: name, url: url))
+            seen.insert(bid)
+        }
+
+        entries.sort { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        allApps = entries
+        lastScanTime = now
+        loadRecents(from: runningApplications)
+        isScanning = false
+        refreshTask = nil
+    }
+
     nonisolated private static func scanDirectory(_ dir: URL, into entries: inout [AppEntry], seen: inout Set<String>, depth: Int) {
         guard depth < 3 else { return }
         let fm = FileManager.default
@@ -121,18 +159,12 @@ final class AppListProvider {
 
     // MARK: - Recents persistence
 
-    private var recentsURL: URL? {
-        StoragePaths.appSupportDirectory()?.appendingPathComponent("recent-apps.json")
-    }
-
-    private func loadRecents() {
-        guard let url = recentsURL,
-              let data = try? Data(contentsOf: url),
-              let ids = try? JSONDecoder().decode([String].self, from: data) else {
+    private func loadRecents(from runningApplications: [RunningApplicationSnapshot]) {
+        guard let ids = client.loadRecents() else {
             // Seed from running apps if no recents file exists
-            recentBundleIDs = NSWorkspace.shared.runningApplications
+            recentBundleIDs = runningApplications
                 .compactMap(\.bundleIdentifier)
-                .filter { $0 != Bundle.main.bundleIdentifier }
+                .filter { $0 != client.mainBundleIdentifier() }
                 .prefix(10)
                 .map { $0 }
             return
@@ -141,7 +173,56 @@ final class AppListProvider {
     }
 
     private func saveRecents() {
-        guard let url = recentsURL else { return }
+        client.saveRecents(recentBundleIDs)
+    }
+}
+
+extension AppListProvider.Client {
+    static let live = AppListProvider.Client(
+        now: {
+            Date()
+        },
+        scanInstalledApps: {
+            await Task.detached(priority: .userInitiated) {
+                AppListProvider.scanInstalledApps()
+            }.value
+        },
+        runningApplications: {
+            NSWorkspace.shared.runningApplications.map { app in
+                RunningApplicationSnapshot(
+                    bundleIdentifier: app.bundleIdentifier,
+                    localizedName: app.localizedName,
+                    bundleURL: app.bundleURL
+                )
+            }
+        },
+        loadRecents: {
+            AppListProvider.loadRecentsFromDisk()
+        },
+        saveRecents: { recentBundleIDs in
+            AppListProvider.saveRecentsToDisk(recentBundleIDs)
+        },
+        mainBundleIdentifier: {
+            Bundle.main.bundleIdentifier
+        }
+    )
+}
+
+private extension AppListProvider {
+    nonisolated static func recentsURL() -> URL? {
+        StoragePaths.appSupportDirectory()?.appendingPathComponent("recent-apps.json")
+    }
+
+    nonisolated static func loadRecentsFromDisk() -> [String]? {
+        guard let url = recentsURL(),
+              let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+        return try? JSONDecoder().decode([String].self, from: data)
+    }
+
+    nonisolated static func saveRecentsToDisk(_ recentBundleIDs: [String]) {
+        guard let url = recentsURL() else { return }
         do {
             let data = try JSONEncoder().encode(recentBundleIDs)
             try data.write(to: url, options: .atomic)

--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -6,10 +6,37 @@ private let logger = Logger(subsystem: DiagnosticLog.subsystem, category: "AppSw
 
 @MainActor
 final class AppSwitcher: AppSwitching {
-    private let frontmostTracker: FrontmostApplicationTracker
+    enum FrontProcessActivationResult {
+        case success(ProcessSerialNumber)
+        case processLookupFailed(OSStatus)
+        case activationFailed(CGError)
+    }
 
-    init(frontmostTracker: FrontmostApplicationTracker = FrontmostApplicationTracker()) {
+    enum ActivationResult {
+        case skyLight(ProcessSerialNumber)
+        case fallback(Bool)
+    }
+
+    struct ActivationClient {
+        let activateFrontProcess: (pid_t, CGWindowID?) -> FrontProcessActivationResult
+    }
+
+    struct FallbackActivationClient {
+        let openApplication: (URL, NSWorkspace.OpenConfiguration, @escaping @Sendable (Error?) -> Void) -> Void
+    }
+
+    private let frontmostTracker: FrontmostApplicationTracker
+    private let activationClient: ActivationClient
+    private let fallbackActivationClient: FallbackActivationClient
+
+    init(
+        frontmostTracker: FrontmostApplicationTracker = FrontmostApplicationTracker(),
+        activationClient: ActivationClient = .live,
+        fallbackActivationClient: FallbackActivationClient = .live
+    ) {
         self.frontmostTracker = frontmostTracker
+        self.activationClient = activationClient
+        self.fallbackActivationClient = fallbackActivationClient
     }
 
     @discardableResult
@@ -72,35 +99,71 @@ final class AppSwitcher: AppSwitching {
     /// 2. SLPSPostEventRecordTo — make the window the key window
     /// 3. AXUIElementPerformAction(kAXRaiseAction) — ensure correct Z-order
     private func activateViaWindowServer(_ app: NSRunningApplication, windows: [AXUIElement]?) -> Bool {
-        let pid = app.processIdentifier
-        var psn = ProcessSerialNumber()
-        let status = GetProcessForPID(pid, &psn)
-        guard status == noErr else {
-            logger.error("GetProcessForPID failed for pid \(pid): \(status)")
-            DiagnosticLog.log("GetProcessForPID failed for pid \(pid): \(status)")
-            return app.activate(options: .activateIgnoringOtherApps)
-        }
-
         // Get the first window's CGWindowID for Space-aware activation
         let windowID = firstWindowID(from: windows)
+        switch activateProcess(
+            pid: app.processIdentifier,
+            windowID: windowID,
+            fallbackActivate: {
+                self.requestFallbackActivation(
+                    bundleURL: app.bundleURL,
+                    bundleIdentifier: app.bundleIdentifier ?? "\(app.processIdentifier)",
+                    plainActivate: {
+                        app.activate()
+                    }
+                )
+            }
+        ) {
+        case .skyLight(var psn):
+            // Layer 2: Make the target window the key window via WindowServer event
+            if let wid = windowID {
+                makeKeyWindow(psn: &psn, windowID: wid)
+            }
 
-        // Layer 1: Activate the process via SkyLight
-        // Passing a real windowID causes macOS to auto-switch to that window's Space
-        let result = _SLPSSetFrontProcessWithOptions(&psn, windowID ?? 0, SLPSMode.userGenerated.rawValue)
-        if result != .success {
+            // Layer 3: Raise the first window via Accessibility to ensure correct Z-order
+            raiseFirstWindow(from: windows)
+            return true
+        case .fallback(let activated):
+            return activated
+        }
+    }
+
+    func activateProcess(
+        pid: pid_t,
+        windowID: CGWindowID?,
+        fallbackActivate: () -> Bool
+    ) -> ActivationResult {
+        switch activationClient.activateFrontProcess(pid, windowID) {
+        case .success(let psn):
+            return .skyLight(psn)
+        case .processLookupFailed(let status):
+            logger.error("GetProcessForPID failed for pid \(pid): \(status)")
+            DiagnosticLog.log("GetProcessForPID failed for pid \(pid): \(status)")
+            return .fallback(fallbackActivate())
+        case .activationFailed(let result):
             logger.error("_SLPSSetFrontProcessWithOptions failed: \(result.rawValue), falling back")
-            DiagnosticLog.log("SkyLight activation failed: \(result.rawValue), falling back to NSRunningApplication.activate")
-            return app.activate(options: .activateIgnoringOtherApps)
+            DiagnosticLog.log("SkyLight activation failed: \(result.rawValue), falling back to modern activation request")
+            return .fallback(fallbackActivate())
+        }
+    }
+
+    func requestFallbackActivation(
+        bundleURL: URL?,
+        bundleIdentifier: String,
+        plainActivate: () -> Bool
+    ) -> Bool {
+        guard let bundleURL else {
+            return plainActivate()
         }
 
-        // Layer 2: Make the target window the key window via WindowServer event
-        if let wid = windowID {
-            makeKeyWindow(psn: &psn, windowID: wid)
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+        fallbackActivationClient.openApplication(bundleURL, configuration) { error in
+            if let error {
+                logger.error("Fallback activation via NSWorkspace failed for \(bundleIdentifier): \(error.localizedDescription)")
+                DiagnosticLog.log("Fallback activation via NSWorkspace failed for \(bundleIdentifier): \(error.localizedDescription)")
+            }
         }
-
-        // Layer 3: Raise the first window via Accessibility to ensure correct Z-order
-        raiseFirstWindow(from: windows)
-
         return true
     }
 
@@ -258,4 +321,35 @@ final class AppSwitcher: AppSwitching {
         keyDown.postToPid(pid)
         keyUp.postToPid(pid)
     }
+}
+
+extension AppSwitcher.ActivationClient {
+    @MainActor
+    static let live = AppSwitcher.ActivationClient(
+        activateFrontProcess: { pid, windowID in
+            var psn = ProcessSerialNumber()
+            let status = GetProcessForPID(pid, &psn)
+            guard status == noErr else {
+                return .processLookupFailed(status)
+            }
+
+            let result = _SLPSSetFrontProcessWithOptions(&psn, windowID ?? 0, SLPSMode.userGenerated.rawValue)
+            guard result == .success else {
+                return .activationFailed(result)
+            }
+
+            return .success(psn)
+        }
+    )
+}
+
+extension AppSwitcher.FallbackActivationClient {
+    @MainActor
+    static let live = AppSwitcher.FallbackActivationClient(
+        openApplication: { url, configuration, completion in
+            NSWorkspace.shared.openApplication(at: url, configuration: configuration) { @Sendable _, error in
+                completion(error)
+            }
+        }
+    )
 }

--- a/Sources/Quickey/Services/FrontmostApplicationTracker.swift
+++ b/Sources/Quickey/Services/FrontmostApplicationTracker.swift
@@ -5,10 +5,22 @@ private let logger = Logger(subsystem: DiagnosticLog.subsystem, category: "Front
 
 @MainActor
 final class FrontmostApplicationTracker {
+    struct Client: Sendable {
+        let currentFrontmostBundleIdentifier: @MainActor () -> String?
+        let processIdentifierForRunningApplication: @MainActor (String) -> pid_t?
+        let activateRunningApplication: @MainActor (String) -> Bool
+        let setFrontProcess: @Sendable (pid_t) -> Bool
+    }
+
     private(set) var lastNonTargetBundleIdentifier: String?
+    private let client: Client
+
+    init(client: Client = .live) {
+        self.client = client
+    }
 
     func currentFrontmostBundleIdentifier() -> String? {
-        NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        client.currentFrontmostBundleIdentifier()
     }
 
     func noteCurrentFrontmostApp(excluding targetBundleIdentifier: String) {
@@ -22,25 +34,47 @@ final class FrontmostApplicationTracker {
     @discardableResult
     func restorePreviousAppIfPossible() -> Bool {
         guard let bundleIdentifier = lastNonTargetBundleIdentifier,
-              let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first else {
+              let pid = client.processIdentifierForRunningApplication(bundleIdentifier) else {
             lastNonTargetBundleIdentifier = nil
             return false
         }
         lastNonTargetBundleIdentifier = nil
 
-        // Use SkyLight activation for consistency with AppSwitcher
-        let pid = app.processIdentifier
-        var psn = ProcessSerialNumber()
-        let status = GetProcessForPID(pid, &psn)
-        guard status == noErr else {
-            logger.warning("restorePrevious: GetProcessForPID failed for \(bundleIdentifier), falling back")
-            return app.activate()
-        }
-        let result = _SLPSSetFrontProcessWithOptions(&psn, 0, SLPSMode.userGenerated.rawValue)
-        if result != .success {
+        if !client.setFrontProcess(pid) {
             logger.warning("restorePrevious: SkyLight failed for \(bundleIdentifier), falling back")
-            return app.activate()
+            return client.activateRunningApplication(bundleIdentifier)
         }
         return true
     }
+}
+
+extension FrontmostApplicationTracker.Client {
+    static let live = FrontmostApplicationTracker.Client(
+        currentFrontmostBundleIdentifier: {
+            NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        },
+        processIdentifierForRunningApplication: { bundleIdentifier in
+            NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first?.processIdentifier
+        },
+        activateRunningApplication: { bundleIdentifier in
+            guard let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first else {
+                return false
+            }
+            return app.activate()
+        },
+        setFrontProcess: { pid in
+            var psn = ProcessSerialNumber()
+            let status = GetProcessForPID(pid, &psn)
+            guard status == noErr else {
+                logger.warning("restorePrevious: GetProcessForPID failed for pid \(pid), falling back")
+                return false
+            }
+            let result = _SLPSSetFrontProcessWithOptions(&psn, 0, SLPSMode.userGenerated.rawValue)
+            if result != .success {
+                logger.warning("restorePrevious: SkyLight failed for pid \(pid), falling back")
+                return false
+            }
+            return true
+        }
+    )
 }

--- a/Tests/QuickeyTests/AccessibilityPermissionServiceTests.swift
+++ b/Tests/QuickeyTests/AccessibilityPermissionServiceTests.swift
@@ -1,0 +1,67 @@
+import Testing
+@testable import Quickey
+
+@Test
+func permissionSnapshotKeepsAccessibilityAndInputMonitoringSeparate() {
+    let service = AccessibilityPermissionService(client: .init(
+        isAccessibilityTrusted: { false },
+        isInputMonitoringTrusted: { true },
+        requestAccessibilityPermission: { _ in false },
+        requestInputMonitoringAccess: { false }
+    ))
+
+    #expect(service.isTrusted() == false)
+    #expect(service.isAccessibilityTrusted() == false)
+    #expect(service.isInputMonitoringTrusted() == true)
+}
+
+@Test
+func requestWithoutPromptDoesNotRequestInputMonitoringAccess() {
+    let recorder = PermissionRequestRecorder()
+    let service = AccessibilityPermissionService(client: .init(
+        isAccessibilityTrusted: { true },
+        isInputMonitoringTrusted: { false },
+        requestAccessibilityPermission: { prompt in
+            recorder.accessibilityPromptValues.append(prompt)
+            return true
+        },
+        requestInputMonitoringAccess: {
+            recorder.inputMonitoringRequestCount += 1
+            return true
+        }
+    ))
+
+    let granted = service.requestIfNeeded(prompt: false)
+
+    #expect(granted == false)
+    #expect(recorder.accessibilityPromptValues == [false])
+    #expect(recorder.inputMonitoringRequestCount == 0)
+}
+
+@Test
+func requestWithPromptRequestsInputMonitoringAccessWhenPreflightFails() {
+    let recorder = PermissionRequestRecorder()
+    let service = AccessibilityPermissionService(client: .init(
+        isAccessibilityTrusted: { true },
+        isInputMonitoringTrusted: { false },
+        requestAccessibilityPermission: { prompt in
+            recorder.accessibilityPromptValues.append(prompt)
+            return true
+        },
+        requestInputMonitoringAccess: {
+            recorder.inputMonitoringRequestCount += 1
+            return true
+        }
+    ))
+
+    let granted = service.requestIfNeeded(prompt: true)
+
+    #expect(granted == true)
+    #expect(recorder.accessibilityPromptValues == [true])
+    #expect(recorder.inputMonitoringRequestCount == 1)
+}
+
+private final class PermissionRequestRecorder: @unchecked Sendable {
+    var accessibilityPromptValues: [Bool] = []
+    var inputMonitoringRequestCount = 0
+}

--- a/Tests/QuickeyTests/AppListProviderTests.swift
+++ b/Tests/QuickeyTests/AppListProviderTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+@testable import Quickey
+
+@Test @MainActor
+func refreshIfNeededMergesRunningAppsAndSeedsRecentsWhenStoredRecentsAreMissing() async {
+    let recorder = AppListProviderRecorder(now: Date(timeIntervalSinceReferenceDate: 100))
+    let safariURL = URL(fileURLWithPath: "/Applications/Safari.app")
+    let terminalURL = URL(fileURLWithPath: "/Applications/Utilities/Terminal.app")
+    let provider = AppListProvider(client: .init(
+        now: { recorder.now },
+        scanInstalledApps: {
+            recorder.scanCallCount += 1
+            return [
+                AppEntry(id: "com.apple.Safari", name: "Safari", url: safariURL)
+            ]
+        },
+        runningApplications: {
+            [
+                .init(bundleIdentifier: "com.apple.Safari", localizedName: "Safari", bundleURL: safariURL),
+                .init(bundleIdentifier: "com.apple.Terminal", localizedName: "Terminal", bundleURL: terminalURL),
+                .init(bundleIdentifier: nil, localizedName: "Broken", bundleURL: nil),
+            ]
+        },
+        loadRecents: { nil },
+        saveRecents: { recents in
+            recorder.savedRecents.append(recents)
+        },
+        mainBundleIdentifier: { "com.example.Quickey" }
+    ))
+
+    provider.refreshIfNeeded()
+    await provider.waitForRefreshForTesting()
+
+    #expect(recorder.scanCallCount == 1)
+    #expect(provider.allApps.map(\.bundleIdentifier) == [
+        "com.apple.Safari",
+        "com.apple.Terminal",
+    ])
+    #expect(provider.recentBundleIDs == [
+        "com.apple.Safari",
+        "com.apple.Terminal",
+    ])
+}
+
+@Test @MainActor
+func refreshIfNeededSkipsRescanUntilSixtySecondsHaveElapsed() async {
+    let recorder = AppListProviderRecorder(now: Date(timeIntervalSinceReferenceDate: 200))
+    let provider = AppListProvider(client: .init(
+        now: { recorder.now },
+        scanInstalledApps: {
+            recorder.scanCallCount += 1
+            return []
+        },
+        runningApplications: { [] },
+        loadRecents: { [] },
+        saveRecents: { _ in },
+        mainBundleIdentifier: { nil }
+    ))
+
+    provider.refreshIfNeeded()
+    await provider.waitForRefreshForTesting()
+
+    recorder.now = recorder.now.addingTimeInterval(30)
+    provider.refreshIfNeeded()
+    await provider.waitForRefreshForTesting()
+
+    recorder.now = recorder.now.addingTimeInterval(31)
+    provider.refreshIfNeeded()
+    await provider.waitForRefreshForTesting()
+
+    #expect(recorder.scanCallCount == 2)
+}
+
+@Test @MainActor
+func noteRecentAppCapsPersistedRecentsAtTenEntries() {
+    let recorder = AppListProviderRecorder(now: Date())
+    let provider = AppListProvider(client: .init(
+        now: { recorder.now },
+        scanInstalledApps: { [] },
+        runningApplications: { [] },
+        loadRecents: { [] },
+        saveRecents: { recents in
+            recorder.savedRecents.append(recents)
+        },
+        mainBundleIdentifier: { nil }
+    ))
+
+    for index in 0..<12 {
+        provider.noteRecentApp(bundleIdentifier: "com.example.\(index)")
+    }
+
+    #expect(provider.recentBundleIDs.count == 10)
+    #expect(provider.recentBundleIDs.first == "com.example.11")
+    #expect(provider.recentBundleIDs.last == "com.example.2")
+    #expect(recorder.savedRecents.last?.count == 10)
+}
+
+private final class AppListProviderRecorder: @unchecked Sendable {
+    var now: Date
+    var scanCallCount = 0
+    var savedRecents: [[String]] = []
+
+    init(now: Date) {
+        self.now = now
+    }
+}

--- a/Tests/QuickeyTests/AppPreferencesTests.swift
+++ b/Tests/QuickeyTests/AppPreferencesTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import ServiceManagement
+import Testing
+@testable import Quickey
+
+@Test @MainActor
+func initSnapshotsShortcutAndLaunchAtLoginState() {
+    let suiteName = "AppPreferencesTests.initSnapshotsShortcutAndLaunchAtLoginState"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "hyperKeyEnabled")
+
+    let preferences = AppPreferences(
+        shortcutManager: makeShortcutManager(
+            permissionService: FakePermissionService(ax: true, input: false),
+            eventTapManager: FakeEventTapManager()
+        ),
+        hyperKeyService: HyperKeyService(runner: { _ in true }, defaults: defaults),
+        launchAtLoginService: makeLaunchAtLoginService(state: MutableLaunchAtLoginState(status: .requiresApproval))
+    )
+
+    #expect(preferences.shortcutCaptureStatus == ShortcutCaptureStatus(
+        accessibilityGranted: true,
+        inputMonitoringGranted: false,
+        eventTapActive: false
+    ))
+    #expect(preferences.launchAtLoginStatus == .requiresApproval)
+    #expect(preferences.launchAtLoginEnabled == false)
+    #expect(preferences.hyperKeyEnabled == true)
+}
+
+@Test @MainActor
+func setLaunchAtLoginDoesNotUpdateStateWhenRegistrationFails() {
+    let state = MutableLaunchAtLoginState(status: .notRegistered)
+    state.registerError = TestError.registerFailed
+    let preferences = AppPreferences(
+        shortcutManager: makeShortcutManager(
+            permissionService: FakePermissionService(ax: true, input: true),
+            eventTapManager: FakeEventTapManager()
+        ),
+        launchAtLoginService: makeLaunchAtLoginService(state: state)
+    )
+
+    preferences.setLaunchAtLogin(true)
+
+    #expect(preferences.launchAtLoginStatus == .disabled)
+    #expect(preferences.launchAtLoginEnabled == false)
+}
+
+@Test @MainActor
+func setHyperKeyEnabledTracksActualServiceStateAfterFailure() {
+    let suiteName = "AppPreferencesTests.setHyperKeyEnabledTracksActualServiceStateAfterFailure"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+
+    let preferences = AppPreferences(
+        shortcutManager: makeShortcutManager(
+            permissionService: FakePermissionService(ax: true, input: true),
+            eventTapManager: FakeEventTapManager()
+        ),
+        hyperKeyService: HyperKeyService(runner: { _ in false }, defaults: defaults)
+    )
+
+    preferences.setHyperKeyEnabled(true)
+
+    #expect(preferences.hyperKeyEnabled == false)
+}
+
+private struct FakePermissionService: PermissionServicing {
+    let ax: Bool
+    let input: Bool
+
+    func isTrusted() -> Bool {
+        ax && input
+    }
+
+    func isAccessibilityTrusted() -> Bool {
+        ax
+    }
+
+    func isInputMonitoringTrusted() -> Bool {
+        input
+    }
+
+    @discardableResult
+    func requestIfNeeded(prompt: Bool) -> Bool {
+        isTrusted()
+    }
+}
+
+@MainActor
+private final class FakeEventTapManager: EventTapManaging {
+    var isRunning = false
+
+    func start(onKeyPress: @escaping (KeyPress) -> Bool) -> EventTapStartResult {
+        isRunning = true
+        return .started
+    }
+
+    func stop() {
+        isRunning = false
+    }
+
+    func updateRegisteredShortcuts(_ keyPresses: Set<KeyPress>) {}
+
+    func setHyperKeyEnabled(_ enabled: Bool) {}
+}
+
+@MainActor
+private struct FakeAppSwitcher: AppSwitching {
+    @discardableResult
+    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+        true
+    }
+}
+
+@MainActor
+private func makeShortcutManager(
+    permissionService: some PermissionServicing,
+    eventTapManager: some EventTapManaging
+) -> ShortcutManager {
+    ShortcutManager(
+        shortcutStore: ShortcutStore(),
+        persistenceService: PersistenceService(),
+        appSwitcher: FakeAppSwitcher(),
+        eventTapManager: eventTapManager,
+        permissionService: permissionService
+    )
+}
+
+private enum TestError: Error {
+    case registerFailed
+    case unregisterFailed
+}
+
+private final class MutableLaunchAtLoginState: @unchecked Sendable {
+    var status: SMAppService.Status
+    var registerError: Error?
+    var unregisterError: Error?
+
+    init(status: SMAppService.Status) {
+        self.status = status
+    }
+}
+
+private func makeLaunchAtLoginService(state: MutableLaunchAtLoginState) -> LaunchAtLoginService {
+    LaunchAtLoginService(client: .init(
+        status: { state.statusValue },
+        register: {
+            if let registerError = state.registerError {
+                throw registerError
+            }
+            state.statusValue = .enabled
+        },
+        unregister: {
+            if let unregisterError = state.unregisterError {
+                throw unregisterError
+            }
+            state.statusValue = .notRegistered
+        },
+        openSystemSettingsLoginItems: {}
+    ))
+}
+
+private extension MutableLaunchAtLoginState {
+    var statusValue: SMAppService.Status {
+        get { status }
+        set { status = newValue }
+    }
+}

--- a/Tests/QuickeyTests/AppSwitcherTests.swift
+++ b/Tests/QuickeyTests/AppSwitcherTests.swift
@@ -1,0 +1,146 @@
+import AppKit
+import ApplicationServices
+import Testing
+@testable import Quickey
+
+@Test @MainActor
+func activateProcessFallsBackWhenProcessLookupFails() {
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        activationClient: .init(activateFrontProcess: { _, _ in
+            .processLookupFailed(-600)
+        })
+    )
+    var fallbackCallCount = 0
+
+    let result = switcher.activateProcess(pid: 42, windowID: 11) {
+        fallbackCallCount += 1
+        return true
+    }
+
+    if case .fallback(let activated) = result {
+        #expect(activated == true)
+    } else {
+        Issue.record("Expected fallback activation when process lookup fails")
+    }
+    #expect(fallbackCallCount == 1)
+}
+
+@Test @MainActor
+func activateProcessFallsBackWhenSkyLightActivationFails() {
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        activationClient: .init(activateFrontProcess: { _, _ in
+            .activationFailed(.failure)
+        })
+    )
+    var fallbackCallCount = 0
+
+    let result = switcher.activateProcess(pid: 42, windowID: 11) {
+        fallbackCallCount += 1
+        return false
+    }
+
+    if case .fallback(let activated) = result {
+        #expect(activated == false)
+    } else {
+        Issue.record("Expected fallback activation when SkyLight activation fails")
+    }
+    #expect(fallbackCallCount == 1)
+}
+
+@Test @MainActor
+func activateProcessReturnsSkyLightResultWhenActivationSucceeds() {
+    var psn = ProcessSerialNumber()
+    psn.highLongOfPSN = 1
+    psn.lowLongOfPSN = 2
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        activationClient: .init(activateFrontProcess: { _, _ in
+            .success(psn)
+        })
+    )
+    var fallbackCallCount = 0
+
+    let result = switcher.activateProcess(pid: 42, windowID: nil) {
+        fallbackCallCount += 1
+        return false
+    }
+
+    if case .skyLight(let receivedPSN) = result {
+        #expect(receivedPSN.highLongOfPSN == 1)
+        #expect(receivedPSN.lowLongOfPSN == 2)
+    } else {
+        Issue.record("Expected SkyLight activation result")
+    }
+    #expect(fallbackCallCount == 0)
+}
+
+@Test @MainActor
+func requestFallbackActivationReopensApplicationViaWorkspaceWhenBundleURLExists() {
+    let recorder = FallbackActivationRecorder()
+    let bundleURL = URL(fileURLWithPath: "/Applications/Terminal.app")
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        fallbackActivationClient: .init(openApplication: { url, configuration, completion in
+            recorder.openedURLs.append(url)
+            recorder.activatesFlags.append(configuration.activates)
+            completion(nil)
+        })
+    )
+    var plainActivateCalls = 0
+
+    let result = switcher.requestFallbackActivation(
+        bundleURL: bundleURL,
+        bundleIdentifier: "com.apple.Terminal"
+    ) {
+        plainActivateCalls += 1
+        return false
+    }
+
+    #expect(result == true)
+    #expect(recorder.openedURLs == [bundleURL])
+    #expect(recorder.activatesFlags == [true])
+    #expect(plainActivateCalls == 0)
+}
+
+@Test @MainActor
+func requestFallbackActivationUsesPlainActivationWhenBundleURLIsMissing() {
+    let recorder = FallbackActivationRecorder()
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        fallbackActivationClient: .init(openApplication: { url, configuration, completion in
+            recorder.openedURLs.append(url)
+            recorder.activatesFlags.append(configuration.activates)
+            completion(nil)
+        })
+    )
+    var plainActivateCalls = 0
+
+    let result = switcher.requestFallbackActivation(
+        bundleURL: nil,
+        bundleIdentifier: "com.apple.Terminal"
+    ) {
+        plainActivateCalls += 1
+        return true
+    }
+
+    #expect(result == true)
+    #expect(recorder.openedURLs.isEmpty)
+    #expect(plainActivateCalls == 1)
+}
+
+@MainActor
+private func makeTrackerForAppSwitcherTests() -> FrontmostApplicationTracker {
+    FrontmostApplicationTracker(client: .init(
+        currentFrontmostBundleIdentifier: { nil },
+        processIdentifierForRunningApplication: { _ in nil },
+        activateRunningApplication: { _ in false },
+        setFrontProcess: { _ in false }
+    ))
+}
+
+private final class FallbackActivationRecorder: @unchecked Sendable {
+    var openedURLs: [URL] = []
+    var activatesFlags: [Bool] = []
+}

--- a/Tests/QuickeyTests/FrontmostApplicationTrackerTests.swift
+++ b/Tests/QuickeyTests/FrontmostApplicationTrackerTests.swift
@@ -1,0 +1,52 @@
+import Darwin
+import Testing
+@testable import Quickey
+
+@Test @MainActor
+func noteCurrentFrontmostAppSkipsTargetBundleIdentifier() {
+    let tracker = FrontmostApplicationTracker(client: .init(
+        currentFrontmostBundleIdentifier: { "com.apple.Terminal" },
+        processIdentifierForRunningApplication: { _ in nil },
+        activateRunningApplication: { _ in false },
+        setFrontProcess: { _ in false }
+    ))
+
+    tracker.noteCurrentFrontmostApp(excluding: "com.apple.Terminal")
+
+    #expect(tracker.lastNonTargetBundleIdentifier == nil)
+}
+
+@Test @MainActor
+func restorePreviousAppFallsBackToActivationWhenSkyLightFails() {
+    let recorder = FrontmostTrackerRecorder()
+    let tracker = FrontmostApplicationTracker(client: .init(
+        currentFrontmostBundleIdentifier: { "com.apple.Terminal" },
+        processIdentifierForRunningApplication: { bundleIdentifier in
+            recorder.lookupBundleIdentifiers.append(bundleIdentifier)
+            return 42
+        },
+        activateRunningApplication: { bundleIdentifier in
+            recorder.activatedBundleIdentifiers.append(bundleIdentifier)
+            return true
+        },
+        setFrontProcess: { pid in
+            recorder.setFrontProcessPIDs.append(pid)
+            return false
+        }
+    ))
+
+    tracker.noteCurrentFrontmostApp(excluding: "com.apple.Safari")
+    let restored = tracker.restorePreviousAppIfPossible()
+
+    #expect(restored == true)
+    #expect(recorder.lookupBundleIdentifiers == ["com.apple.Terminal"])
+    #expect(recorder.setFrontProcessPIDs == [42])
+    #expect(recorder.activatedBundleIdentifiers == ["com.apple.Terminal"])
+    #expect(tracker.lastNonTargetBundleIdentifier == nil)
+}
+
+private final class FrontmostTrackerRecorder: @unchecked Sendable {
+    var lookupBundleIdentifiers: [String] = []
+    var activatedBundleIdentifiers: [String] = []
+    var setFrontProcessPIDs: [pid_t] = []
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,6 +121,7 @@ Responsibilities:
 Responsibilities:
 - activate target apps
 - launch installed apps if not already running
+- fall back to `NSWorkspace` reopen requests before plain AppKit activation requests when SkyLight activation cannot complete
 - restore previous app when toggling away
 - hide target app as fallback
 - reveal selected application in Finder when needed
@@ -191,8 +192,10 @@ Global keyDown event
 - **O(1) trigger index**: `ShortcutSignature` dictionary replaces linear scans in the hot path
 - **Hardened EventTap lifecycle**: explicit ownership, auto-recovery on disable/timeout, run-loop cleanup
 - **Active tap only**: passive `.listenOnly` mode is not used in the normal interception path because it cannot consume shortcut events
-- **SkyLight activation path**: private API is used for reliable foreground switching from LSUIElement context
+- **SkyLight primary activation path**: private API is used for reliable foreground switching from LSUIElement context
+- **Modern AppKit fallback**: when SkyLight activation fails, Quickey re-requests activation via `NSWorkspace.OpenConfiguration` (`activates = true`) and only falls back to a plain AppKit activation request if no bundle URL is available
 - **Best-effort toggle semantics**: activate → restore previous app → hide fallback
+- **Service-level test seams**: system-facing services use small injected clients or existing collaborators so runtime decision logic can be covered without live TCC or app-launch side effects
 - **UsageTracker**: SQLite-backed daily usage aggregation off the main actor
 - **Launch-at-login status modeling**: `LaunchAtLoginStatus` preserves enabled / approval-needed / disabled / not-found states
 

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -1,7 +1,7 @@
 # Handoff Notes
 
 ## Current State
-Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. The 2026-03-21 remediation set is implemented and GitHub Actions-verified, but the changed runtime paths still need a fresh targeted macOS pass before we can call them revalidated. A signed and notarized distributable is still unresolved.
+Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. On 2026-03-23, the runtime hardening follow-up added service-level test seams for permission, app discovery, frontmost-app restore, preferences, and activation fallback paths, and replaced the deprecated `activateIgnoringOtherApps` fallback with a modern `NSWorkspace` reopen request. Automated `swift test`, `swift test --enable-code-coverage`, `swift build`, and `swift build -c release` passed on 2026-03-23. Coverage for the newly targeted services is now measurable: `AccessibilityPermissionService` 64.29%, `AppListProvider` 40.78%, `AppPreferences` 72.50%, `FrontmostApplicationTracker` 43.64%, and `AppSwitcher` 10.55%. The changed activation/runtime paths still need a fresh targeted macOS pass before we can call them revalidated. A signed and notarized distributable is still unresolved.
 
 ## Validated on macOS
 - Broad real-device validation completed on macOS 15.3.1 on 2026-03-20
@@ -13,6 +13,7 @@ Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. The 2026-03-21 reme
 ## Follow-up Requiring macOS Validation
 - Launch-at-login approval flow after the 2026-03-21 remediation set
 - Active event-tap startup and readiness reporting after permission or lifecycle changes
+- AppSwitcher fallback behavior after SkyLight failure now that it re-requests activation via `NSWorkspace`
 - Hyper Key failure handling, especially persistence only after `hidutil` succeeds
 - Insights date-window and refresh-race fixes
 - Signed/notarized distributable workflow once a Developer ID certificate is available
@@ -22,6 +23,7 @@ Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. The 2026-03-21 reme
 - Ad-hoc signing changes can invalidate TCC state; use `tccutil reset` during development when needed
 - Launch the app with `open`, not by executing the binary directly, so TCC matches the correct app identity
 - SkyLight is a private API dependency for reliable activation from LSUIElement apps and may block App Store submission
+- If SkyLight activation fails, Quickey now falls back to an `NSWorkspace` reopen request instead of the deprecated `activateIgnoringOtherApps` path
 - Unified logging can hide useful runtime details; file-based debug logs (`~/.config/Quickey/debug.log`) are more reliable for diagnosis
 
 ## Immediate Next Actions


### PR DESCRIPTION
## Summary
- add focused test seams and coverage for permission, app discovery, preferences, frontmost-app restore, and AppSwitcher activation decisions
- replace the deprecated `activateIgnoringOtherApps` fallback with an `NSWorkspace` reopen request plus plain AppKit activation fallback when needed
- update architecture and handoff notes with the new activation rationale and current coverage snapshot

## Test Plan
- [x] `swift test`
- [x] `swift test --enable-code-coverage`
- [x] `swift build`
- [x] `swift build -c release`

Closes #70
Closes #71
