### PR TITLE
引入 ToggleSessionCoordinator 及通知驱动生命周期规则

### DIFF
--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -112,6 +112,7 @@ final class AppSwitcher: AppSwitching {
     private let activationClient: ActivationClient
     private let fallbackActivationClient: FallbackActivationClient
     private let confirmationClient: ConfirmationClient
+    private let sessionCoordinator: ToggleSessionCoordinator
     private var nextPendingGeneration = 0
     private(set) var pendingActivationState: PendingActivationState?
     private(set) var stableActivationState: StableActivationState?
@@ -121,13 +122,16 @@ final class AppSwitcher: AppSwitching {
         applicationObservation: ApplicationObservation = .live,
         activationClient: ActivationClient = .live,
         fallbackActivationClient: FallbackActivationClient = .live,
-        confirmationClient: ConfirmationClient = .live
+        confirmationClient: ConfirmationClient = .live,
+        sessionCoordinator: ToggleSessionCoordinator = ToggleSessionCoordinator()
     ) {
         self.frontmostTracker = frontmostTracker
         self.applicationObservation = applicationObservation
         self.activationClient = activationClient
         self.fallbackActivationClient = fallbackActivationClient
         self.confirmationClient = confirmationClient
+        self.sessionCoordinator = sessionCoordinator
+        sessionCoordinator.startObservingWorkspaceNotifications()
     }
 
     @discardableResult
@@ -147,6 +151,7 @@ final class AppSwitcher: AppSwitching {
         if stableActivationState?.bundleIdentifier == bundleIdentifier {
             stableActivationState = nil
         }
+        sessionCoordinator.beginActivation(for: bundleIdentifier, previousBundle: previousBundleIdentifier)
         return state
     }
 
@@ -174,6 +179,11 @@ final class AppSwitcher: AppSwitching {
         guard pendingActivationState?.bundleIdentifier != bundleIdentifier else {
             return false
         }
+        // Coordinator may have invalidated the session via notification
+        guard sessionCoordinator.session(for: bundleIdentifier)?.phase == .activeStable else {
+            self.stableActivationState = nil
+            return false
+        }
         return true
     }
 
@@ -198,6 +208,7 @@ final class AppSwitcher: AppSwitching {
             confirmedAt: confirmationClient.now()
         )
         self.pendingActivationState = nil
+        sessionCoordinator.markStable(for: bundleIdentifier)
         return true
     }
 
@@ -294,6 +305,7 @@ final class AppSwitcher: AppSwitching {
         if resetPreviousTracking {
             frontmostTracker.resetPreviousAppTracking()
         }
+        sessionCoordinator.resetSession(for: bundleIdentifier)
     }
 
     @discardableResult
