### PR TITLE
补强应用切换与 event tap 诊断基础

### DIFF
--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -4,6 +4,40 @@ import os.log
 
 private let logger = Logger(subsystem: DiagnosticLog.subsystem, category: "AppSwitcher")
 
+struct TogglePostActionState: Equatable, Sendable {
+    let frontmostBundleIdentifier: String?
+    let targetBundleIdentifier: String?
+    let targetFrontmost: Bool
+    let targetHidden: Bool
+    let targetVisibleWindows: Bool
+
+    init(
+        frontmostBundleIdentifier: String?,
+        targetBundleIdentifier: String?,
+        targetFrontmost: Bool,
+        targetHidden: Bool,
+        targetVisibleWindows: Bool
+    ) {
+        self.frontmostBundleIdentifier = frontmostBundleIdentifier
+        self.targetBundleIdentifier = targetBundleIdentifier
+        self.targetFrontmost = targetFrontmost
+        self.targetHidden = targetHidden
+        self.targetVisibleWindows = targetVisibleWindows
+    }
+
+    init(snapshot: ActivationObservationSnapshot) {
+        self.frontmostBundleIdentifier = snapshot.observedFrontmostBundleIdentifier
+        self.targetBundleIdentifier = snapshot.targetBundleIdentifier
+        self.targetFrontmost = snapshot.targetIsObservedFrontmost
+        self.targetHidden = snapshot.targetIsHidden
+        self.targetVisibleWindows = snapshot.targetHasVisibleWindows
+    }
+
+    var logDetails: String {
+        "postFrontmost=\(frontmostBundleIdentifier ?? "nil"), targetBundle=\(targetBundleIdentifier ?? "nil"), targetFrontmost=\(targetFrontmost), targetHidden=\(targetHidden), targetVisibleWindows=\(targetVisibleWindows)"
+    }
+}
+
 @MainActor
 final class AppSwitcher: AppSwitching {
     enum FrontProcessActivationResult {
@@ -26,27 +60,39 @@ final class AppSwitcher: AppSwitching {
     }
 
     private let frontmostTracker: FrontmostApplicationTracker
+    private let applicationObservation: ApplicationObservation
     private let activationClient: ActivationClient
     private let fallbackActivationClient: FallbackActivationClient
 
     init(
         frontmostTracker: FrontmostApplicationTracker = FrontmostApplicationTracker(),
+        applicationObservation: ApplicationObservation = .live,
         activationClient: ActivationClient = .live,
         fallbackActivationClient: FallbackActivationClient = .live
     ) {
         self.frontmostTracker = frontmostTracker
+        self.applicationObservation = applicationObservation
         self.activationClient = activationClient
         self.fallbackActivationClient = fallbackActivationClient
     }
 
     @discardableResult
     func toggleApplication(for shortcut: AppShortcut) -> Bool {
+        let attemptStartedAt = CFAbsoluteTimeGetCurrent()
+
         guard let runningApp = NSRunningApplication.runningApplications(withBundleIdentifier: shortcut.bundleIdentifier).first else {
             // App not running — launch it
             if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: shortcut.bundleIdentifier) {
                 frontmostTracker.noteCurrentFrontmostApp(excluding: shortcut.bundleIdentifier)
                 logger.info("TOGGLE[\(shortcut.appName)]: NOT RUNNING → launching")
                 DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: NOT RUNNING → launching, saved previous=\(frontmostTracker.lastNonTargetBundleIdentifier ?? "nil")")
+                logToggleLifecycle(
+                    for: shortcut,
+                    lifecycle: "TOGGLE_ATTEMPT",
+                    previousBundle: frontmostTracker.lastNonTargetBundleIdentifier,
+                    activationPath: "launch",
+                    elapsedMilliseconds: elapsedMilliseconds(since: attemptStartedAt)
+                )
                 let bundleId = shortcut.bundleIdentifier
                 let configuration = NSWorkspace.OpenConfiguration()
                 NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { @Sendable app, error in
@@ -65,30 +111,88 @@ final class AppSwitcher: AppSwitching {
         if runningApp.isActive {
             // App is frontmost — hide it and restore the previous app
             let previousApp = frontmostTracker.lastNonTargetBundleIdentifier
-            let restored = frontmostTracker.restorePreviousAppIfPossible()
+            let preActionWindowObservation = applicationObservation.windowObservation(for: runningApp)
+            let preActionSnapshot = applicationObservation.snapshot(
+                for: runningApp,
+                windowObservation: preActionWindowObservation
+            )
+            logToggleLifecycle(
+                for: shortcut,
+                lifecycle: "TOGGLE_RESTORE_ATTEMPT",
+                previousBundle: previousApp,
+                activationPath: "restore_previous",
+                snapshot: preActionSnapshot,
+                elapsedMilliseconds: elapsedMilliseconds(since: attemptStartedAt)
+            )
+            let restoreAttempt = frontmostTracker.restorePreviousAppIfPossible()
             let hidden = runningApp.hide()
+            let restored = restoreAttempt.restoreAccepted
             logger.info("TOGGLE[\(shortcut.appName)]: IS ACTIVE → restored=\(restored), hidden=\(hidden)")
-            DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: IS ACTIVE → restored=\(restored) (prev=\(previousApp ?? "nil")), hidden=\(hidden)")
+            DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: IS ACTIVE → restored=\(restored) (prev=\(restoreAttempt.bundleIdentifier ?? previousApp ?? "nil")), hidden=\(hidden)")
+            let postRestoreWindowObservation = applicationObservation.windowObservation(for: runningApp)
+            let postRestoreSnapshot = applicationObservation.snapshot(
+                for: runningApp,
+                windowObservation: postRestoreWindowObservation
+            )
+            if !postRestoreSnapshot.targetIsObservedFrontmost {
+                frontmostTracker.confirmRestoreAttempt()
+            }
+            logPostActionState(
+                shortcut: shortcut,
+                phase: "POST_RESTORE_STATE",
+                snapshot: postRestoreSnapshot,
+                previousBundle: restoreAttempt.bundleIdentifier ?? previousApp,
+                activationPath: "restore_previous",
+                elapsedMilliseconds: elapsedMilliseconds(since: attemptStartedAt)
+            )
             return restored || hidden
         }
 
         // App is running but not frontmost — bring it forward.
         frontmostTracker.noteCurrentFrontmostApp(excluding: shortcut.bundleIdentifier)
+        let previousApp = frontmostTracker.lastNonTargetBundleIdentifier
+        let activationPath = runningApp.isHidden ? "unhide_activate" : "activate"
+        let preActionWindowObservation = applicationObservation.windowObservation(for: runningApp)
+        let preActionSnapshot = applicationObservation.snapshot(
+            for: runningApp,
+            windowObservation: preActionWindowObservation
+        )
         logger.info("TOGGLE[\(shortcut.appName)]: RUNNING NOT FRONT → activating, isHidden=\(runningApp.isHidden)")
-        DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: RUNNING NOT FRONT → activating, saved previous=\(frontmostTracker.lastNonTargetBundleIdentifier ?? "nil"), isHidden=\(runningApp.isHidden)")
+        DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: RUNNING NOT FRONT → activating, saved previous=\(previousApp ?? "nil"), isHidden=\(runningApp.isHidden)")
+        logToggleLifecycle(
+            for: shortcut,
+            lifecycle: "TOGGLE_ATTEMPT",
+            previousBundle: previousApp,
+            activationPath: activationPath,
+            snapshot: preActionSnapshot,
+            elapsedMilliseconds: elapsedMilliseconds(since: attemptStartedAt)
+        )
         if runningApp.isHidden {
             runningApp.unhide()
         }
-        let windows = fetchWindows(of: runningApp)
+        let windows = preActionWindowObservation.windows
         unminimizeWindows(of: runningApp, windows: windows)
         let activated = activateViaWindowServer(runningApp, windows: windows)
+        let postActivationWindowObservation = applicationObservation.windowObservation(for: runningApp)
+        let postActivationSnapshot = applicationObservation.snapshot(
+            for: runningApp,
+            windowObservation: postActivationWindowObservation
+        )
 
         // If app has no visible windows after activation, try to get one
-        if activated && !hasVisibleWindows(of: runningApp, windows: windows) {
+        if activated && !postActivationWindowObservation.hasVisibleWindows {
             logger.info("TOGGLE[\(shortcut.appName)]: no visible windows after activation")
             DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: no visible windows, attempting recovery")
             recoverWindowlessApp(runningApp, shortcut: shortcut)
         }
+        logPostActionState(
+            shortcut: shortcut,
+            phase: "POST_ACTIVATE_STATE",
+            snapshot: postActivationSnapshot,
+            previousBundle: previousApp,
+            activationPath: activationPath,
+            elapsedMilliseconds: elapsedMilliseconds(since: attemptStartedAt)
+        )
         return activated
     }
 
@@ -320,6 +424,106 @@ final class AppSwitcher: AppSwitching {
         let pid = app.processIdentifier
         keyDown.postToPid(pid)
         keyUp.postToPid(pid)
+    }
+
+    private func logPostActionState(
+        shortcut: AppShortcut,
+        phase: String,
+        snapshot: ActivationObservationSnapshot,
+        previousBundle: String?,
+        activationPath: String,
+        elapsedMilliseconds: Int
+    ) {
+        let message = postActionLogMessage(for: shortcut, phase: phase, snapshot: snapshot)
+        logger.info("\(message)")
+        DiagnosticLog.log(message)
+
+        if phase == "POST_RESTORE_STATE" {
+            let lifecycle = snapshot.targetIsObservedFrontmost ? "TOGGLE_RESTORE_DEGRADED" : "TOGGLE_RESTORE_CONFIRMED"
+            logToggleLifecycle(
+                for: shortcut,
+                lifecycle: lifecycle,
+                previousBundle: previousBundle,
+                activationPath: activationPath,
+                snapshot: snapshot,
+                elapsedMilliseconds: elapsedMilliseconds
+            )
+            return
+        }
+
+        logToggleLifecycle(
+            for: shortcut,
+            lifecycle: "TOGGLE_CONFIRMATION",
+            previousBundle: previousBundle,
+            activationPath: activationPath,
+            snapshot: snapshot,
+            elapsedMilliseconds: elapsedMilliseconds
+        )
+        logToggleLifecycle(
+            for: shortcut,
+            lifecycle: snapshot.isStableActivation ? "TOGGLE_STABLE" : "TOGGLE_DEGRADED",
+            previousBundle: previousBundle,
+            activationPath: activationPath,
+            snapshot: snapshot,
+            elapsedMilliseconds: elapsedMilliseconds
+        )
+    }
+
+    func postActionLogMessage(
+        for shortcut: AppShortcut,
+        phase: String,
+        snapshot: ActivationObservationSnapshot
+    ) -> String {
+        let state = TogglePostActionState(snapshot: snapshot)
+        return "TOGGLE[\(shortcut.appName)]: \(phase) \(state.logDetails) \(snapshot.structuredLogFields)"
+    }
+
+    func toggleLifecycleLogMessage(
+        for shortcut: AppShortcut,
+        lifecycle: String,
+        previousBundle: String?,
+        activationPath: String,
+        snapshot: ActivationObservationSnapshot? = nil,
+        elapsedMilliseconds: Int
+    ) -> String {
+        var fields = [
+            "target=\(shortcut.bundleIdentifier)",
+            "previous=\(previousBundle ?? "nil")",
+            "activationPath=\(activationPath)",
+            "elapsedMs=\(elapsedMilliseconds)"
+        ]
+
+        if let snapshot {
+            fields.append(snapshot.structuredLogFields)
+        } else {
+            fields.append(ActivationObservationSnapshot.quotedField("frontmost", frontmostTracker.currentFrontmostBundleIdentifier()))
+        }
+
+        return "TOGGLE[\(shortcut.appName)]: \(lifecycle) \(fields.joined(separator: " "))"
+    }
+
+    private func logToggleLifecycle(
+        for shortcut: AppShortcut,
+        lifecycle: String,
+        previousBundle: String?,
+        activationPath: String,
+        snapshot: ActivationObservationSnapshot? = nil,
+        elapsedMilliseconds: Int
+    ) {
+        let message = toggleLifecycleLogMessage(
+            for: shortcut,
+            lifecycle: lifecycle,
+            previousBundle: previousBundle,
+            activationPath: activationPath,
+            snapshot: snapshot,
+            elapsedMilliseconds: elapsedMilliseconds
+        )
+        logger.info("\(message)")
+        DiagnosticLog.log(message)
+    }
+
+    private func elapsedMilliseconds(since startedAt: CFAbsoluteTime) -> Int {
+        Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
     }
 }
 

--- a/Sources/Quickey/Services/ApplicationObservation.swift
+++ b/Sources/Quickey/Services/ApplicationObservation.swift
@@ -1,0 +1,226 @@
+import AppKit
+import ApplicationServices
+
+enum ApplicationClassification: String, Sendable {
+    case regularWindowed
+    case nonStandardWindowed
+    case windowlessOrAccessory
+    case systemUtility
+}
+
+struct ActivationObservationSnapshot: Sendable, Equatable {
+    let targetBundleIdentifier: String?
+    let observedFrontmostBundleIdentifier: String?
+    let targetIsActive: Bool
+    let targetIsHidden: Bool
+    let visibleWindowCount: Int
+    let hasFocusedWindow: Bool
+    let hasMainWindow: Bool
+    let windowObservationSucceeded: Bool
+    let windowObservationFailureReason: String?
+    let classification: ApplicationClassification
+    let classificationReason: String
+
+    var targetHasVisibleWindows: Bool {
+        visibleWindowCount > 0
+    }
+
+    var targetIsObservedFrontmost: Bool {
+        guard let targetBundleIdentifier else { return false }
+        return targetBundleIdentifier == observedFrontmostBundleIdentifier
+    }
+
+    var isStableActivation: Bool {
+        guard targetIsObservedFrontmost, targetIsActive, !targetIsHidden else {
+            return false
+        }
+
+        switch classification {
+        case .regularWindowed, .nonStandardWindowed:
+            return targetHasVisibleWindows || hasFocusedWindow || hasMainWindow
+        case .windowlessOrAccessory, .systemUtility:
+            return true
+        }
+    }
+
+    var structuredLogFields: String {
+        [
+            Self.quotedField("frontmost", observedFrontmostBundleIdentifier),
+            Self.quotedField("target", targetBundleIdentifier),
+            "targetActive=\(targetIsActive)",
+            "targetHidden=\(targetIsHidden)",
+            "visibleWindowCount=\(visibleWindowCount)",
+            "hasFocusedWindow=\(hasFocusedWindow)",
+            "hasMainWindow=\(hasMainWindow)",
+            "windowObservationSucceeded=\(windowObservationSucceeded)",
+            Self.quotedField("windowObservationFailureReason", windowObservationFailureReason),
+            Self.quotedField("classification", classification.rawValue),
+            Self.quotedField("classificationReason", classificationReason),
+            "stable=\(isStableActivation)"
+        ].joined(separator: " ")
+    }
+
+    static func quotedField(_ key: String, _ value: String?) -> String {
+        "\(key)=\(encode(value ?? "nil"))"
+    }
+
+    private static func encode(_ value: String) -> String {
+        var escaped = "\""
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "\"":
+                escaped.append("\\\"")
+            case "\\":
+                escaped.append("\\\\")
+            case "\n":
+                escaped.append("\\n")
+            case "\r":
+                escaped.append("\\r")
+            case "\t":
+                escaped.append("\\t")
+            default:
+                escaped.unicodeScalars.append(scalar)
+            }
+        }
+        escaped.append("\"")
+        return escaped
+    }
+}
+
+struct ApplicationObservation {
+    struct WindowObservation {
+        let windows: [AXUIElement]?
+        let visibleWindowCount: Int
+        let hasFocusedWindow: Bool
+        let hasMainWindow: Bool
+        let windowsReadSucceeded: Bool
+        let failureReason: String?
+
+        var hasVisibleWindows: Bool {
+            visibleWindowCount > 0
+        }
+    }
+
+    struct Client: Sendable {
+        let currentFrontmostBundleIdentifier: @MainActor () -> String?
+        let windowObservation: @MainActor (NSRunningApplication) -> WindowObservation
+        let activationPolicy: @MainActor (NSRunningApplication) -> NSApplication.ActivationPolicy
+    }
+
+    private let client: Client
+
+    init(client: Client) {
+        self.client = client
+    }
+
+    @MainActor
+    func windowObservation(for app: NSRunningApplication) -> WindowObservation {
+        client.windowObservation(app)
+    }
+
+    @MainActor
+    func snapshot(
+        for app: NSRunningApplication,
+        windowObservation: WindowObservation? = nil
+    ) -> ActivationObservationSnapshot {
+        let windowObservation = windowObservation ?? client.windowObservation(app)
+        let classification = classify(
+            bundleIdentifier: app.bundleIdentifier,
+            activationPolicy: client.activationPolicy(app),
+            windowObservation: windowObservation
+        )
+
+        return ActivationObservationSnapshot(
+            targetBundleIdentifier: app.bundleIdentifier,
+            observedFrontmostBundleIdentifier: client.currentFrontmostBundleIdentifier(),
+            targetIsActive: app.isActive,
+            targetIsHidden: app.isHidden,
+            visibleWindowCount: windowObservation.visibleWindowCount,
+            hasFocusedWindow: windowObservation.hasFocusedWindow,
+            hasMainWindow: windowObservation.hasMainWindow,
+            windowObservationSucceeded: windowObservation.windowsReadSucceeded,
+            windowObservationFailureReason: windowObservation.failureReason,
+            classification: classification.classification,
+            classificationReason: classification.reason
+        )
+    }
+
+    private func classify(
+        bundleIdentifier: String?,
+        activationPolicy: NSApplication.ActivationPolicy,
+        windowObservation: WindowObservation
+    ) -> (classification: ApplicationClassification, reason: String) {
+        if activationPolicy != .regular {
+            return (.systemUtility, "activation policy is \(String(describing: activationPolicy))")
+        }
+
+        if !windowObservation.windowsReadSucceeded {
+            return (.nonStandardWindowed, windowObservation.failureReason ?? "window observation failed")
+        }
+
+        if windowObservation.visibleWindowCount == 0 &&
+            !windowObservation.hasFocusedWindow &&
+            !windowObservation.hasMainWindow {
+            return (.windowlessOrAccessory, "no visible, focused, or main windows")
+        }
+
+        if windowObservation.visibleWindowCount == 0 ||
+            !windowObservation.hasFocusedWindow ||
+            !windowObservation.hasMainWindow {
+            return (.nonStandardWindowed, "window evidence is incomplete for \(bundleIdentifier ?? "unknown bundle")")
+        }
+
+        return (.regularWindowed, "visible focused main window")
+    }
+}
+
+extension ApplicationObservation {
+    @MainActor
+    static let live = ApplicationObservation(client: .live)
+}
+
+extension ApplicationObservation.Client {
+    @MainActor
+    static let live = ApplicationObservation.Client(
+        currentFrontmostBundleIdentifier: {
+            NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        },
+        windowObservation: { app in
+            captureWindowObservation(for: app)
+        },
+        activationPolicy: { app in
+            app.activationPolicy
+        }
+    )
+
+    @MainActor
+    private static func captureWindowObservation(for app: NSRunningApplication) -> ApplicationObservation.WindowObservation {
+        let axApp = AXUIElementCreateApplication(app.processIdentifier)
+        var windowsRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef)
+        let windows = result == .success ? windowsRef as? [AXUIElement] : nil
+        let visibleWindowCount = (windows ?? []).reduce(into: 0) { count, window in
+            var minimizedRef: CFTypeRef?
+            let minimizedResult = AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimizedRef)
+            let isMinimized = minimizedResult == .success && (minimizedRef as? Bool ?? false)
+            if !isMinimized {
+                count += 1
+            }
+        }
+
+        return ApplicationObservation.WindowObservation(
+            windows: windows,
+            visibleWindowCount: visibleWindowCount,
+            hasFocusedWindow: hasAppWindowAttribute(kAXFocusedWindowAttribute, on: axApp),
+            hasMainWindow: hasAppWindowAttribute(kAXMainWindowAttribute, on: axApp),
+            windowsReadSucceeded: result == .success,
+            failureReason: result == .success ? nil : "axWindowsReadFailed=\(result.rawValue)"
+        )
+    }
+
+    private static func hasAppWindowAttribute(_ attribute: String, on appElement: AXUIElement) -> Bool {
+        var valueRef: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(appElement, attribute as CFString, &valueRef)
+        return result == .success && valueRef != nil
+    }
+}

--- a/Sources/Quickey/Services/EventTapManager.swift
+++ b/Sources/Quickey/Services/EventTapManager.swift
@@ -5,6 +5,25 @@ import os.log
 
 private let logger = Logger(subsystem: DiagnosticLog.subsystem, category: "EventTapManager")
 
+struct EventTapDiagnosticsSnapshot: Equatable, Sendable {
+    let reason: CGEventType
+    let disableCount: Int
+    let lastEventType: CGEventType?
+    let lastKeyCode: CGKeyCode?
+    let lastModifierFlags: UInt
+    let lastShortcutWasSwallowed: Bool
+    let lastHyperInjected: Bool
+    let registeredShortcutCount: Int
+    let hyperKeyEnabled: Bool
+    let hyperKeyHeld: Bool
+
+    var logMessage: String {
+        let lastEvent = lastEventType.map { String($0.rawValue) } ?? "nil"
+        let lastKey = lastKeyCode.map { String($0) } ?? "nil"
+        return "EVENT TAP DIAGNOSTICS: reason=\(reason.rawValue), disableCount=\(disableCount), lastEvent=\(lastEvent), lastKeyCode=\(lastKey), lastModifiers=\(lastModifierFlags), lastShortcutWasSwallowed=\(lastShortcutWasSwallowed), lastHyperInjected=\(lastHyperInjected), registeredShortcutCount=\(registeredShortcutCount), hyperKeyEnabled=\(hyperKeyEnabled), hyperKeyHeld=\(hyperKeyHeld)"
+    }
+}
+
 enum MatchedShortcutDelivery {
     static func makeHandler(
         _ handler: @escaping @MainActor @Sendable (KeyPress) -> Void
@@ -25,8 +44,9 @@ func handleEventTapEvent(
 ) -> Unmanaged<CGEvent>? {
     switch type {
     case .tapDisabledByTimeout, .tapDisabledByUserInput:
-        logger.warning("EVENT TAP DISABLED by system (reason: \(type.rawValue)), re-enabling")
-        DiagnosticLog.log("EVENT TAP DISABLED by system (reason: \(type.rawValue)), re-enabling")
+        let snapshot = box.captureDisableSnapshot(reason: type)
+        logger.warning("EVENT TAP DISABLED by system (reason: \(type.rawValue), count: \(snapshot.disableCount)), re-enabling")
+        box.onTapDisabled?(snapshot)
         if let reenableTap = box.reenableTap {
             reenableTap()
         } else if let tap = box.tap {
@@ -61,6 +81,14 @@ func handleEventTapEvent(
         }
 
         if swallow && keyCode == HyperKeyService.f19KeyCode {
+            let modifierFlags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
+            box.recordObservedEvent(
+                type: .keyDown,
+                keyCode: keyCode,
+                modifierFlags: modifierFlags.intersection(.deviceIndependentFlagsMask),
+                swallowed: true,
+                injectedHyper: false
+            )
             return nil
         }
 
@@ -72,6 +100,13 @@ func handleEventTapEvent(
         let keyPress = KeyPress(
             keyCode: keyCode,
             modifiers: flags.intersection(.deviceIndependentFlagsMask)
+        )
+        box.recordObservedEvent(
+            type: .keyDown,
+            keyCode: keyCode,
+            modifierFlags: keyPress.modifiers,
+            swallowed: swallow,
+            injectedHyper: injectHyper
         )
 
         if swallow {
@@ -89,9 +124,25 @@ func handleEventTapEvent(
             }
             return false
         }
+        let modifierFlags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
+        box.recordObservedEvent(
+            type: .keyUp,
+            keyCode: keyCode,
+            modifierFlags: modifierFlags.intersection(.deviceIndependentFlagsMask),
+            swallowed: swallowUp,
+            injectedHyper: false
+        )
         return swallowUp ? nil : Unmanaged.passUnretained(event)
 
     case .flagsChanged:
+        let modifierFlags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
+        box.recordObservedEvent(
+            type: .flagsChanged,
+            keyCode: nil,
+            modifierFlags: modifierFlags.intersection(.deviceIndependentFlagsMask),
+            swallowed: false,
+            injectedHyper: false
+        )
         return Unmanaged.passUnretained(event)
 
     default:
@@ -143,6 +194,11 @@ final class EventTapManager: EventTapManaging {
         let box = EventTapBox()
         box.onKeyPress = MatchedShortcutDelivery.makeHandler { [weak self] keyPress in
             self?.handleAsync(keyPress)
+        }
+        box.onTapDisabled = { snapshot in
+            DispatchQueue.global(qos: .utility).async {
+                DiagnosticLog.log(snapshot.logMessage)
+            }
         }
         box.registeredShortcuts = registeredKeyPresses
         let retained = Unmanaged.passRetained(box)
@@ -304,6 +360,8 @@ final class EventTapBox {
     var reenableTap: (@Sendable () -> Void)?
     /// Background-safe closure that hops to the main actor before invoking app logic.
     var onKeyPress: (@Sendable (KeyPress) -> Void)?
+    /// Background-safe closure for asynchronous timeout diagnostics.
+    var onTapDisabled: (@Sendable (EventTapDiagnosticsSnapshot) -> Void)?
 
     // MARK: - Lock-protected shared state
 
@@ -313,6 +371,12 @@ final class EventTapBox {
     fileprivate var _registeredShortcuts: Set<KeyPress> = []
     fileprivate var _hyperKeyEnabled: Bool = false
     fileprivate var _isHyperHeld: Bool = false
+    fileprivate var _disableCount: Int = 0
+    fileprivate var _lastEventType: CGEventType?
+    fileprivate var _lastKeyCode: CGKeyCode?
+    fileprivate var _lastModifierFlags: UInt = 0
+    fileprivate var _lastShortcutWasSwallowed: Bool = false
+    fileprivate var _lastHyperInjected: Bool = false
 
     var registeredShortcuts: Set<KeyPress> {
         get { withLock { _registeredShortcuts } }
@@ -332,6 +396,40 @@ final class EventTapBox {
         withLock {
             _hyperKeyEnabled = enabled
             if !enabled { _isHyperHeld = false }
+        }
+    }
+
+    func recordObservedEvent(
+        type: CGEventType,
+        keyCode: CGKeyCode?,
+        modifierFlags: NSEvent.ModifierFlags,
+        swallowed: Bool,
+        injectedHyper: Bool
+    ) {
+        withLock {
+            _lastEventType = type
+            _lastKeyCode = keyCode
+            _lastModifierFlags = modifierFlags.rawValue
+            _lastShortcutWasSwallowed = swallowed
+            _lastHyperInjected = injectedHyper
+        }
+    }
+
+    func captureDisableSnapshot(reason: CGEventType) -> EventTapDiagnosticsSnapshot {
+        withLock {
+            _disableCount += 1
+            return EventTapDiagnosticsSnapshot(
+                reason: reason,
+                disableCount: _disableCount,
+                lastEventType: _lastEventType,
+                lastKeyCode: _lastKeyCode,
+                lastModifierFlags: _lastModifierFlags,
+                lastShortcutWasSwallowed: _lastShortcutWasSwallowed,
+                lastHyperInjected: _lastHyperInjected,
+                registeredShortcutCount: _registeredShortcuts.count,
+                hyperKeyEnabled: _hyperKeyEnabled,
+                hyperKeyHeld: _isHyperHeld
+            )
         }
     }
 

--- a/Sources/Quickey/Services/FrontmostApplicationTracker.swift
+++ b/Sources/Quickey/Services/FrontmostApplicationTracker.swift
@@ -5,6 +5,11 @@ private let logger = Logger(subsystem: DiagnosticLog.subsystem, category: "Front
 
 @MainActor
 final class FrontmostApplicationTracker {
+    struct PreviousAppRestoreAttempt: Sendable, Equatable {
+        let bundleIdentifier: String?
+        let restoreAccepted: Bool
+    }
+
     struct Client: Sendable {
         let currentFrontmostBundleIdentifier: @MainActor () -> String?
         let processIdentifierForRunningApplication: @MainActor (String) -> pid_t?
@@ -13,6 +18,7 @@ final class FrontmostApplicationTracker {
     }
 
     private(set) var lastNonTargetBundleIdentifier: String?
+    private(set) var lastRestoreAttempt: PreviousAppRestoreAttempt?
     private let client: Client
 
     init(client: Client = .live) {
@@ -28,23 +34,50 @@ final class FrontmostApplicationTracker {
             return
         }
         lastNonTargetBundleIdentifier = current
+        lastRestoreAttempt = nil
     }
 
     /// Restore the previous app using SkyLight for reliable activation (consistent with AppSwitcher).
     @discardableResult
-    func restorePreviousAppIfPossible() -> Bool {
-        guard let bundleIdentifier = lastNonTargetBundleIdentifier,
-              let pid = client.processIdentifierForRunningApplication(bundleIdentifier) else {
-            lastNonTargetBundleIdentifier = nil
-            return false
+    func restorePreviousAppIfPossible() -> PreviousAppRestoreAttempt {
+        guard let bundleIdentifier = lastNonTargetBundleIdentifier else {
+            let attempt = PreviousAppRestoreAttempt(bundleIdentifier: nil, restoreAccepted: false)
+            lastRestoreAttempt = attempt
+            return attempt
         }
-        lastNonTargetBundleIdentifier = nil
+
+        guard let pid = client.processIdentifierForRunningApplication(bundleIdentifier) else {
+            let attempt = PreviousAppRestoreAttempt(bundleIdentifier: bundleIdentifier, restoreAccepted: false)
+            lastRestoreAttempt = attempt
+            return attempt
+        }
 
         if !client.setFrontProcess(pid) {
             logger.warning("restorePrevious: SkyLight failed for \(bundleIdentifier), falling back")
-            return client.activateRunningApplication(bundleIdentifier)
+            let attempt = PreviousAppRestoreAttempt(
+                bundleIdentifier: bundleIdentifier,
+                restoreAccepted: client.activateRunningApplication(bundleIdentifier)
+            )
+            lastRestoreAttempt = attempt
+            return attempt
         }
-        return true
+
+        let attempt = PreviousAppRestoreAttempt(bundleIdentifier: bundleIdentifier, restoreAccepted: true)
+        lastRestoreAttempt = attempt
+        return attempt
+    }
+
+    func confirmRestoreAttempt() {
+        guard let lastRestoreAttempt else { return }
+        if lastRestoreAttempt.restoreAccepted {
+            lastNonTargetBundleIdentifier = nil
+        }
+        self.lastRestoreAttempt = nil
+    }
+
+    func resetPreviousAppTracking() {
+        lastNonTargetBundleIdentifier = nil
+        lastRestoreAttempt = nil
     }
 }
 

--- a/Tests/QuickeyTests/AppSwitcherTests.swift
+++ b/Tests/QuickeyTests/AppSwitcherTests.swift
@@ -130,6 +130,94 @@ func requestFallbackActivationUsesPlainActivationWhenBundleURLIsMissing() {
     #expect(plainActivateCalls == 1)
 }
 
+@Test
+func togglePostActionStateLogDetailsIncludesFrontmostAndTargetFlags() {
+    let state = TogglePostActionState(
+        frontmostBundleIdentifier: "com.openai.codex",
+        targetBundleIdentifier: "com.apple.Safari",
+        targetFrontmost: false,
+        targetHidden: true,
+        targetVisibleWindows: false
+    )
+
+    #expect(
+        state.logDetails ==
+        "postFrontmost=com.openai.codex, targetBundle=com.apple.Safari, targetFrontmost=false, targetHidden=true, targetVisibleWindows=false"
+    )
+}
+
+@Test @MainActor
+func postActionLogMessageUsesObservationSnapshotForFrontmostState() {
+    let switcher = AppSwitcher(frontmostTracker: makeTrackerForAppSwitcherTests())
+    let shortcut = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "s",
+        modifierFlags: ["command"]
+    )
+    let snapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Safari",
+        observedFrontmostBundleIdentifier: "com.openai.codex",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 1,
+        hasFocusedWindow: false,
+        hasMainWindow: true,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .regularWindowed,
+        classificationReason: "visible window but frontmost mismatch"
+    )
+
+    let message = switcher.postActionLogMessage(
+        for: shortcut,
+        phase: "POST_ACTIVATE_STATE",
+        snapshot: snapshot
+    )
+
+    #expect(message.contains("postFrontmost=com.openai.codex"))
+    #expect(message.contains("targetFrontmost=false"))
+}
+
+@Test @MainActor
+func toggleLifecycleLogMessageIncludesStructuredObservationFields() {
+    let switcher = AppSwitcher(frontmostTracker: makeTrackerForAppSwitcherTests())
+    let shortcut = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "s",
+        modifierFlags: ["command"]
+    )
+    let snapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Safari",
+        observedFrontmostBundleIdentifier: "com.openai.codex",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 1,
+        hasFocusedWindow: false,
+        hasMainWindow: true,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .regularWindowed,
+        classificationReason: "visible window but frontmost mismatch"
+    )
+
+    let message = switcher.toggleLifecycleLogMessage(
+        for: shortcut,
+        lifecycle: "TOGGLE_CONFIRMATION",
+        previousBundle: "com.openai.codex",
+        activationPath: "activate",
+        snapshot: snapshot,
+        elapsedMilliseconds: 75
+    )
+
+    #expect(message.contains("TOGGLE_CONFIRMATION"))
+    #expect(message.contains("previous=com.openai.codex"))
+    #expect(message.contains("activationPath=activate"))
+    #expect(message.contains("elapsedMs=75"))
+    #expect(message.contains("classification=\"regularWindowed\""))
+}
+
 @MainActor
 private func makeTrackerForAppSwitcherTests() -> FrontmostApplicationTracker {
     FrontmostApplicationTracker(client: .init(

--- a/Tests/QuickeyTests/ApplicationObservationTests.swift
+++ b/Tests/QuickeyTests/ApplicationObservationTests.swift
@@ -1,0 +1,123 @@
+import Testing
+@testable import Quickey
+
+@Test
+func observationMarksFrontmostMismatchAsNotStable() {
+    let snapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Safari",
+        observedFrontmostBundleIdentifier: "com.openai.codex",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 1,
+        hasFocusedWindow: false,
+        hasMainWindow: true,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .regularWindowed,
+        classificationReason: "visible main window"
+    )
+
+    #expect(snapshot.isStableActivation == false)
+}
+
+@Test
+func observationReevaluatesClassificationPerAttempt() {
+    let firstAttempt = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Home",
+        observedFrontmostBundleIdentifier: "com.apple.Home",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 0,
+        hasFocusedWindow: false,
+        hasMainWindow: false,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .windowlessOrAccessory,
+        classificationReason: "no visible windows"
+    )
+    let secondAttempt = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Home",
+        observedFrontmostBundleIdentifier: "com.apple.Home",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 1,
+        hasFocusedWindow: true,
+        hasMainWindow: true,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .nonStandardWindowed,
+        classificationReason: "window appeared during confirmation"
+    )
+
+    #expect(firstAttempt.classification == .windowlessOrAccessory)
+    #expect(secondAttempt.classification == .nonStandardWindowed)
+    #expect(firstAttempt.classification != secondAttempt.classification)
+}
+
+@Test
+func observationCanRepresentCurrentTogglePostActionFields() {
+    let snapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Safari",
+        observedFrontmostBundleIdentifier: "com.apple.Safari",
+        targetIsActive: true,
+        targetIsHidden: true,
+        visibleWindowCount: 0,
+        hasFocusedWindow: false,
+        hasMainWindow: false,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .regularWindowed,
+        classificationReason: "hidden app"
+    )
+
+    let state = TogglePostActionState(snapshot: snapshot)
+
+    #expect(state.frontmostBundleIdentifier == "com.apple.Safari")
+    #expect(state.targetBundleIdentifier == "com.apple.Safari")
+    #expect(state.targetFrontmost == true)
+    #expect(state.targetHidden == true)
+    #expect(state.targetVisibleWindows == false)
+}
+
+@Test
+func structuredLogFieldsQuoteStringValues() {
+    let snapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Safari",
+        observedFrontmostBundleIdentifier: "com.openai.codex",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 1,
+        hasFocusedWindow: true,
+        hasMainWindow: true,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .regularWindowed,
+        classificationReason: "visible focused \"main\" window"
+    )
+
+    #expect(snapshot.structuredLogFields.contains("frontmost=\"com.openai.codex\""))
+    #expect(snapshot.structuredLogFields.contains("target=\"com.apple.Safari\""))
+    #expect(snapshot.structuredLogFields.contains("classification=\"regularWindowed\""))
+    #expect(snapshot.structuredLogFields.contains("classificationReason=\"visible focused \\\"main\\\" window\""))
+}
+
+@Test
+func structuredLogFieldsIncludeWindowObservationFailureSignal() {
+    let snapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Home",
+        observedFrontmostBundleIdentifier: "com.apple.Home",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 0,
+        hasFocusedWindow: false,
+        hasMainWindow: false,
+        windowObservationSucceeded: false,
+        windowObservationFailureReason: "axWindowsReadFailed=-25204",
+        classification: .nonStandardWindowed,
+        classificationReason: "axWindowsReadFailed=-25204"
+    )
+
+    #expect(snapshot.structuredLogFields.contains("windowObservationSucceeded=false"))
+    #expect(snapshot.structuredLogFields.contains("windowObservationFailureReason=\"axWindowsReadFailed=-25204\""))
+    #expect(snapshot.structuredLogFields.contains("classification=\"nonStandardWindowed\""))
+}

--- a/Tests/QuickeyTests/FrontmostApplicationTrackerTests.swift
+++ b/Tests/QuickeyTests/FrontmostApplicationTrackerTests.swift
@@ -36,17 +36,67 @@ func restorePreviousAppFallsBackToActivationWhenSkyLightFails() {
     ))
 
     tracker.noteCurrentFrontmostApp(excluding: "com.apple.Safari")
-    let restored = tracker.restorePreviousAppIfPossible()
+    let restoreAttempt = tracker.restorePreviousAppIfPossible()
 
-    #expect(restored == true)
+    #expect(restoreAttempt.bundleIdentifier == "com.apple.Terminal")
+    #expect(restoreAttempt.restoreAccepted == true)
     #expect(recorder.lookupBundleIdentifiers == ["com.apple.Terminal"])
     #expect(recorder.setFrontProcessPIDs == [42])
     #expect(recorder.activatedBundleIdentifiers == ["com.apple.Terminal"])
+    #expect(tracker.lastNonTargetBundleIdentifier == "com.apple.Terminal")
+
+    tracker.confirmRestoreAttempt()
+
     #expect(tracker.lastNonTargetBundleIdentifier == nil)
+}
+
+@Test @MainActor
+func restoreAttemptDoesNotDiscardPreviousBundleBeforeConfirmation() {
+    let tracker = FrontmostApplicationTracker(client: .init(
+        currentFrontmostBundleIdentifier: { "com.apple.Terminal" },
+        processIdentifierForRunningApplication: { _ in 42 },
+        activateRunningApplication: { _ in true },
+        setFrontProcess: { _ in true }
+    ))
+
+    tracker.noteCurrentFrontmostApp(excluding: "com.apple.Safari")
+    let restoreAttempt = tracker.restorePreviousAppIfPossible()
+
+    #expect(restoreAttempt.bundleIdentifier == "com.apple.Terminal")
+    #expect(restoreAttempt.restoreAccepted == true)
+    #expect(tracker.lastNonTargetBundleIdentifier == "com.apple.Terminal")
+}
+
+@Test @MainActor
+func resetPreviousBundleAllowsFreshActivationToCaptureNewFrontmostApp() {
+    let frontmostState = MutableFrontmostState(bundleIdentifier: "com.apple.Terminal")
+    let tracker = FrontmostApplicationTracker(client: .init(
+        currentFrontmostBundleIdentifier: { frontmostState.bundleIdentifier },
+        processIdentifierForRunningApplication: { _ in 42 },
+        activateRunningApplication: { _ in true },
+        setFrontProcess: { _ in true }
+    ))
+
+    tracker.noteCurrentFrontmostApp(excluding: "com.apple.Safari")
+    _ = tracker.restorePreviousAppIfPossible()
+
+    frontmostState.bundleIdentifier = "com.openai.codex"
+    tracker.resetPreviousAppTracking()
+    tracker.noteCurrentFrontmostApp(excluding: "com.apple.Safari")
+
+    #expect(tracker.lastNonTargetBundleIdentifier == "com.openai.codex")
 }
 
 private final class FrontmostTrackerRecorder: @unchecked Sendable {
     var lookupBundleIdentifiers: [String] = []
     var activatedBundleIdentifiers: [String] = []
     var setFrontProcessPIDs: [pid_t] = []
+}
+
+private final class MutableFrontmostState: @unchecked Sendable {
+    var bundleIdentifier: String
+
+    init(bundleIdentifier: String) {
+        self.bundleIdentifier = bundleIdentifier
+    }
 }

--- a/Tests/QuickeyTests/QuickeyTests.swift
+++ b/Tests/QuickeyTests/QuickeyTests.swift
@@ -161,6 +161,37 @@ struct EventTapManagerDeliveryTests {
     }
 
     @Test
+    func disabledTapDiagnosticsIncludeMostRecentShortcutContext() throws {
+        let keyPress = KeyPress(keyCode: CGKeyCode(kVK_ANSI_A), modifiers: [.command])
+        let event = makeKeyEvent(keyPress.keyCode, modifiers: keyPress.modifiers, keyDown: true)
+        let box = EventTapBox()
+        box.registeredShortcuts = [keyPress]
+
+        let diagnostics = LockedValue<EventTapDiagnosticsSnapshot?>(nil)
+        box.onTapDisabled = { snapshot in
+            diagnostics.value = snapshot
+        }
+
+        let keyDownResult = handleEventTapEvent(type: .keyDown, event: event, box: box)
+        #expect(keyDownResult == nil)
+
+        let timeoutResult = handleEventTapEvent(type: .tapDisabledByTimeout, event: event, box: box)
+        #expect(timeoutResult != nil)
+
+        let snapshot = try #require(diagnostics.value)
+        #expect(snapshot.reason == .tapDisabledByTimeout)
+        #expect(snapshot.disableCount == 1)
+        #expect(snapshot.lastEventType == .keyDown)
+        #expect(snapshot.lastKeyCode == keyPress.keyCode)
+        #expect(snapshot.lastModifierFlags == keyPress.modifiers.rawValue)
+        #expect(snapshot.lastShortcutWasSwallowed == true)
+        #expect(snapshot.lastHyperInjected == false)
+        #expect(snapshot.registeredShortcutCount == 1)
+        #expect(snapshot.hyperKeyEnabled == false)
+        #expect(snapshot.hyperKeyHeld == false)
+    }
+
+    @Test
     func hyperKeyPressAndReleaseToggleHeldState() {
         let keyDown = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: true)
         let keyUp = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: false)
@@ -212,6 +243,28 @@ struct EventTapManagerDeliveryTests {
 
 private final class SendableCounter: @unchecked Sendable {
     var value = 0
+}
+
+private final class LockedValue<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: T
+
+    init(_ value: T) {
+        storage = value
+    }
+
+    var value: T {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+        set {
+            lock.lock()
+            storage = newValue
+            lock.unlock()
+        }
+    }
 }
 
 // MARK: - KeyMatcher

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -1,7 +1,7 @@
 # Handoff Notes
 
 ## Current State
-Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. On 2026-03-23, the runtime hardening follow-up added service-level test seams for permission, app discovery, frontmost-app restore, preferences, and activation fallback paths, and replaced the deprecated `activateIgnoringOtherApps` fallback with a modern `NSWorkspace` reopen request. Issue #67's launch-at-login approval-state UX also landed on 2026-03-23, including Settings foreground refresh coverage for launch-at-login state changes, and `swift test`, `swift build`, `swift build -c release`, and `./scripts/package-app.sh` were rerun afterward. Coverage for the newly targeted services is now measurable: `AccessibilityPermissionService` 64.29%, `AppListProvider` 40.78%, `AppPreferences` 72.50%, `FrontmostApplicationTracker` 43.64%, and `AppSwitcher` 10.55%. The changed activation/runtime paths still need a fresh targeted macOS pass before we can call them revalidated. A signed and notarized distributable is still unresolved.
+Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. On 2026-03-23, the runtime hardening follow-up added service-level test seams for permission, app discovery, frontmost-app restore, preferences, and activation fallback paths, and replaced the deprecated `activateIgnoringOtherApps` fallback with a modern `NSWorkspace` reopen request. Issue #67's launch-at-login approval-state UX also landed on 2026-03-23, including Settings foreground refresh coverage for launch-at-login state changes, and `swift test`, `swift build`, `swift build -c release`, and `./scripts/package-app.sh` were rerun afterward. Coverage for the newly targeted services is now measurable: `AccessibilityPermissionService` 64.29%, `AppListProvider` 40.78%, `AppPreferences` 72.50%, `FrontmostApplicationTracker` 43.64%, and `AppSwitcher` 10.55%. A deeper macOS runtime investigation later on 2026-03-23 found that toggle semantics are still not stable enough for some system apps such as Home: new post-action logs showed cases where the target app had visible windows while `NSWorkspace.shared.frontmostApplication` remained another bundle, and other cases where `NSRunningApplication.isActive` disagreed with the frontmost-app snapshot during restore. A design follow-up is now in progress to introduce stable activation gating, degraded-success rules for window-weird apps, and stricter event tap recovery observability. A signed and notarized distributable is still unresolved.
 
 ## Validated on macOS
 - Broad real-device validation completed on macOS 15.3.1 on 2026-03-20
@@ -14,6 +14,7 @@ Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. On 2026-03-23, the 
 - Launch-at-login approval flow after the 2026-03-23 issue #67 approval-state UX update, especially `.requiresApproval` -> `.enabled` foreground refresh and `.notFound` behavior on real installs
 - Active event-tap startup and readiness reporting after permission or lifecycle changes
 - AppSwitcher fallback behavior after SkyLight failure now that it re-requests activation via `NSWorkspace`
+- App toggle stability after the 2026-03-23 Home/system-app investigation, especially "visible but not truly frontmost" states and second-trigger behavior during transitional activation
 - Hyper Key failure handling, especially persistence only after `hidutil` succeeds
 - Insights date-window and refresh-race fixes
 - Signed/notarized distributable workflow once a Developer ID certificate is available
@@ -27,6 +28,7 @@ Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. On 2026-03-23, the 
 - Unified logging can hide useful runtime details; file-based debug logs (`~/.config/Quickey/debug.log`) are more reliable for diagnosis
 
 ## Immediate Next Actions
-1. Re-run the targeted macOS validation for the 2026-03-21 remediation changes
-2. Produce a signed and notarized `.app` once a Developer ID certificate is available
-3. Fold any new validation findings back into this note, not into the feature overview docs
+1. Turn the approved toggle-stability and event-tap reliability design into an implementation plan before making further runtime behavior changes
+2. Run a targeted macOS validation pass for normal apps and system apps after the stability redesign lands, especially Home, Clock, System Settings, and fast repeat-trigger flows
+3. Produce a signed and notarized `.app` once a Developer ID certificate is available
+4. Fold any new validation findings back into this note, not into the feature overview docs

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -72,3 +72,47 @@ The cooperative activation path can report success without actually activating t
 
 **Practical guidance**
 Use the SkyLight-based activation path when Quickey must reliably front the target app. Treat it as the validated route for LSUIElement activation behavior.
+
+## Frontmost Truth for Toggle Semantics
+
+**Issue**
+An app can appear visually present while Quickey still should not treat it as safely toggleable.
+
+**Cause**
+App activation on macOS is transitional. `NSRunningApplication.activate()` only attempts activation, and `NSRunningApplication.isActive` can briefly disagree with `NSWorkspace.shared.frontmostApplication` during odd system-app or window-recovery flows.
+
+**Practical guidance**
+For app-level toggle behavior, treat `NSWorkspace.shared.frontmostApplication` as the primary truth because Apple defines it as the app receiving key events. Use `isActive`, `isHidden`, and window visibility as supporting signals, not as the sole toggle-off gate.
+
+## Stable Activation Beats Instantaneous Activation
+
+**Issue**
+Repeated shortcut presses can flap between "activate" and "toggle off" if Quickey decides from a single immediate state snapshot.
+
+**Cause**
+The first trigger may only have started activation, while the second trigger arrives before the app has reached a stable frontmost state with a usable window.
+
+**Practical guidance**
+Do not let "activation requested" mean "activation complete". Require a short post-activation confirmation pass and only allow toggle-off from a stable active state. During pending or degraded activation, a repeat trigger should re-confirm or re-attempt activation instead of restoring away immediately.
+
+## System Apps Need Honest Downgrade Rules
+
+**Issue**
+Apps such as Home can produce visible windows without behaving like normal key-window-driven document apps.
+
+**Cause**
+Some system utilities use nonstandard scene, hide/unhide, or window activation behavior that does not match assumptions baked into regular AppKit apps.
+
+**Practical guidance**
+Do not force all apps through one generic "front app with visible window means success" rule. Keep a degraded-success path for system or window-weird apps, log why the app is degraded, and avoid counting degraded activation as safe toggle-off state.
+
+## Event Tap Timeout Recovery Needs Escalation
+
+**Issue**
+Re-enabling an event tap after a timeout is necessary but not always sufficient.
+
+**Cause**
+macOS can repeatedly disable the tap with `tapDisabledByTimeout`, which indicates sustained callback or lifecycle pressure rather than a one-off interruption.
+
+**Practical guidance**
+Keep the callback path light and re-enable in place first, but track rolling timeout counts. If repeated timeouts cluster together, escalate from in-place re-enable to full tap recreation and log the recovery tier so later diagnosis does not start from scratch.

--- a/docs/superpowers/plans/2026-03-24-toggle-stability-and-event-tap-reliability.md
+++ b/docs/superpowers/plans/2026-03-24-toggle-stability-and-event-tap-reliability.md
@@ -1,0 +1,592 @@
+# Toggle Stability And Event Tap Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the approved stable-state toggle redesign and event tap recovery hardening without regressing Quickey's app-level shortcut behavior.
+
+**Architecture:** Land the redesign in three controlled phases. Phase 1 adds observation snapshots, structured diagnostics, and restore-state foundations. Phase 2 adds lightweight pending/stable confirmation inside the existing `AppSwitcher` flow without a full coordinator. Phase 3 introduces `ToggleSessionCoordinator`, degraded-state lifecycle rules, and bounded event-tap recreation on the dedicated background run loop.
+
+**Tech Stack:** Swift 6, Swift Testing, AppKit, CoreGraphics, Accessibility APIs, `NSWorkspace` notifications, background RunLoop event taps
+
+---
+
+## Spec Input
+
+- Design spec: `docs/superpowers/specs/2026-03-23-toggle-stability-and-event-tap-design.md`
+
+## File Map
+
+- Create: `Sources/Quickey/Services/ApplicationObservation.swift`
+- Create: `Sources/Quickey/Services/ToggleSessionCoordinator.swift`
+- Create: `Tests/QuickeyTests/ApplicationObservationTests.swift`
+- Create: `Tests/QuickeyTests/ToggleSessionCoordinatorTests.swift`
+- Create: `Tests/QuickeyTests/EventTapManagerLifecycleTests.swift`
+- Modify: `Sources/Quickey/Services/AppSwitcher.swift`
+- Modify: `Sources/Quickey/Services/FrontmostApplicationTracker.swift`
+- Modify: `Sources/Quickey/Services/EventTapManager.swift`
+- Modify: `Sources/Quickey/Services/ShortcutManager.swift` only if accepted-trigger semantics need explicit comments or test seams
+- Modify: `Tests/QuickeyTests/AppSwitcherTests.swift`
+- Modify: `Tests/QuickeyTests/QuickeyTests.swift` only if existing event-tap callback tests remain the best home for callback-safe assertions
+- Modify: `docs/architecture.md`
+- Modify: `docs/handoff-notes.md`
+- Modify: `docs/lessons-learned.md` if implementation changes the recommended event-tap recovery guidance
+
+## Phase Boundaries
+
+- Phase 1 in this plan = Tasks 1-2
+- Phase 2 in this plan = Task 3
+- Phase 3 in this plan = Tasks 4-5
+- Final documentation and validation = Task 6
+
+The plan itself is the Phase 2 implementation spec the design review asked for. Do not start Phase 3 until Phase 2 behavior is green and manually understandable from logs.
+
+### Task 1: Build Application Observation And Phase-1 Diagnostics
+
+**Files:**
+- Create: `Sources/Quickey/Services/ApplicationObservation.swift`
+- Modify: `Sources/Quickey/Services/AppSwitcher.swift`
+- Test: `Tests/QuickeyTests/ApplicationObservationTests.swift`
+- Test: `Tests/QuickeyTests/AppSwitcherTests.swift`
+
+- [ ] **Step 1: Write failing observation tests before creating the helper**
+
+Add focused tests that pin the intended observation behavior:
+
+```swift
+@Test @MainActor
+func observationMarksFrontmostMismatchAsNotStable()
+
+@Test @MainActor
+func observationReevaluatesClassificationPerAttempt()
+
+@Test @MainActor
+func observationCanRepresentCurrentTogglePostActionFields()
+```
+
+- [ ] **Step 2: Run the focused observation tests to verify they fail for the right reason**
+
+Run: `swift test --filter ApplicationObservation`
+Expected: fail because the helper types and seams do not exist yet.
+
+- [ ] **Step 3: Create the new observation helper with an injectable client seam**
+
+Add `Sources/Quickey/Services/ApplicationObservation.swift` with a small, testable surface:
+
+```swift
+enum ApplicationClassification: Sendable {
+    case regularWindowed
+    case nonStandardWindowed
+    case windowlessOrAccessory
+    case systemUtility
+}
+
+struct ActivationObservationSnapshot: Sendable, Equatable {
+    let targetBundleIdentifier: String?
+    let observedFrontmostBundleIdentifier: String?
+    let targetIsActive: Bool
+    let targetIsHidden: Bool
+    let visibleWindowCount: Int
+    let hasFocusedWindow: Bool
+    let hasMainWindow: Bool
+    let classification: ApplicationClassification
+    let classificationReason: String
+}
+```
+
+Use injected closures or a `Client` struct, not direct global calls, so the helper can be tested without live AppKit state.
+
+- [ ] **Step 4: Preserve and bridge the existing `TogglePostActionState` path**
+
+Keep `TogglePostActionState` in `AppSwitcher.swift`, but make it a compatibility view over `ActivationObservationSnapshot` instead of a parallel truth source. During Phase 1, both log paths can coexist.
+
+- [ ] **Step 5: Replace ad hoc post-action logging with structured `key=value` records**
+
+Update `AppSwitcher` log helpers to emit fields from `ActivationObservationSnapshot`:
+
+```swift
+"frontmost=\(snapshot.observedFrontmostBundleIdentifier ?? "nil") target=\(snapshot.targetBundleIdentifier ?? "nil") targetActive=\(snapshot.targetIsActive) targetHidden=\(snapshot.targetIsHidden) visibleWindowCount=\(snapshot.visibleWindowCount) classification=\(snapshot.classification)"
+```
+
+Do not remove `POST_ACTIVATE_STATE` / `POST_RESTORE_STATE` yet; make them wrappers over the structured fields.
+
+- [ ] **Step 6: Enumerate the required toggle lifecycle log families**
+
+Make the Phase 1 diagnostics deliver the named lifecycle records required by the design spec:
+- `TOGGLE_ATTEMPT`
+- `TOGGLE_CONFIRMATION`
+- `TOGGLE_STABLE`
+- `TOGGLE_DEGRADED`
+- `TOGGLE_RESTORE_ATTEMPT`
+- `TOGGLE_RESTORE_CONFIRMED`
+- `TOGGLE_RESTORE_DEGRADED`
+
+Each record should emit, when available:
+- target bundle
+- previous bundle
+- observed frontmost bundle
+- `isActive`
+- `isHidden`
+- visible-window evidence
+- app classification and classification reason
+- activation or recovery path
+- elapsed milliseconds
+
+`POST_ACTIVATE_STATE` / `POST_RESTORE_STATE` may remain as compatibility wrappers during Phase 1, but the implementation should already route through the canonical structured fields above.
+
+- [ ] **Step 7: Add a failing `AppSwitcher` test proving the new snapshot is used for logs**
+
+Cover a case where:
+- `frontmostApplication` is another bundle
+- `runningApp.isActive == true`
+- the snapshot still marks the state as not stable
+
+- [ ] **Step 8: Run the focused observation and app-switcher tests to verify they now pass**
+
+Run:
+
+```bash
+swift test --filter ApplicationObservation
+swift test --filter AppSwitcher
+```
+
+Expected: green, with diagnostics still representing the old post-action fields.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/Quickey/Services/ApplicationObservation.swift Sources/Quickey/Services/AppSwitcher.swift Tests/QuickeyTests/ApplicationObservationTests.swift Tests/QuickeyTests/AppSwitcherTests.swift
+git commit -m "feat: add activation observation snapshots"
+```
+
+### Task 2: Fix Previous-App Ownership And Tracker Semantics
+
+**Files:**
+- Modify: `Sources/Quickey/Services/FrontmostApplicationTracker.swift`
+- Modify: `Sources/Quickey/Services/AppSwitcher.swift`
+- Test: `Tests/QuickeyTests/AppSwitcherTests.swift`
+- Create or modify: focused frontmost-tracker tests under `Tests/QuickeyTests/`
+
+- [ ] **Step 1: Write a failing test for premature previous-app clearing**
+
+Add a test proving the current tracker behavior is wrong for post-restore confirmation:
+
+```swift
+@Test @MainActor
+func restoreAttemptDoesNotDiscardPreviousBundleBeforeConfirmation()
+```
+
+- [ ] **Step 2: Run the focused tracker test to verify it fails**
+
+Run: `swift test --filter FrontmostApplicationTracker`
+Expected: fail because the current implementation clears state too early.
+
+- [ ] **Step 3: Introduce explicit restore-attempt state instead of destructive read semantics**
+
+Refactor the tracker so the code can:
+
+```swift
+let previousBundle = tracker.lastNonTargetBundleIdentifier
+let restoreAccepted = tracker.restorePreviousAppIfPossible()
+// bundle is only cleared after explicit confirmation or explicit session reset
+```
+
+If a cleaner shape is needed, add a tiny value type:
+
+```swift
+struct PreviousAppRestoreAttempt: Sendable, Equatable {
+    let bundleIdentifier: String?
+    let restoreAccepted: Bool
+}
+```
+
+Do not leave a "read-and-clear" API behind.
+
+- [ ] **Step 4: Update `AppSwitcher` to stop depending on destructive tracker reads**
+
+Current restore logs capture `previousApp` before restore. Keep that behavior, but ensure a failed confirmation path can still see the same bundle later.
+
+- [ ] **Step 5: Add a failing test for manual frontmost change invalidating the stored previous bundle**
+
+This test should model:
+- first trigger captures previous bundle
+- user manually changes the frontmost app before confirmation succeeds
+- the next fresh activation session refreshes `previousBundle` from current frontmost state
+
+- [ ] **Step 6: Implement the minimum refresh rule**
+
+Refresh `previousBundle` only when a session restarts from `idle` or when a confirmation generation mismatch invalidates the old activation session. Do not rewrite previous-bundle history mid-session unless the session has been abandoned.
+
+- [ ] **Step 7: Verify tracker and app-switcher tests pass**
+
+Run:
+
+```bash
+swift test --filter FrontmostApplicationTracker
+swift test --filter AppSwitcher
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/Quickey/Services/FrontmostApplicationTracker.swift Sources/Quickey/Services/AppSwitcher.swift Tests/QuickeyTests
+git commit -m "fix: preserve previous app until restore is confirmed"
+```
+
+### Task 3: Implement Phase-2 Pending/Stable Confirmation In `AppSwitcher`
+
+**Files:**
+- Modify: `Sources/Quickey/Services/AppSwitcher.swift`
+- Modify: `Sources/Quickey/Services/ShortcutManager.swift` only if accepted-trigger semantics need comments or test adjustments
+- Test: `Tests/QuickeyTests/AppSwitcherTests.swift`
+- Test: `Tests/QuickeyTests/ApplicationObservationTests.swift`
+
+- [ ] **Step 1: Write failing tests for the Phase-2 pending/stable behavior**
+
+Cover the highest-risk flows:
+
+```swift
+@Test @MainActor
+func secondTriggerDuringPendingActivationDoesNotToggleOff()
+
+@Test @MainActor
+func staleConfirmationGenerationCannotPromoteState()
+
+@Test @MainActor
+func acceptedTriggerStillReturnsTrueWhileConfirmationIsPending()
+```
+
+- [ ] **Step 2: Run the focused Phase-2 tests to verify they fail**
+
+Run: `swift test --filter AppSwitcher`
+Expected: fail because no pending/stable coordination exists yet.
+
+- [ ] **Step 3: Replace the blind nested recovery timers with stage-by-stage completion**
+
+Refactor `recoverWindowlessApp` so it can be coordinated instead of racing with a separate confirmation timer. The implementation should move toward:
+
+```swift
+private func recoverWindowlessApp(
+    _ app: NSRunningApplication,
+    shortcut: AppShortcut,
+    completion: @escaping @MainActor (WindowRecoveryStageResult) -> Void
+)
+```
+
+Do not keep an unstructured `asyncAfter -> asyncAfter -> final fallback` chain once Phase 2 begins.
+
+- [ ] **Step 4: Implement a lightweight pending/stable store inside `AppSwitcher`**
+
+Do not introduce `ToggleSessionCoordinator` yet. Use a small Phase-2-local structure such as:
+
+```swift
+private struct PendingActivationState {
+    let bundleIdentifier: String
+    let previousBundleIdentifier: String?
+    let generation: Int
+    let startedAt: CFAbsoluteTime
+}
+```
+
+This is enough for:
+- confirmation generation invalidation
+- pending vs stable distinction
+- accepted-trigger boolean semantics
+
+- [ ] **Step 5: Make confirmation interleave with recovery stages rather than race them**
+
+Required order for one activation attempt:
+
+```text
+activation attempt
+-> confirmation pass
+-> if needed, recovery stage 1
+-> confirmation pass
+-> if needed, recovery stage 2
+-> confirmation pass
+-> stable or idle
+```
+
+Do not run a confirmation timer in parallel with an unfinished recovery stage.
+
+- [ ] **Step 6: Keep synchronous return semantics stable for `ShortcutManager`**
+
+`ShortcutManager.trigger(_:)` should continue to treat `true` as "the trigger was accepted and work started", not "the app definitely reached stable state." Document that expectation in code comments if needed.
+
+- [ ] **Step 7: Add a focused regression test for the existing `recoverWindowlessApp` timing path**
+
+The test should prove that a recovery stage can complete before the next confirmation is evaluated.
+
+- [ ] **Step 8: Verify the Phase-2 suite passes**
+
+Run:
+
+```bash
+swift test --filter AppSwitcher
+swift test --filter ApplicationObservation
+```
+
+Expected: green, with no visual-rollback logic added.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/Quickey/Services/AppSwitcher.swift Sources/Quickey/Services/ShortcutManager.swift Tests/QuickeyTests
+git commit -m "feat: add pending and stable activation confirmation"
+```
+
+### Task 4: Introduce `ToggleSessionCoordinator` And Notification-Driven Lifecycle Rules
+
+**Files:**
+- Create: `Sources/Quickey/Services/ToggleSessionCoordinator.swift`
+- Modify: `Sources/Quickey/Services/AppSwitcher.swift`
+- Modify: `Sources/Quickey/Services/ApplicationObservation.swift`
+- Create: `Tests/QuickeyTests/ToggleSessionCoordinatorTests.swift`
+- Modify: `Tests/QuickeyTests/AppSwitcherTests.swift`
+
+- [ ] **Step 1: Write failing coordinator tests before creating the coordinator**
+
+Cover:
+
+```swift
+@Test @MainActor
+func activeStableExpiresWhenAnotherAppBecomesFrontmost()
+
+@Test @MainActor
+func degradedSessionReturnsToIdleAfterRetryCap()
+
+@Test @MainActor
+func terminatedTargetClearsPendingSession()
+
+@Test @MainActor
+func sessionStoreEvictsStalestIdleOrExpiredSessionAtConfiguredCap()
+```
+
+- [ ] **Step 2: Run the focused coordinator tests to verify they fail**
+
+Run: `swift test --filter ToggleSessionCoordinator`
+Expected: fail because the coordinator file does not exist yet.
+
+- [ ] **Step 3: Create the coordinator as `@MainActor` and document the exception**
+
+Implement a focused coordinator:
+
+```swift
+@MainActor
+final class ToggleSessionCoordinator {
+    struct Session { ... }
+    func beginActivation(for bundleIdentifier: String, previousBundle: String?, now: CFAbsoluteTime) -> Session
+    func markStable(...)
+    func markDegraded(...)
+    func beginDeactivation(...)
+    func handleFrontmostChange(...)
+    func handleTermination(...)
+}
+```
+
+Add a short comment that this is an intentional `@MainActor` exception because it coordinates AppKit/AX/`NSWorkspace` ordering and is not part of the event-tap callback hot path.
+
+- [ ] **Step 4: Use `NSWorkspace` notifications as the invalidation source**
+
+Wire notification-driven helpers for:
+- `NSWorkspace.didActivateApplicationNotification`
+- `NSWorkspace.didTerminateApplicationNotification`
+
+Do not poll.
+
+- [ ] **Step 5: Move previous-bundle ownership into the coordinator session**
+
+At this point the coordinator, not `FrontmostApplicationTracker`, should be the durable source of `previousBundle` for:
+- pending activation
+- active stable
+- deactivation
+
+- [ ] **Step 6: Add failing tests for degraded expiry and retry interaction**
+
+Prove:
+- user-triggered reconfirm resets degraded idle expiry
+- user-triggered reconfirm does not reset the 5-second absolute ceiling
+- same-session retries count against the same retry cap
+
+- [ ] **Step 7: Implement idle expiry, retry cap, bounded session storage, and session reset rules**
+
+Use deterministic time injection in tests. Do not rely on `sleep`.
+
+Bound live coordinator sessions to configured target bundles, with an initial runtime cap of 50 sessions. When the cap is reached:
+- evict the stalest idle session first
+- if no idle session exists, evict the stalest expired non-idle session
+- do not evict the currently mutating session
+
+- [ ] **Step 8: Verify coordinator and integration tests pass**
+
+Run:
+
+```bash
+swift test --filter ToggleSessionCoordinator
+swift test --filter AppSwitcher
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/Quickey/Services/ToggleSessionCoordinator.swift Sources/Quickey/Services/AppSwitcher.swift Sources/Quickey/Services/ApplicationObservation.swift Tests/QuickeyTests/ToggleSessionCoordinatorTests.swift Tests/QuickeyTests/AppSwitcherTests.swift
+git commit -m "feat: add toggle session coordinator"
+```
+
+### Task 5: Harden Event Tap Recreation And Background RunLoop Ownership
+
+**Files:**
+- Modify: `Sources/Quickey/Services/EventTapManager.swift`
+- Create: `Tests/QuickeyTests/EventTapManagerLifecycleTests.swift`
+- Modify: `Tests/QuickeyTests/QuickeyTests.swift` if existing callback tests should be moved or shared
+
+- [ ] **Step 1: Write failing tests for repeated recreation on the same background thread**
+
+Cover:
+
+```swift
+@Test
+func repeatedTimeoutsTriggerRecreationAfterThreshold()
+
+@Test
+func repeatedRecreationDoesNotDeadlockBackgroundRunLoopThread()
+
+@Test
+func recreationFailureEmitsExplicitDegradedState()
+```
+
+- [ ] **Step 2: Run the focused event-tap lifecycle tests to verify they fail**
+
+Run: `swift test --filter EventTapManagerLifecycle`
+Expected: fail because the lifecycle state and recreation thresholds do not exist yet.
+
+- [ ] **Step 3: Replace the one-shot readiness semaphore with a reusable readiness mechanism**
+
+Do not implement same-thread recreation while `BackgroundRunLoopThread.addSource(_:)` still depends on a single-consume semaphore.
+
+Prefer a reusable state holder, for example:
+
+```swift
+private struct RunLoopState {
+    var runLoop: CFRunLoop?
+    var isReady: Bool
+}
+```
+
+guarded by a lock or condition. The goal is repeated add/remove/recreate on the same owning thread, not a one-time startup handshake.
+
+- [ ] **Step 4: Implement lifecycle counters and escalation thresholds**
+
+Add deterministic state for:
+- first timeout -> in-place re-enable
+- 3 timeouts / 30 seconds -> full recreation
+- 2 recreation failures / 120 seconds -> degraded capture state
+
+- [ ] **Step 5: Recreate the tap with explicit same-thread ordering**
+
+Keep a single dedicated background run loop thread by default. Follow the documented order:
+
+```text
+remove source
+-> disable/invalidate old tap
+-> release old references
+-> create new tap
+-> create new source
+-> add new source
+-> enable new tap
+```
+
+If same-thread recreation proves impossible quickly, a fresh-thread fallback is acceptable only as an explicitly documented temporary path.
+
+- [ ] **Step 6: Add a regression test for callback-safe logging during recovery**
+
+Ensure timeout logging remains callback-safe and does not perform synchronous file I/O or AX work.
+
+- [ ] **Step 7: Enumerate the required event-tap lifecycle log families**
+
+Make the hardened event-tap implementation emit the named lifecycle records required by the design spec:
+- `EVENT_TAP_STARTED`
+- `EVENT_TAP_DISABLED`
+- `EVENT_TAP_REENABLED`
+- `EVENT_TAP_RECREATED`
+- `EVENT_TAP_RECREATION_FAILED`
+- `EVENT_TAP_DEGRADED`
+- `EVENT_TAP_RECOVERED`
+
+Each record should emit, when available:
+- rolling timeout count
+- time since last timeout
+- recovery mode (`in_place` or `recreated`)
+- owning run-loop thread identity
+- readiness state before and after recovery
+
+- [ ] **Step 8: Verify the event-tap suite passes**
+
+Run:
+
+```bash
+swift test --filter EventTapManagerLifecycle
+swift test --filter EventTapManager
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/Quickey/Services/EventTapManager.swift Tests/QuickeyTests/EventTapManagerLifecycleTests.swift Tests/QuickeyTests/QuickeyTests.swift
+git commit -m "fix: harden event tap recreation lifecycle"
+```
+
+### Task 6: Documentation, Verification, And macOS Validation
+
+**Files:**
+- Modify: `docs/architecture.md`
+- Modify: `docs/handoff-notes.md`
+- Modify: `docs/lessons-learned.md` if event-tap recovery guidance changes materially
+
+- [ ] **Step 1: Update architecture and runtime docs to match the landed implementation**
+
+Document:
+- observation helper responsibilities
+- coordinator ownership of `previousBundle`
+- notification-driven invalidation
+- event-tap recreation strategy
+
+- [ ] **Step 2: Run the full automated verification suite**
+
+Run:
+
+```bash
+swift test
+swift build
+swift build -c release
+./scripts/package-app.sh
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Run the targeted macOS validation matrix**
+
+Validate:
+- Safari, Finder, Terminal
+- Home, Clock, System Settings
+- hidden app reactivation
+- minimized window recovery
+- fast repeated same-shortcut presses
+- at least one event-tap timeout/recovery stress run if reproducible
+
+- [ ] **Step 4: Confirm the new behavioral guarantees on macOS**
+
+Verify:
+- no half-active frontmost mismatch is promoted to stable
+- second press during pending activation does not toggle off
+- confirmation failure does not cause flicker-inducing restore-away rollback
+- stable toggle-off restores the previous app and leaves coherent state
+- event tap recreation either succeeds or reports degraded state explicitly
+
+- [ ] **Step 5: Update handoff notes with real results and residual risks**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/architecture.md docs/handoff-notes.md docs/lessons-learned.md
+git commit -m "docs: document toggle stability and event tap lifecycle changes"
+```

--- a/docs/superpowers/specs/2026-03-23-toggle-stability-and-event-tap-design.md
+++ b/docs/superpowers/specs/2026-03-23-toggle-stability-and-event-tap-design.md
@@ -1,0 +1,789 @@
+# Toggle Stability and Event Tap Reliability Design
+
+**Date:** 2026-03-23
+**Branch:** main
+**Status:** Draft
+**Scope:** Redesign Quickey's app toggle stability checks, special-case handling for system or window-weird apps, and event tap recovery/diagnostic strategy
+
+## Overview
+
+Quickey's current app switching behavior is intentionally simple: activate the target app on first trigger, then restore the previous app and hide the target as a fallback on the second trigger. That model works for many normal apps, but recent macOS validation on 2026-03-23 exposed a reliability gap for system apps such as Home.
+
+The observed failure mode is not a crash. It is worse from a UX perspective: Quickey can leave the target app in a half-activated state where a window is visible, but the system frontmost app is still something else, or a second trigger tries to toggle off before the first activation has become stable. In practice this produces behavior like:
+
+- the target app appears in front visually but is not the actual active app
+- the same shortcut alternates between "activate" and "toggle off" too aggressively
+- clicking the visible target window can make it disappear because the app is still in a transient show/hide state
+
+At the same time, the event tap path is stable enough to avoid the historical crash paths, but it still needs a clearer lifecycle and better escalation when macOS disables the tap for timeout.
+
+This design keeps Quickey's product model as an app-level toggle utility, but makes the runtime semantics stricter and more observable:
+
+- activation is not considered complete until it reaches a stable frontmost state
+- toggle-off is only allowed from that stable state
+- system apps and window-weird apps get explicit downgrade rules instead of falling through generic logic
+- repeated event tap timeouts move through a documented recovery ladder with actionable logs
+
+## Goals
+
+- Preserve Quickey's app-level toggle product behavior instead of turning it into a full window switcher
+- Eliminate "half-active" states from counting as a successful activation
+- Prevent rapid repeat triggers from flipping between activate and restore based on stale or contradictory state
+- Make toggle decisions depend on state that matches user-visible reality
+- Improve diagnostics so future runtime failures can be localized from logs without reproducing in LLDB
+- Define an event tap recovery strategy that is lightweight on the hot path but escalates when timeout churn persists
+
+## Non-Goals
+
+- Replacing Quickey with a window-first AltTab-style product
+- Removing the SkyLight activation path
+- Adding a full persistence layer for per-window focus history
+- Solving every exotic app activation edge case in one pass
+- Introducing synchronous file logging or other heavy work into the event tap callback
+
+## Current Evidence
+
+The strongest evidence comes from the newly added post-action logs in `~/.config/Quickey/debug.log`.
+
+Representative entries from 2026-03-23:
+
+- `2026-03-23T08:29:13Z TOGGLE[Home]: POST_ACTIVATE_STATE postFrontmost=com.apple.systempreferences, targetBundle=com.apple.Home, targetFrontmost=false, targetHidden=true, targetVisibleWindows=true`
+- `2026-03-23T08:29:28Z TOGGLE[Home]: POST_RESTORE_STATE postFrontmost=com.apple.systempreferences, targetBundle=com.apple.Home, targetFrontmost=true, targetHidden=false, targetVisibleWindows=true`
+
+These lines show two important contradictions:
+
+1. Quickey can visually surface a target app with visible windows while the system frontmost app remains another bundle.
+2. `NSRunningApplication.isActive` can disagree with `NSWorkspace.shared.frontmostApplication`, which means `isActive` alone is not a safe gate for toggle-off behavior.
+
+The event tap logs from prior runs also showed repeated:
+
+- `EVENT TAP DISABLED by system (reason: 4294967294)`
+
+Apple's current documentation identifies that event type as `tapDisabledByTimeout`, which means macOS disabled the tap because the callback path took too long or was otherwise judged unhealthy.
+
+## Current Context
+
+- `AppSwitcher` currently uses `runningApp.isActive` as the primary toggle-off gate.
+- `FrontmostApplicationTracker` stores a single `lastNonTargetBundleIdentifier`.
+- `FrontmostApplicationTracker.restorePreviousAppIfPossible()` currently clears `lastNonTargetBundleIdentifier` before restore success is confirmed, which is incompatible with a design that wants post-restore confirmation and retry safety.
+- Post-action logging now records `postFrontmost`, `targetFrontmost`, `targetHidden`, and `targetVisibleWindows`.
+- `TogglePostActionState` is the current diagnostics bridge for post-action state; the redesign needs an explicit migration path instead of silently replacing it.
+- `EventTapManager` already avoids synchronous file I/O in the callback and already records a useful timeout snapshot asynchronously.
+- `EventTapManager` currently re-enables the tap in place when disabled by timeout or user input.
+
+The current architecture intentionally favors app-level semantics:
+
+- activate target app
+- restore previous app when toggling away
+- hide target app as a fallback
+
+That model stays in place. The redesign is about making it truthful and stable.
+
+## Official API Semantics That Matter
+
+Apple's current documentation and system behavior imply the following:
+
+- `NSRunningApplication.activate(options:)` only attempts activation; it is not a guarantee of a stable interactive result.
+- `NSWorkspace.frontmostApplication` returns the app that receives key events.
+- `NSRunningApplication.isActive` indicates whether the app is currently frontmost, but our observed logs show it can briefly disagree with `frontmostApplication` during transition-heavy system app behavior.
+- `NSRunningApplication.hide()` attempts to hide the target app, which is the relevant app-level hide operation in Quickey's runtime path.
+- `NSWorkspace.openApplication(at:configuration:completionHandler:)` calls its completion handler asynchronously on a concurrent queue.
+- `CGEvent.tapCreate(...)` invokes the callback on the run loop to which the tap source is attached.
+- `CGEventType.tapDisabledByTimeout` explicitly means the event tap was disabled because of timeout.
+
+These semantics lead to two design constraints:
+
+1. A single activation API return value cannot be treated as the final truth for toggle state.
+2. Event tap diagnostics must remain callback-safe and run-loop-aware.
+
+## External Reference Implementations
+
+### AltTab
+
+AltTab is primarily window-first. Its switching logic focuses a specific window using a layered approach:
+
+- bring the process forward
+- make the window key
+- raise the window
+
+This is the right design for a window switcher, but Quickey is not trying to become one. The lesson for Quickey is narrower:
+
+- visual presence is not enough
+- "window became key" and "app became frontmost" are different truths
+- system apps and Space-related transitions are explicitly buggy enough that AltTab carries extra recovery logic
+
+### Hammerspoon
+
+Hammerspoon exposes separate app-level and window-level concepts:
+
+- app activation
+- frontmost checks
+- main/focused window inspection
+- explicit hide/unhide primitives
+
+Its `hs.application.open(..., waitForFirstWindow)` API is especially instructive because it models "app launched" and "first usable window exists" as different checkpoints. That same distinction is what Quickey currently lacks.
+
+### Practical takeaway
+
+Mature tools do not treat "requested activation" as equivalent to "toggle target is ready". They either:
+
+- focus a concrete window, or
+- gate app-level behavior behind additional confirmation such as "wait until the first usable window exists"
+
+Quickey should adopt the second approach.
+
+## Approaches Considered
+
+### 1. Minimal fix: keep app-level toggle and switch the gate from `isActive` to `frontmostApplication`
+
+Pros:
+
+- Smallest change
+- Directly addresses the most obvious mismatch
+
+Cons:
+
+- Still treats one snapshot as sufficient
+- Does not handle transient activation states or window-weird system apps
+- Does not define what "stable enough to toggle off" means
+
+### 2. Stable-state app toggle
+
+Pros:
+
+- Preserves Quickey's product semantics
+- Separates activation request from activation success
+- Provides a clean place to integrate app-type exceptions and retry behavior
+- Gives logs and tests a more explicit state model
+
+Cons:
+
+- More moving parts than the minimal fix
+- Requires new internal state and clearer phase boundaries
+
+### 3. Window-first redesign
+
+Pros:
+
+- Most precise model for interactive focus
+- Best alignment with AltTab-style reliability patterns
+
+Cons:
+
+- Changes the product
+- Requires heavier architectural work than this problem needs
+
+## Recommendation
+
+Use approach 2: keep Quickey as an app-level toggle tool, but move the runtime behavior to a stable-state model.
+
+This gives us the smallest change that can still produce mature behavior. The key shift is:
+
+> "Activation requested" is no longer enough to count as "target is active and the next trigger should toggle it off."
+
+## Approved Product Decisions
+
+| Topic | Decision |
+|------|----------|
+| Product model | Keep app-level toggle semantics |
+| Toggle-off gate | Only allow toggle-off from a stable active state |
+| Primary truth source | Treat `NSWorkspace.frontmostApplication` as the main user-visible truth for app-level toggle decisions |
+| Role of `isActive` | Keep as supporting signal and diagnostic field, not the sole authority |
+| Window signals | Use focused/main/visible-window signals to confirm stability for regular windowed apps |
+| System/window-weird apps | Handle with explicit degraded-success rules instead of pretending generic activation always worked |
+| Previous app memory | Keep current single previous-app model for now; do not add a multi-entry history stack in this pass |
+| Event tap timeout handling | Keep callback-light re-enable behavior, but add lifecycle tiers and escalation after repeated timeouts |
+
+## Delivery Strategy
+
+The reviewer concern about implementation jump is valid: the current `AppSwitcher.toggleApplication(for:)` path is still a compact synchronous method, while the full target design introduces explicit runtime phases and delayed confirmation. This should land in controlled stages.
+
+### Phase 1: Observation-first hardening
+
+- Introduce a reusable activation observation snapshot that records:
+  - `frontmostApplication`
+  - target `isActive`
+  - target `isHidden`
+  - visible-window evidence
+  - focused/main-window evidence when available
+- Keep the current public synchronous entry point
+- Keep existing behavior mostly intact, but stop using `isActive` as the only truth source
+- Expand logging into structured `key=value` records so every later phase has better evidence
+
+### Phase 2: Stable confirmation without full session coordinator
+
+- Add delayed confirmation with a bounded confirmation window
+- Add a lightweight pending/stable concept around the current toggle path
+- Prevent second-trigger toggle-off while the target is still pending confirmation
+- Keep storage local and minimal so behavior can be validated before introducing a broader coordinator
+- In this phase, the practical state model should stay intentionally small:
+  - `idle`
+  - `activating`
+  - `activeStable`
+
+### Phase 3: Full session coordination and degraded-state handling
+
+- Introduce `ToggleSessionCoordinator`
+- Add per-target runtime session state
+- Add degraded-success rules and explicit expiry behavior
+- Add event tap escalation thresholds and recreation ladder
+- In this phase, the full target state model becomes available:
+  - `idle`
+  - `activating`
+  - `activeStable`
+  - `deactivating`
+  - `degraded`
+
+Each phase must be independently testable and independently reversible. This is not just implementation caution; it is part of the design intended to keep the runtime reliable during rollout.
+
+## Design
+
+### 1. Introduce a Toggle Session State Machine
+
+Quickey should track a small in-memory toggle session per target bundle identifier.
+
+Recommended states:
+
+- `idle`
+- `activating(previousBundle, startedAt, activationAttempt, recoveryStage)`
+- `activeStable(previousBundle, confirmedAt, stabilityEvidence)`
+- `deactivating(previousBundle, startedAt)`
+- `degraded(previousBundle, reason, observedAt)`
+
+This does not need to be persisted. It is runtime-only coordination.
+
+#### Why per-target session state is needed
+
+Right now Quickey decides each shortcut press only from instantaneous app state. That is the direct cause of flapping:
+
+- press 1 starts activation
+- system state is still transitioning
+- press 2 lands before activation stabilizes
+- Quickey mistakes the target for "already active" or toggles based on contradictory signals
+
+With a session state machine:
+
+- repeated presses during `activating` can re-confirm or re-attempt activation instead of toggling off
+- repeated presses during `activeStable` can perform true toggle-off
+- degraded states can be logged and handled intentionally
+
+#### Session ownership and lifecycle
+
+Session state should be keyed by target bundle identifier, not by shortcut UUID. Multiple shortcuts targeting the same app should share one runtime session because the user-visible object is the app, not the binding row.
+
+Sessions should be:
+
+- created lazily on first trigger for a bundle
+- cleared on successful toggle-off
+- cleared when the target app terminates
+- cleared when no configured shortcuts still reference that bundle
+- expired after a bounded idle period so stale degraded or pending state cannot accumulate indefinitely
+
+Recommended initial expiry values:
+
+- `activating` and `degraded` expire after 2 seconds of no reinforcing trigger or successful confirmation
+- `activeStable` expires after 5 minutes of inactivity or immediately if the target is no longer frontmost
+
+Recommended initial absolute ceilings:
+
+- no activation session should stay pending longer than 5 seconds from its first accepted trigger
+- no degraded retry loop should continue past 2 re-confirm attempts within the same activation session
+
+If either ceiling is reached, the session should fall back to `idle` instead of retrying indefinitely.
+
+Because Quickey typically has a small configured shortcut set, memory pressure is not expected to be meaningful here. The implementation should still cap sessions to the active configured target bundles and avoid unbounded growth.
+
+Recommended initial cap:
+
+- at most `50` live bundle-keyed sessions at once
+
+If the cap would be exceeded, the implementation should evict the stalest `idle` session first, then the stalest expired non-idle session.
+
+### 2. Define Stable Active State Explicitly
+
+`activeStable` should require a short confirmation step, not just a single boolean read.
+
+#### Primary app-level truth
+
+Use `NSWorkspace.shared.frontmostApplication?.bundleIdentifier == targetBundleIdentifier` as the primary condition because Apple defines the frontmost app as the one receiving key events.
+
+#### Supporting stability evidence for regular windowed apps
+
+For apps with normal windows, stability should require:
+
+- target bundle is frontmost
+- target is not hidden
+- at least one of:
+  - AX focused window belongs to the target app
+  - AX main window belongs to the target app
+  - a visible non-minimized target window exists and the frontmost match survives a short confirmation delay
+
+#### Short confirmation delay
+
+After activation attempt succeeds, Quickey should perform a delayed confirmation pass after a small interval such as 50-150 ms. The goal is not animation delay. The goal is to let AppKit, SkyLight, AX, and odd system apps settle before we declare success.
+
+If the target is still frontmost after that delay and the supporting evidence matches, transition to `activeStable`.
+
+If not, remain in `activating` and run the next recovery step or record a degraded result.
+
+#### Timing semantics relative to debounce
+
+This redesign must coexist cleanly with the current `EventTapManager` debounce window, which is 200 ms for repeated identical shortcuts.
+
+The intended interaction is:
+
+- confirmation delay should start below the debounce interval
+- the initial recommended confirmation delay is 75 ms
+- a second confirmation pass may be scheduled, but the total confirmation budget for an already-running app should stay under 300 ms before resolving to `activeStable` or `degraded`
+- Space-switching activations are a known exception; if the app-level frontmost transition depends on Mission Control space movement and does not stabilize within the nominal 300 ms budget, the session should degrade instead of forcing rollback, and validation should treat this as a known slow-path exception rather than a budget regression by default
+
+Behavioral rules:
+
+- a repeated trigger suppressed by event-tap debounce behaves exactly as it does today: no new toggle decision is made
+- a repeated trigger that arrives after debounce but while the session is still `activating` should be interpreted as "continue or re-confirm activation", not "toggle off"
+- if the user changes apps externally during confirmation, the pending confirmation must be invalidated via a monotonic confirmation generation counter so stale results cannot promote the wrong state
+
+#### Visual feedback and rollback policy
+
+The frontmost-switch request should be issued immediately. Confirmation exists to decide state promotion, not to delay the visible app switch behind a timer.
+
+Product rule:
+
+- confirmation should not block the initial bring-to-front attempt
+- confirmation failure should not proactively restore the previous app just to "undo" a non-stable activation
+- if confirmation cannot establish `activeStable`, Quickey should mark the session pending, degraded, or idle according to the session rules and wait for explicit user input rather than causing a flicker-inducing visual rollback
+
+This keeps the keyboard interaction feeling immediate even when the state model is still deciding whether the activation became trustworthy enough for later toggle-off.
+
+#### Public method semantics
+
+The design keeps `toggleApplication(for:) -> Bool` synchronous in the first rollout stages to avoid widening the change surface through `ShortcutManager`, usage tracking, and test seams all at once.
+
+In this design, the synchronous return value should continue to mean:
+
+> Quickey accepted the trigger and initiated a switch attempt.
+
+It should not be interpreted as:
+
+> The target is definitely already in `activeStable`.
+
+Stable/degraded promotion can occur after the method returns. If later validation shows that downstream callers need richer semantics than a boolean, the implementation plan can introduce an internal result enum or callback path while preserving the external behavior during migration.
+
+### 3. Distinguish App Classes
+
+Quickey should stop pretending every app behaves like a normal document app.
+
+Recommended coarse classes:
+
+- `regularWindowed`
+- `nonStandardWindowed`
+- `windowlessOrAccessory`
+- `systemUtility`
+
+This classification does not need a giant hard-coded app database on day one. It can start with heuristics plus a tiny explicit exception list for known bad actors.
+
+Classification should be re-evaluated on each toggle attempt from the current runtime evidence gathered for that toggle. The design intentionally avoids a long-lived global classification cache because app window behavior can change while the app is running.
+
+#### Heuristics
+
+- activation policy
+- whether AX windows exist
+- whether focused/main window can be resolved
+- whether the app frequently reports visible windows while never becoming the key-event receiver
+- whether the app should skip focused/main-window checks because it is accessory-like, windowless, or already known to be nonstandard
+
+Classification results should be logged with their observed reasons so later bug reports can distinguish "the app was misclassified" from "the app changed runtime behavior on a new macOS release."
+
+#### Initial explicit exceptions
+
+The current evidence justifies starting with a small exception bucket for apps like:
+
+- `com.apple.Home`
+- other system utilities that routinely expose nonstandard window or scene behavior during toggling
+
+The exception policy is not "special-case forever". It is "be honest about apps that already disprove the generic path."
+
+### 4. Activation Flow
+
+When the user triggers a shortcut for a running, non-frontmost target:
+
+1. Record the current previous app if the target is not already frontmost.
+2. Enter `activating`.
+3. Unhide the target if needed.
+4. Recover minimized windows if relevant.
+5. Attempt activation through the existing layered path:
+   - SkyLight foreground request
+   - key-window request if a window ID exists
+   - AX raise
+6. Run a delayed confirmation pass.
+7. If stable, transition to `activeStable`.
+8. If not stable:
+   - if no usable windows exist, run window recovery
+   - if the app is in an exception class, apply its degraded-success policy
+   - otherwise remain degraded and log the failure reason
+
+`unhide` and "recover minimized windows" are intentionally separate steps. Unhiding an app does not guarantee that minimized windows are restored to a usable state, so the design keeps `unhide -> unminimize/recover` ordering explicit.
+
+#### Confirmation versus recovery-stage timing
+
+The existing code already contains an asynchronous recovery chain for windowless or non-visible-window situations. The redesign must not layer a blind confirmation timer on top of that chain.
+
+Required rule:
+
+- confirmation for a given recovery stage runs after that stage's effect window, not in parallel with an unfinished recovery stage
+
+Practical sequencing:
+
+- initial activation attempt -> confirmation pass
+- if recovery stage 1 is needed, schedule that recovery stage, then run the next confirmation after its expected settling delay
+- if recovery stage 2 is needed, do the same again
+
+The recovery chain and the confirmation chain therefore interleave stage-by-stage rather than race each other.
+
+For the not-running launch path, Quickey should preserve today's previous-app capture behavior before launching. The user expectation is still Thor-like: if launch succeeds and later becomes stable, the next trigger should be able to restore away from that app.
+
+### 5. Toggle-Off Flow
+
+Toggle-off should only be reachable from `activeStable`.
+
+When the same shortcut fires from `activeStable`:
+
+1. Enter `deactivating`.
+2. Attempt to restore the previous app.
+3. Confirm whether the previous app actually became frontmost.
+4. If the target still has visible windows or contradictory active state after restore, explicitly hide it.
+5. Confirm the target is no longer frontmost.
+6. Clear or downgrade the session state.
+
+This flow fixes a current weakness: Quickey logs `restored=true` or `hidden=true/false`, but it does not currently model whether the post-restore state is actually coherent enough to count as a completed toggle-off.
+
+#### Previous-app ownership during restore confirmation
+
+The current `FrontmostApplicationTracker` clears previous-app memory too early for this design. During rollout, Quickey needs one of these two explicit strategies:
+
+- delay clearing `lastNonTargetBundleIdentifier` until restore success is confirmed, or
+- store `previousBundle` in the session/coordinator and treat that session-owned value as the source of truth during `activating`, `activeStable`, and `deactivating`
+
+For the stable-state design, session-owned `previousBundle` is the more reliable model because it stays attached to the toggle attempt even if the tracker implementation remains lightweight during the migration.
+
+### 6. Degraded Success Rules
+
+Some activations should not count as full success, but they also should not be treated as total failure.
+
+Examples:
+
+- target became frontmost but no focused window could be verified yet
+- target is a system utility with visible content but unstable AX key-window reporting
+- target re-opened successfully but did not stabilize before the deadline
+
+These cases should transition to `degraded`, not `activeStable`.
+
+Behavior in `degraded`:
+
+- the next shortcut should prefer another activation confirmation pass, not toggle-off
+- the UI behavior remains "best effort bring forward"
+- logs must explain why the state is degraded
+- degraded state should automatically expire back to `idle` if the target never stabilizes within the bounded expiry window
+- if the target loses frontmost status before stabilizing, the session should drop out of `degraded` instead of staying sticky
+- degraded re-confirm attempts should be capped at 2 within one activation session
+- if the degraded retry cap or the 5-second absolute activation ceiling is hit, the session should give up and return to `idle`
+
+Degraded is a runtime honesty mechanism, not a permanent limbo state.
+
+#### Expiry and retry interaction
+
+The degraded idle-expiry timer, degraded retry cap, and 5-second absolute activation ceiling must not fight each other.
+
+Rules:
+
+- user-triggered re-confirmation may reset the short degraded idle-expiry timer
+- user-triggered re-confirmation must not reset the 5-second absolute activation ceiling
+- user-triggered re-confirmation must increment against the same activation session's retry cap until that session returns to `idle`
+
+This keeps degraded usable for short re-attempts without accidentally turning it into an endless loop.
+
+#### User experience rule for repeated triggers
+
+The user-visible rule should stay simple:
+
+- first press tries to bring the app forward
+- second press only toggles away if Quickey has already confirmed a stable active state
+- if the app is still degraded or pending, another press keeps trying to complete activation rather than immediately hiding or restoring away
+- if the retry cap or absolute activation ceiling has already been reached, the next press starts a fresh activation attempt from `idle`
+
+This design deliberately does not add a hidden "force toggle-off" escape hatch in the same shortcut path. That would make the model harder to learn and easier to trigger accidentally. If real-world validation later shows that a manual escape hatch is necessary, it should be introduced intentionally as a separate product decision, not as an implicit third state on the same shortcut.
+
+This avoids the user-visible bug where Quickey toggles off an app that never fully toggled on.
+
+### 7. Required New Observability for Toggle Semantics
+
+The current `POST_ACTIVATE_STATE` and `POST_RESTORE_STATE` logs were enough to expose the bug, but not enough to explain every branch of a future state machine.
+
+`TogglePostActionState` should remain in place during Phase 1 as the compatibility bridge for today's diagnostics. In Phase 2 and Phase 3, it should either be expanded into or be superseded by the richer activation observation snapshot and log families in this design. It should not be removed before equivalent structured fields exist in the new logs.
+
+Add log phases with stable names:
+
+- `TOGGLE_ATTEMPT`
+- `TOGGLE_CONFIRMATION`
+- `TOGGLE_STABLE`
+- `TOGGLE_DEGRADED`
+- `TOGGLE_RESTORE_ATTEMPT`
+- `TOGGLE_RESTORE_CONFIRMED`
+- `TOGGLE_RESTORE_DEGRADED`
+
+Each record should capture:
+
+- target bundle
+- shortcut app name
+- session state
+- previous bundle
+- observed frontmost bundle
+- `isActive`
+- `isHidden`
+- visible window count or boolean
+- focused/main window availability if known
+- activation path used
+- recovery path used
+- app classification and classification reason
+- elapsed milliseconds since trigger
+
+These records should use structured `key=value` formatting rather than ad hoc prose so they remain grep-friendly in `debug.log` and easy to compare across runs.
+
+This data should be logged from main-actor-safe or background-safe code paths only, never directly from the event tap callback.
+
+### 8. Event Tap Reliability Design
+
+The event tap path needs to be treated as a lifecycle system, not just a callback.
+
+Recommended lifecycle states:
+
+- `stopped`
+- `starting`
+- `running`
+- `disabledBySystem`
+- `recovering`
+- `degraded`
+
+#### Recovery ladder
+
+For `tapDisabledByTimeout`:
+
+1. Capture a callback-safe snapshot.
+2. Asynchronously record the snapshot.
+3. Re-enable the tap in place.
+4. Increment a rolling timeout counter.
+5. If the counter exceeds a threshold within a time window, tear down and recreate the tap on the background run loop.
+6. If recreation fails, mark capture degraded and surface that truth through readiness state and diagnostics.
+
+For `tapDisabledByUserInput`:
+
+- keep the light re-enable path
+- do not immediately escalate to full recreation unless repeated disables indicate the tap is unhealthy
+
+This design preserves hot-path safety while making repeated timeout storms diagnosable and actionable.
+
+#### Recreation ordering and run loop ownership
+
+Full recreation should default to the same dedicated background run loop thread that owns the current tap. The design should not migrate the tap across threads unless there is a deliberate architectural reason to do so.
+
+Important implementation constraint from the current codebase:
+
+- the existing `BackgroundRunLoopThread.addSource` readiness synchronization is one-shot semaphore based, which is not safe for repeated same-thread add/remove/recreate cycles
+
+Before same-thread full recreation is implemented, the synchronization primitive must be upgraded to a reusable readiness mechanism. Creating a fresh thread per recreation is an acceptable fallback only if the reusable-thread approach cannot be made reliable quickly.
+
+Recommended cleanup and rebuild order:
+
+1. remove the old run loop source from the owning run loop
+2. disable and invalidate the old tap
+3. release the old run loop source and tap references
+4. create the new tap on the dedicated background thread
+5. create the new run loop source
+6. add the new source to the same owning run loop
+7. enable the new tap
+
+This order avoids overlapping live tap ownership and keeps run loop cleanup explicit.
+
+#### Recommended initial thresholds
+
+The design should not leave the first implementation guessing at thresholds. Recommended starting values:
+
+- first timeout: in-place re-enable only
+- `3` timeouts within `30` seconds: full event tap recreation
+- `2` recreation failures within `120` seconds: mark the event-tap subsystem `degraded` and report shortcut capture as not fully ready until recovery succeeds
+
+These are starting values, not immutable product constants. They should be called out in tests and validation notes so later tuning is evidence-driven rather than guesswork.
+
+### 9. Event Tap Diagnostics Strategy
+
+Current diagnostics already record:
+
+- disable reason
+- last event type
+- last key code
+- modifier flags
+- whether the shortcut was swallowed
+- Hyper injection state
+- registered shortcut count
+
+The design extends this into structured lifecycle logging.
+
+Recommended log families:
+
+- `EVENT_TAP_STARTED`
+- `EVENT_TAP_DISABLED`
+- `EVENT_TAP_REENABLED`
+- `EVENT_TAP_RECREATED`
+- `EVENT_TAP_RECREATION_FAILED`
+- `EVENT_TAP_DEGRADED`
+- `EVENT_TAP_RECOVERED`
+
+Additional fields:
+
+- rolling timeout count
+- time since last timeout
+- whether recovery was in-place or full recreation
+- run loop thread identity
+- readiness state before and after recovery
+
+The key rule remains:
+
+> No synchronous file I/O, no expensive AX work, and no state-machine-heavy branching should happen inside the callback itself.
+
+### 10. Architecture Placement
+
+To keep responsibilities clear, the redesign should split concerns instead of growing `AppSwitcher` into a monolith.
+
+Recommended responsibilities:
+
+- `AppSwitcher`
+  - orchestrates shortcut-triggered switching
+  - owns high-level activation and toggle flow
+- new `ToggleSessionCoordinator`
+  - owns per-target runtime state
+  - evaluates transitions between `idle`, `activating`, `activeStable`, `degraded`, and `deactivating`
+- existing `FrontmostApplicationTracker`
+  - remains responsible for previous-app memory and restore attempts
+- new or expanded `ApplicationObservation` helper
+  - computes frontmost/focused/main/visible-window evidence snapshots
+  - should expose a test seam via an injected client or protocol-backed adapter, consistent with the existing `FrontmostApplicationTracker.Client` pattern
+- `EventTapManager`
+  - owns tap lifecycle and callback-safe recovery
+
+This decomposition keeps:
+
+- toggle semantics logic testable without live event tap behavior
+- app observation logic testable separately from state transitions
+- event tap recovery independent from app switching logic
+
+#### Actor boundary
+
+`ToggleSessionCoordinator` should be `@MainActor` in the initial design.
+
+Reasoning:
+
+- it is not part of the event tap callback hot path
+- it will coordinate with `AppSwitcher`, `NSWorkspace` notifications, restore confirmation, and AX/AppKit-derived observation
+- keeping it on the same actor as `AppSwitcher` reduces cross-actor timing races during rollout
+
+If later profiling shows the coordinator itself has become a bottleneck, it can be revisited with a more explicit concurrency model. The default design should optimize for correctness and predictable ordering first.
+
+#### Active-state invalidation
+
+The design should use `NSWorkspace.didActivateApplicationNotification` as the primary invalidation signal for `activeStable` session expiry when another app becomes frontmost.
+
+Related notification hooks should also be used where appropriate:
+
+- `NSWorkspace.didTerminateApplicationNotification` to clear sessions for terminated targets
+- `NSWorkspace.didLaunchApplicationNotification` or equivalent app-lifecycle signals only if later phases need them for launch-path confirmation
+
+#### Observation performance constraints
+
+The confirmation pass must not turn every shortcut press into unbounded AX chatter.
+
+Performance rules:
+
+- always read cheap app-level signals first:
+  - `frontmostApplication`
+  - target `isHidden`
+  - target process/bundle identity
+- only perform AX focused/main-window checks if the app class needs them
+- `windowlessOrAccessory` and some `systemUtility` cases may skip focused/main-window checks entirely
+- reuse one fetched window list within a confirmation pass instead of repeating AX window enumeration
+- cap confirmation to a small number of passes before degrading
+
+This keeps AX IPC off the hot input path and bounds the extra work to toggle-time confirmation only.
+
+### 11. Testing Strategy
+
+#### Highest-value automated tests
+
+- `ToggleSessionCoordinator` transition tests
+  - activating does not immediately become stable without confirmation
+  - repeated trigger during `activating` does not toggle off
+  - stable state does toggle off
+  - degraded state retries activation instead of toggling off
+- `ApplicationObservation` snapshot tests
+  - frontmost mismatch with visible windows is not stable
+  - frontmost match plus focused/main window is stable
+  - hidden app is not stable
+- timing-dependent tests
+  - confirmation generation counters discard stale confirmation results
+  - pending activation expires back to `idle` after the configured ceiling
+  - degraded retry cap returns the session to `idle` instead of looping forever
+  - repeated triggers suppressed by debounce do not incorrectly promote or toggle state
+- session and lifecycle tests
+  - target app termination while `activating` clears the pending session
+  - target app termination while `degraded` clears the pending session
+- repeated-trigger race tests
+  - a same-shortcut trigger arriving after debounce but before confirmation completion continues activation rather than toggling off
+- `AppSwitcher` orchestration tests
+  - chooses restore path only from stable state
+  - hide fallback runs when restore leaves contradictory visibility/frontmost results
+- `EventTapManager` lifecycle tests
+  - single timeout re-enables in place
+  - repeated timeouts escalate to full tap recreation
+  - degraded state is surfaced if recreation fails
+
+#### Manual macOS validation
+
+This design cannot be considered complete without targeted macOS validation.
+
+Required manual validation matrix:
+
+- normal apps: Safari, Finder, Terminal
+- system/window-weird apps: Home, Clock, System Settings
+- hidden app reactivation
+- minimized-window recovery
+- fast repeated shortcut presses
+- event tap timeout stress path
+
+Validation should confirm:
+
+- no half-active frontmost mismatches are counted as success
+- second press does not toggle off until stable activation is achieved
+- toggle-off actually restores the previous app and leaves the target in a coherent state
+- repeated event tap timeouts are logged and escalated predictably
+
+## Acceptance Criteria
+
+- Quickey no longer treats a transient or contradictory activation state as fully active
+- Repeated shortcut presses during activation do not flap between activate and restore
+- System apps that do not behave like regular windowed apps are handled honestly through degraded-success rules
+- Toggle-off decisions align with the actual frontmost app that receives key events
+- Event tap timeout storms produce structured diagnostics and a bounded recovery sequence
+- Automated tests cover the new state transitions and escalation rules
+- for already-running regular apps under nominal system load, Quickey should resolve an accepted trigger to `activeStable` or `degraded` within `300` ms
+- the initial confirmation delay should remain below the current `200` ms shortcut debounce window
+- full event tap recreation, when triggered under healthy permissions, should either complete or report explicit degraded state within `1` second
+- confirmation failure should not cause an automatic restore-away visual rollback that makes the target app flicker out of view
+
+## Implementation Notes For Planning
+
+- Start with the phased rollout in this document instead of jumping directly to the full coordinator
+- Introduce observation snapshots before changing activation mechanics
+- Do not remove existing `POST_ACTIVATE_STATE` and `POST_RESTORE_STATE` logs until the new log families fully supersede them
+- Keep `NSWorkspace.frontmostApplication` and `NSRunningApplication.isActive` side by side in logs during migration so mismatches remain visible
+- Keep the current single previous-app memory in this pass; a multi-entry history stack is a later enhancement if needed
+- Preserve callback-light behavior in `EventTapManager`; escalation should be scheduled outside the callback
+- Expect `Home` and similar apps to remain special during early validation; that is a product-quality concession, not an architectural failure


### PR DESCRIPTION
新增 ApplicationObservation 与结构化 toggle 生命周期日志。\n将 previous app restore 改为显式 attempt/confirm/reset 语义。\n补充 event tap 诊断、设计 spec 与实现计划。