@@ -341,7 +353,10 @@ final class AppSwitcher: AppSwitching {
         if shouldToggleOff(bundleIdentifier: shortcut.bundleIdentifier, runningAppIsActive: runningApp.isActive),
            preActionSnapshot.isStableActivation {
             // App is stably frontmost — hide it and restore the previous app
-            let previousApp = stableActivationState?.previousBundleIdentifier ?? frontmostTracker.lastNonTargetBundleIdentifier
+            let previousApp = sessionCoordinator.previousBundle(for: shortcut.bundleIdentifier)
+                ?? stableActivationState?.previousBundleIdentifier
+                ?? frontmostTracker.lastNonTargetBundleIdentifier
+            sessionCoordinator.beginDeactivation(for: shortcut.bundleIdentifier)
             logToggleLifecycle(
                 for: shortcut,
                 lifecycle: "TOGGLE_RESTORE_ATTEMPT",

--- a/Sources/Quickey/Services/ToggleSessionCoordinator.swift
+++ b/Sources/Quickey/Services/ToggleSessionCoordinator.swift
@@ -1,0 +1,315 @@
+import AppKit
+
+// Intentional @MainActor: coordinates AppKit/AX/NSWorkspace lifecycle ordering
+// and is not part of the event-tap callback hot path.
+@MainActor
+final class ToggleSessionCoordinator {
+
+    struct Configuration: Equatable, Sendable {
+        var activatingIdleExpiry: TimeInterval = 2.0
+        var degradedIdleExpiry: TimeInterval = 2.0
+        var absoluteActivationCeiling: TimeInterval = 5.0
+        var activeStableIdleExpiry: TimeInterval = 300.0
+        var degradedRetryCap: Int = 2
+        var sessionCap: Int = 50
+    }
+
+    struct Session: Equatable {
+        let bundleIdentifier: String
+        var phase: Phase
+        var previousBundle: String?
+        var activationStartedAt: CFAbsoluteTime
+        var lastActivityAt: CFAbsoluteTime
+        var confirmedAt: CFAbsoluteTime?
+        var retryCount: Int
+        var degradedReason: String?
+
+        enum Phase: String, Equatable, Sendable {
+            case idle
+            case activating
+            case activeStable
+            case deactivating
+            case degraded
+        }
+    }
+
+    enum ReconfirmResult: Equatable {
+        case accepted
+        case retryCapped
+        case absoluteCeilingReached
+        case notDegraded
+    }
+
+    let configuration: Configuration
+    private let now: @MainActor () -> CFAbsoluteTime
+    private(set) var sessions: [String: Session] = [:]
+
+    init(
+        configuration: Configuration = .init(),
+        now: @escaping @MainActor () -> CFAbsoluteTime = { CFAbsoluteTimeGetCurrent() }
+    ) {
+        self.configuration = configuration
+        self.now = now
+    }
+
+    // MARK: - Query
+
+    func session(for bundleIdentifier: String) -> Session? {
+        guard var session = sessions[bundleIdentifier] else { return nil }
+        if expireIfNeeded(&session) {
+            sessions[bundleIdentifier] = session
+        }
+        return session
+    }
+
+    func previousBundle(for bundleIdentifier: String) -> String? {
+        session(for: bundleIdentifier)?.previousBundle
+    }
+
+    // MARK: - Mutations
+
+    @discardableResult
+    func beginActivation(for bundleIdentifier: String, previousBundle: String?) -> Session {
+        evictIfNeeded(excluding: bundleIdentifier)
+        let currentTime = now()
+        let session = Session(
+            bundleIdentifier: bundleIdentifier,
+            phase: .activating,
+            previousBundle: previousBundle,
+            activationStartedAt: currentTime,
+            lastActivityAt: currentTime,
+            confirmedAt: nil,
+            retryCount: 0,
+            degradedReason: nil
+        )
+        sessions[bundleIdentifier] = session
+        return session
+    }
+
+    @discardableResult
+    func markStable(for bundleIdentifier: String) -> Session? {
+        guard var session = sessions[bundleIdentifier],
+              session.phase == .activating || session.phase == .degraded else {
+            return nil
+        }
+        let currentTime = now()
+        session.phase = .activeStable
+        session.confirmedAt = currentTime
+        session.lastActivityAt = currentTime
+        sessions[bundleIdentifier] = session
+        return session
+    }
+
+    @discardableResult
+    func markDegraded(for bundleIdentifier: String, reason: String) -> Session? {
+        guard var session = sessions[bundleIdentifier],
+              session.phase == .activating || session.phase == .degraded else {
+            return nil
+        }
+        session.phase = .degraded
+        session.degradedReason = reason
+        sessions[bundleIdentifier] = session
+        return session
+    }
+
+    func reconfirmDegraded(for bundleIdentifier: String) -> ReconfirmResult {
+        guard var session = sessions[bundleIdentifier],
+              session.phase == .degraded else {
+            return .notDegraded
+        }
+
+        let currentTime = now()
+
+        if currentTime - session.activationStartedAt > configuration.absoluteActivationCeiling {
+            session.phase = .idle
+            session.lastActivityAt = currentTime
+            sessions[bundleIdentifier] = session
+            return .absoluteCeilingReached
+        }
+
+        if session.retryCount >= configuration.degradedRetryCap {
+            session.phase = .idle
+            session.lastActivityAt = currentTime
+            sessions[bundleIdentifier] = session
+            return .retryCapped
+        }
+
+        session.retryCount += 1
+        session.phase = .activating
+        session.lastActivityAt = currentTime
+        sessions[bundleIdentifier] = session
+        return .accepted
+    }
+
+    @discardableResult
+    func beginDeactivation(for bundleIdentifier: String) -> Session? {
+        guard var session = sessions[bundleIdentifier],
+              session.phase == .activeStable else {
+            return nil
+        }
+        let currentTime = now()
+        session.phase = .deactivating
+        session.lastActivityAt = currentTime
+        sessions[bundleIdentifier] = session
+        return session
+    }
+
+    func completeDeactivation(for bundleIdentifier: String) {
+        guard var session = sessions[bundleIdentifier],
+              session.phase == .deactivating else {
+            return
+        }
+        session.phase = .idle
+        session.lastActivityAt = now()
+        sessions[bundleIdentifier] = session
+    }
+
+    func resetSession(for bundleIdentifier: String) {
+        guard var session = sessions[bundleIdentifier] else { return }
+        session.phase = .idle
+        session.lastActivityAt = now()
+        sessions[bundleIdentifier] = session
+    }
+
+    /// Update lastActivityAt to keep the session alive during ongoing work.
+    func touchSession(for bundleIdentifier: String) {
+        guard var session = sessions[bundleIdentifier] else { return }
+        session.lastActivityAt = now()
+        sessions[bundleIdentifier] = session
+    }
+
+    // MARK: - Notification handlers
+
+    func handleFrontmostChange(newFrontmostBundle: String?) {
+        let currentTime = now()
+        for (bundleId, var session) in sessions {
+            if bundleId != newFrontmostBundle
+                && (session.phase == .activeStable || session.phase == .deactivating) {
+                session.phase = .idle
+                session.lastActivityAt = currentTime
+                sessions[bundleId] = session
+            }
+        }
+    }
+
+    func handleTermination(bundleIdentifier: String) {
+        sessions.removeValue(forKey: bundleIdentifier)
+    }
+
+    // MARK: - Live notification wiring
+
+    private var activationObserver: Any?
+    private var terminationObserver: Any?
+
+    func startObservingWorkspaceNotifications() {
+        let center = NSWorkspace.shared.notificationCenter
+        activationObserver = center.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let bundle = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?.bundleIdentifier
+            Task { @MainActor [weak self] in
+                self?.handleFrontmostChange(newFrontmostBundle: bundle)
+            }
+        }
+        terminationObserver = center.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let bundle = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?.bundleIdentifier
+            if let bundle {
+                Task { @MainActor [weak self] in
+                    self?.handleTermination(bundleIdentifier: bundle)
+                }
+            }
+        }
+    }
+
+    func stopObservingWorkspaceNotifications() {
+        let center = NSWorkspace.shared.notificationCenter
+        if let activationObserver {
+            center.removeObserver(activationObserver)
+        }
+        if let terminationObserver {
+            center.removeObserver(terminationObserver)
+        }
+        activationObserver = nil
+        terminationObserver = nil
+    }
+
+    // MARK: - Expiry
+
+    private func expireIfNeeded(_ session: inout Session) -> Bool {
+        let currentTime = now()
+        switch session.phase {
+        case .idle:
+            return false
+        case .deactivating:
+            if currentTime - session.lastActivityAt > configuration.activatingIdleExpiry {
+                session.phase = .idle
+                session.lastActivityAt = currentTime
+                return true
+            }
+            return false
+        case .activating:
+            if currentTime - session.lastActivityAt > configuration.activatingIdleExpiry
+                || currentTime - session.activationStartedAt > configuration.absoluteActivationCeiling {
+                session.phase = .idle
+                session.lastActivityAt = currentTime
+                return true
+            }
+            return false
+        case .activeStable:
+            if currentTime - session.lastActivityAt > configuration.activeStableIdleExpiry {
+                session.phase = .idle
+                session.lastActivityAt = currentTime
+                return true
+            }
+            return false
+        case .degraded:
+            if currentTime - session.lastActivityAt > configuration.degradedIdleExpiry
+                || currentTime - session.activationStartedAt > configuration.absoluteActivationCeiling {
+                session.phase = .idle
+                session.lastActivityAt = currentTime
+                return true
+            }
+            return false
+        }
+    }
+
+    // MARK: - Eviction
+
+    private func evictIfNeeded(excluding currentBundleIdentifier: String) {
+        guard sessions.count >= configuration.sessionCap else { return }
+
+        // Prefer evicting stalest idle session
+        if let stalestIdle = sessions
+            .filter({ $0.key != currentBundleIdentifier && $0.value.phase == .idle })
+            .min(by: { $0.value.lastActivityAt < $1.value.lastActivityAt }) {
+            sessions.removeValue(forKey: stalestIdle.key)
+            return
+        }
+
+        // Fall back to stalest expired non-idle session.
+        // expireIfNeeded is called on a local copy purely as a predicate;
+        // the session is removed immediately, so the write-back is unnecessary.
+        if let stalestExpired = sessions
+            .filter({ $0.key != currentBundleIdentifier })
+            .filter({ var s = $0.value; return expireIfNeeded(&s) })
+            .min(by: { $0.value.lastActivityAt < $1.value.lastActivityAt }) {
+            sessions.removeValue(forKey: stalestExpired.key)
+            return
+        }
+
+        // Safety net: if all non-current sessions are non-idle and non-expired,
+        // evict the stalest to prevent exceeding the cap. This goes beyond
+        // the two-tier spec rule but ensures the cap is never violated.
+        if let stalest = sessions
+            .filter({ $0.key != currentBundleIdentifier })
+            .min(by: { $0.value.lastActivityAt < $1.value.lastActivityAt }) {
+            sessions.removeValue(forKey: stalest.key)
+        }
+    }
+}

--- a/Tests/QuickeyTests/AppSwitcherTests.swift
+++ b/Tests/QuickeyTests/AppSwitcherTests.swift
@@ -436,6 +436,137 @@ func recoverWindowlessAppStageCompletionHappensBeforeNextConfirmation() {
     #expect(switcher.stableActivationState?.bundleIdentifier == "com.apple.Home")
 }
 
+// MARK: - Coordinator integration tests
+
+@Test @MainActor
+func acceptPendingActivationNotifiesCoordinator() {
+    let coordinator = ToggleSessionCoordinator(now: { 100 })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        sessionCoordinator: coordinator
+    )
+
+    switcher.acceptPendingActivation(
+        for: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal",
+        startedAt: 100
+    )
+
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .activating)
+    #expect(coordinator.previousBundle(for: "com.apple.Safari") == "com.apple.Terminal")
+}
+
+@Test @MainActor
+func promotionToStableNotifiesCoordinator() {
+    let clock = MutableClock(time: 100)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        confirmationClient: .init(now: { clock.time }, schedule: { _, _ in }),
+        sessionCoordinator: coordinator
+    )
+
+    let pending = switcher.acceptPendingActivation(
+        for: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal",
+        startedAt: clock.time
+    )
+    clock.time = 101
+    let stableSnapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Safari",
+        observedFrontmostBundleIdentifier: "com.apple.Safari",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 1,
+        hasFocusedWindow: true,
+        hasMainWindow: true,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .regularWindowed,
+        classificationReason: "visible focused main window"
+    )
+
+    let promoted = switcher.promotePendingActivationIfCurrent(
+        bundleIdentifier: "com.apple.Safari",
+        generation: pending.generation,
+        snapshot: stableSnapshot
+    )
+
+    #expect(promoted == true)
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .activeStable)
+}
+
+@Test @MainActor
+func shouldToggleOffReturnsFalseWhenCoordinatorInvalidatesSession() {
+    let clock = MutableClock(time: 100)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        confirmationClient: .init(now: { clock.time }, schedule: { _, _ in }),
+        sessionCoordinator: coordinator
+    )
+
+    let pending = switcher.acceptPendingActivation(
+        for: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal",
+        startedAt: clock.time
+    )
+    clock.time = 101
+    let stableSnapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Safari",
+        observedFrontmostBundleIdentifier: "com.apple.Safari",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 1,
+        hasFocusedWindow: true,
+        hasMainWindow: true,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .regularWindowed,
+        classificationReason: "visible focused main window"
+    )
+    switcher.promotePendingActivationIfCurrent(
+        bundleIdentifier: "com.apple.Safari",
+        generation: pending.generation,
+        snapshot: stableSnapshot
+    )
+
+    // Coordinator invalidates via frontmost change
+    coordinator.handleFrontmostChange(newFrontmostBundle: "com.apple.Terminal")
+
+    #expect(switcher.shouldToggleOff(bundleIdentifier: "com.apple.Safari", runningAppIsActive: true) == false)
+    #expect(switcher.stableActivationState == nil)
+}
+
+@Test @MainActor
+func clearActivationTrackingResetsCoordinatorSession() {
+    let coordinator = ToggleSessionCoordinator(now: { 100 })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        sessionCoordinator: coordinator
+    )
+
+    switcher.acceptPendingActivation(
+        for: "com.apple.Safari",
+        previousBundleIdentifier: nil,
+        startedAt: 100
+    )
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .activating)
+
+    // recordAcceptedTrigger for a different app clears the previous one
+    switcher.recordAcceptedTrigger(
+        bundleIdentifier: "com.apple.Terminal",
+        previousBundleIdentifier: nil,
+        startedAt: 100
+    )
+
+    // recordAcceptedTrigger calls acceptPendingActivation which doesn't call
+    // clearActivationTracking directly — that happens inside toggleApplication
+    // for different-bundle conflicts. Verify coordinator's resetSession works.
+    coordinator.resetSession(for: "com.apple.Safari")
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
+}
+
 @MainActor
 private func makeTrackerForAppSwitcherTests() -> FrontmostApplicationTracker {
     FrontmostApplicationTracker(client: .init(
@@ -444,6 +575,15 @@ private func makeTrackerForAppSwitcherTests() -> FrontmostApplicationTracker {
         activateRunningApplication: { _ in false },
         setFrontProcess: { _ in false }
     ))
+}
+
+@MainActor
+private final class MutableClock {
+    var time: CFAbsoluteTime
+
+    init(time: CFAbsoluteTime) {
+        self.time = time
+    }
 }
 
 private final class FallbackActivationRecorder: @unchecked Sendable {

--- a/Tests/QuickeyTests/ToggleSessionCoordinatorTests.swift
+++ b/Tests/QuickeyTests/ToggleSessionCoordinatorTests.swift
@@ -1,0 +1,375 @@
+import CoreFoundation
+import Testing
+@testable import Quickey
+
+// MARK: - Required test directions
+
+@Test @MainActor
+func activeStableExpiresWhenAnotherAppBecomesFrontmost() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(now: { currentTime })
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: "com.apple.Terminal")
+    currentTime = 101
+    coordinator.markStable(for: "com.apple.Safari")
+
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .activeStable)
+
+    coordinator.handleFrontmostChange(newFrontmostBundle: "com.apple.Terminal")
+
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
+}
+
+@Test @MainActor
+func degradedSessionReturnsToIdleAfterRetryCap() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(degradedRetryCap: 2),
+        now: { currentTime }
+    )
+
+    coordinator.beginActivation(for: "com.apple.Home", previousBundle: "com.apple.Terminal")
+    coordinator.markDegraded(for: "com.apple.Home", reason: "no visible windows")
+
+    // First reconfirm — accepted
+    currentTime = 101
+    let result1 = coordinator.reconfirmDegraded(for: "com.apple.Home")
+    #expect(result1 == .accepted)
+    coordinator.markDegraded(for: "com.apple.Home", reason: "still no visible windows")
+
+    // Second reconfirm — accepted
+    currentTime = 102
+    let result2 = coordinator.reconfirmDegraded(for: "com.apple.Home")
+    #expect(result2 == .accepted)
+    coordinator.markDegraded(for: "com.apple.Home", reason: "still no visible windows")
+
+    // Third reconfirm — capped (retry cap is 2)
+    currentTime = 103
+    let result3 = coordinator.reconfirmDegraded(for: "com.apple.Home")
+    #expect(result3 == .retryCapped)
+    #expect(coordinator.session(for: "com.apple.Home")?.phase == .idle)
+}
+
+@Test @MainActor
+func terminatedTargetClearsPendingSession() {
+    let coordinator = ToggleSessionCoordinator(now: { 100 })
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: "com.apple.Terminal")
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .activating)
+
+    coordinator.handleTermination(bundleIdentifier: "com.apple.Safari")
+
+    #expect(coordinator.session(for: "com.apple.Safari") == nil)
+}
+
+@Test @MainActor
+func sessionStoreEvictsStalestIdleOrExpiredSessionAtConfiguredCap() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(sessionCap: 3),
+        now: { currentTime }
+    )
+
+    // Create 3 sessions that become idle
+    coordinator.beginActivation(for: "com.app.A", previousBundle: nil)
+    currentTime = 101
+    coordinator.resetSession(for: "com.app.A")
+
+    currentTime = 200
+    coordinator.beginActivation(for: "com.app.B", previousBundle: nil)
+    currentTime = 201
+    coordinator.resetSession(for: "com.app.B")
+
+    currentTime = 300
+    coordinator.beginActivation(for: "com.app.C", previousBundle: nil)
+
+    // Cap is 3, we have 3 sessions. Adding one more should evict stalest idle.
+    currentTime = 400
+    coordinator.beginActivation(for: "com.app.D", previousBundle: nil)
+
+    // A was stalest idle → evicted
+    #expect(coordinator.session(for: "com.app.A") == nil)
+    // B, C, D remain
+    #expect(coordinator.session(for: "com.app.B") != nil)
+    #expect(coordinator.session(for: "com.app.C") != nil)
+    #expect(coordinator.session(for: "com.app.D") != nil)
+}
+
+// MARK: - Degraded expiry and retry interaction
+
+@Test @MainActor
+func degradedReconfirmResetsIdleExpiryTimer() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(degradedIdleExpiry: 2.0, absoluteActivationCeiling: 10.0),
+        now: { currentTime }
+    )
+
+    coordinator.beginActivation(for: "com.apple.Home", previousBundle: "com.apple.Terminal")
+    coordinator.markDegraded(for: "com.apple.Home", reason: "no windows")
+
+    // Advance 1.5s (under 2s idle expiry)
+    currentTime = 101.5
+    let result = coordinator.reconfirmDegraded(for: "com.apple.Home")
+    #expect(result == .accepted)
+    coordinator.markDegraded(for: "com.apple.Home", reason: "still no windows")
+
+    // Advance 1.5s more (3.0 total, but only 1.5s since reconfirm) — still valid
+    currentTime = 103.0
+    #expect(coordinator.session(for: "com.apple.Home")?.phase == .degraded)
+
+    // Advance past idle expiry from last activity (101.5 + 2.0 = 103.5)
+    currentTime = 104.0
+    #expect(coordinator.session(for: "com.apple.Home")?.phase == .idle)
+}
+
+@Test @MainActor
+func degradedReconfirmDoesNotResetAbsoluteActivationCeiling() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(
+            degradedIdleExpiry: 2.0,
+            absoluteActivationCeiling: 5.0,
+            degradedRetryCap: 10
+        ),
+        now: { currentTime }
+    )
+
+    coordinator.beginActivation(for: "com.apple.Home", previousBundle: "com.apple.Terminal")
+    coordinator.markDegraded(for: "com.apple.Home", reason: "no windows")
+
+    // Reconfirm at 1.5s
+    currentTime = 101.5
+    let result1 = coordinator.reconfirmDegraded(for: "com.apple.Home")
+    #expect(result1 == .accepted)
+    coordinator.markDegraded(for: "com.apple.Home", reason: "still no windows")
+
+    // Reconfirm at 3.0s — still under ceiling
+    currentTime = 103.0
+    let result2 = coordinator.reconfirmDegraded(for: "com.apple.Home")
+    #expect(result2 == .accepted)
+    coordinator.markDegraded(for: "com.apple.Home", reason: "still no windows")
+
+    // Reconfirm at 5.5s — past absolute ceiling (100 + 5.0 = 105.0)
+    currentTime = 105.5
+    let result3 = coordinator.reconfirmDegraded(for: "com.apple.Home")
+    #expect(result3 == .absoluteCeilingReached)
+    #expect(coordinator.session(for: "com.apple.Home")?.phase == .idle)
+}
+
+@Test @MainActor
+func sameSessionRetriesCountAgainstSameRetryCap() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(absoluteActivationCeiling: 20.0, degradedRetryCap: 2),
+        now: { currentTime }
+    )
+
+    coordinator.beginActivation(for: "com.apple.Home", previousBundle: nil)
+    coordinator.markDegraded(for: "com.apple.Home", reason: "no windows")
+
+    // Reconfirm 1
+    currentTime = 101
+    _ = coordinator.reconfirmDegraded(for: "com.apple.Home")
+    #expect(coordinator.session(for: "com.apple.Home")?.retryCount == 1)
+    coordinator.markDegraded(for: "com.apple.Home", reason: "still no windows")
+
+    // Reconfirm 2
+    currentTime = 102
+    _ = coordinator.reconfirmDegraded(for: "com.apple.Home")
+    #expect(coordinator.session(for: "com.apple.Home")?.retryCount == 2)
+    coordinator.markDegraded(for: "com.apple.Home", reason: "still no windows")
+
+    // Reconfirm 3 — capped
+    currentTime = 103
+    let result = coordinator.reconfirmDegraded(for: "com.apple.Home")
+    #expect(result == .retryCapped)
+}
+
+// MARK: - Additional coordinator behavior
+
+@Test @MainActor
+func beginActivationStoresPreviousBundleInSession() {
+    let coordinator = ToggleSessionCoordinator(now: { 100 })
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: "com.apple.Terminal")
+
+    #expect(coordinator.previousBundle(for: "com.apple.Safari") == "com.apple.Terminal")
+}
+
+@Test @MainActor
+func activatingSessionExpiresAfterIdleTimeout() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(activatingIdleExpiry: 2.0),
+        now: { currentTime }
+    )
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: nil)
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .activating)
+
+    currentTime = 102.5
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
+}
+
+@Test @MainActor
+func activatingSessionExpiresAfterAbsoluteCeiling() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(activatingIdleExpiry: 10.0, absoluteActivationCeiling: 5.0),
+        now: { currentTime }
+    )
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: nil)
+
+    // Simulate activity within idle expiry but past absolute ceiling
+    currentTime = 103
+    coordinator.touchSession(for: "com.apple.Safari")
+    currentTime = 105.5
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
+}
+
+@Test @MainActor
+func handleFrontmostChangeDoesNotExpireCurrentFrontmostApp() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(now: { currentTime })
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: "com.apple.Terminal")
+    currentTime = 101
+    coordinator.markStable(for: "com.apple.Safari")
+
+    // Safari is still frontmost
+    coordinator.handleFrontmostChange(newFrontmostBundle: "com.apple.Safari")
+
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .activeStable)
+}
+
+@Test @MainActor
+func evictionPrefersIdleOverExpiredNonIdle() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(activatingIdleExpiry: 2.0, sessionCap: 2),
+        now: { currentTime }
+    )
+
+    // A: activating (will become expired non-idle)
+    coordinator.beginActivation(for: "com.app.A", previousBundle: nil)
+
+    // B: idle
+    currentTime = 200
+    coordinator.beginActivation(for: "com.app.B", previousBundle: nil)
+    coordinator.resetSession(for: "com.app.B")
+
+    // C: triggers eviction — B (idle) should be evicted before A (expired non-idle)
+    currentTime = 300
+    coordinator.beginActivation(for: "com.app.C", previousBundle: nil)
+
+    #expect(coordinator.session(for: "com.app.B") == nil)
+    #expect(coordinator.session(for: "com.app.A") != nil)
+    #expect(coordinator.session(for: "com.app.C") != nil)
+}
+
+@Test @MainActor
+func evictionDoesNotEvictCurrentlyMutatingSession() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(sessionCap: 2),
+        now: { currentTime }
+    )
+
+    coordinator.beginActivation(for: "com.app.A", previousBundle: nil)
+    currentTime = 200
+    coordinator.beginActivation(for: "com.app.B", previousBundle: nil)
+
+    // Both sessions are activating (non-idle). Adding C should evict stalest non-idle,
+    // but NOT the currently mutating session (C itself).
+    currentTime = 300
+    coordinator.beginActivation(for: "com.app.C", previousBundle: nil)
+
+    // A is stalest, should be evicted
+    #expect(coordinator.session(for: "com.app.A") == nil)
+    #expect(coordinator.session(for: "com.app.B") != nil)
+    #expect(coordinator.session(for: "com.app.C") != nil)
+}
+
+@Test @MainActor
+func terminatedTargetClearsDegradedSession() {
+    let coordinator = ToggleSessionCoordinator(now: { 100 })
+
+    coordinator.beginActivation(for: "com.apple.Home", previousBundle: nil)
+    coordinator.markDegraded(for: "com.apple.Home", reason: "no windows")
+
+    coordinator.handleTermination(bundleIdentifier: "com.apple.Home")
+
+    #expect(coordinator.session(for: "com.apple.Home") == nil)
+}
+
+@Test @MainActor
+func deactivationResetsSessionToIdle() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(now: { currentTime })
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: "com.apple.Terminal")
+    currentTime = 101
+    coordinator.markStable(for: "com.apple.Safari")
+    coordinator.beginDeactivation(for: "com.apple.Safari")
+
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .deactivating)
+
+    coordinator.completeDeactivation(for: "com.apple.Safari")
+
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
+}
+
+@Test @MainActor
+func activeStableIdleExpiryAppliesLazily() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(activeStableIdleExpiry: 300),
+        now: { currentTime }
+    )
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: nil)
+    currentTime = 101
+    coordinator.markStable(for: "com.apple.Safari")
+
+    currentTime = 200
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .activeStable)
+
+    currentTime = 402  // 301s since confirmedAt
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
+}
+
+@Test @MainActor
+func deactivatingSessionExpiresAfterIdleTimeout() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(activatingIdleExpiry: 2.0),
+        now: { currentTime }
+    )
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: nil)
+    currentTime = 101
+    coordinator.markStable(for: "com.apple.Safari")
+    coordinator.beginDeactivation(for: "com.apple.Safari")
+
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .deactivating)
+
+    currentTime = 104  // 3s since deactivation started, past 2s expiry
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
+}
+
+@Test @MainActor
+func handleFrontmostChangeResetsDeactivatingSession() {
+    var currentTime: CFAbsoluteTime = 100
+    let coordinator = ToggleSessionCoordinator(now: { currentTime })
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: nil)
+    currentTime = 101
+    coordinator.markStable(for: "com.apple.Safari")
+    coordinator.beginDeactivation(for: "com.apple.Safari")
+
+    coordinator.handleFrontmostChange(newFrontmostBundle: "com.apple.Terminal")
+
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
+}


### PR DESCRIPTION
## Summary

- 新增 `ToggleSessionCoordinator`，通过 `NSWorkspace` 通知（非轮询）管理 toggle session 生命周期
- 五阶段状态机（idle / activating / activeStable / deactivating / degraded），惰性过期评估，三层 LRU 驱逐（上限 50）
- `AppSwitcher` 集成：在 `acceptPendingActivation`、`markStable`、`beginDeactivation`、`resetSession` 节点调用 coordinator，`shouldToggleOff` 交叉校验 session 状态，`previousBundle` 优先从 coordinator 查询
- 确定性时间注入（`now` 闭包），完整可测试

## Test plan

- [x] 18 项 `ToggleSessionCoordinator` 单元测试覆盖所有阶段转换、过期、驱逐、重试
- [x] 4 项 `AppSwitcher` 集成测试验证 coordinator 联动
- [x] `swift test --filter ToggleSessionCoordinator` 全通过（18/18）
- [x] `swift test --filter AppSwitcher` 全通过（18/18）
- [x] `swift build` 编译成功
- [x] `/simplify` 三审（代码复用 / 质量 / 效率）完成，唯一修复：`sessionCoordinator` 改为 `private`