### PR TITLE
docs: update architecture and handoff notes for toggle-stability redesign

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,9 +45,17 @@ Quickey is a menu bar macOS utility that stores app-shortcut bindings, captures 
 +--------------------+
 |    AppSwitcher     |
 | activate/toggle    |
-+---------+----------+
-          |
-          v
++----+---------+-----------+
+     |         |
+     |         +-----------------------+
+     |                                 |
+     v                                 v
++---------------------------+   +------------------------+
+| ToggleSessionCoordinator  |   | ApplicationObservation |
+| per-target runtime state  |   | frontmost/window truth |
++------------+--------------+   +------------------------+
+             |
+             v
 +---------------------------+
 | FrontmostApplicationTracker |
 | previous app restore state |
@@ -109,12 +117,21 @@ Responsibilities:
 
 Responsibilities:
 - listen for global keyDown events via `CGEvent.tapCreate`
+- host the active event tap on a dedicated background RunLoop thread
 - normalize captured key events
 - map between key codes and human-readable shortcut symbols
 - match incoming events against stored bindings
+- keep callback work lightweight and dispatch recovery work off the callback path
+- track lifecycle state and escalation thresholds:
+  - first timeout -> in-place re-enable
+  - 3 timeouts within 30 seconds -> full recreation
+  - 2 recreation failures within 120 seconds -> degraded readiness state
+- recreate the tap on the same background thread using a reusable readiness mechanism instead of a one-shot startup handshake
 
 ### Activation and toggle logic
 - `AppSwitcher`
+- `ApplicationObservation`
+- `ToggleSessionCoordinator`
 - `FrontmostApplicationTracker`
 - `AppBundleLocator`
 
@@ -122,8 +139,13 @@ Responsibilities:
 - activate target apps
 - launch installed apps if not already running
 - fall back to `NSWorkspace` reopen requests before plain AppKit activation requests when SkyLight activation cannot complete
-- restore previous app when toggling away
-- hide target app as fallback
+- build `ActivationObservationSnapshot` values from frontmost-app, active/hidden, visible-window, focused-window, main-window, and app-classification evidence
+- re-evaluate app classification per toggle attempt instead of caching it globally
+- keep per-target toggle sessions on the main actor and let `ToggleSessionCoordinator` own the durable `previousBundle` for `activating`, `activeStable`, `degraded`, and `deactivating` phases
+- invalidate or clear sessions from `NSWorkspace.didActivateApplicationNotification` and `NSWorkspace.didTerminateApplicationNotification` instead of polling
+- only allow toggle-off from a confirmed stable state; repeat triggers during pending or degraded activation re-confirm the session instead of restoring away
+- use `FrontmostApplicationTracker` for current-frontmost capture and restore attempts, while session-owned `previousBundle` remains the source of truth during confirmation and deactivation
+- restore previous app when toggling away, then hide the target app as a fallback if post-restore observation is still contradictory
 - reveal selected application in Finder when needed
 
 ### Usage tracking
@@ -182,7 +204,22 @@ Global keyDown event
   -> ShortcutManager.handleKeyPress()
   -> KeyMatcher finds matching AppShortcut
   -> AppSwitcher.toggleApplication()
-  -> activate / restore previous app / hide fallback
+  -> ToggleSessionCoordinator records bundle-keyed session + previousBundle
+  -> ApplicationObservation captures frontmost/window evidence
+  -> activate / confirm / recover stage-by-stage
+  -> restore previous app / hide fallback only from activeStable
+```
+
+### 4. Event tap recovery flow
+```text
+CGEvent callback receives tapDisabledByTimeout / tapDisabledByUserInput
+  -> EventTapManager captures callback-safe snapshot
+  -> in-place re-enable happens immediately
+  -> lifecycle tracker updates counters
+  -> repeated timeout threshold reached
+  -> same-thread tap recreation on the dedicated background RunLoop
+  -> recreation success returns readiness to running
+  -> repeated recreation failure escalates readiness to degraded
 ```
 
 ## Current design choices
@@ -190,11 +227,14 @@ Global keyDown event
 - **AppKit-first with selective SwiftUI**: deliberate architectural decision documented in `docs/archive/app-structure-direction.md`; hard AppKit requirements (`.accessory` policy, raw key capture, CGEvent tap, NSWorkspace) prevent a pure SwiftUI scene-based approach
 - **Truthful shortcut readiness**: `ShortcutCaptureStatus` reports Accessibility, Input Monitoring, and active event-tap state separately
 - **O(1) trigger index**: `ShortcutSignature` dictionary replaces linear scans in the hot path
-- **Hardened EventTap lifecycle**: explicit ownership, auto-recovery on disable/timeout, run-loop cleanup
+- **Observation-first toggle truth**: `ApplicationObservation` snapshots gate stable-state promotion from frontmost/window evidence instead of trusting `isActive` alone
+- **Session-owned previous-app memory**: `ToggleSessionCoordinator` holds the durable `previousBundle` once a toggle session is accepted; `FrontmostApplicationTracker` remains the restore executor
+- **Notification-driven invalidation**: `NSWorkspace` activation and termination notifications clear or expire stable/deactivating sessions without polling
+- **Hardened EventTap lifecycle**: explicit ownership, callback-safe timeout snapshots, threshold-based escalation, and same-thread run-loop recreation
 - **Active tap only**: passive `.listenOnly` mode is not used in the normal interception path because it cannot consume shortcut events
 - **SkyLight primary activation path**: private API is used for reliable foreground switching from LSUIElement context
 - **Modern AppKit fallback**: when SkyLight activation fails, Quickey re-requests activation via `NSWorkspace.OpenConfiguration` (`activates = true`) and only falls back to a plain AppKit activation request if no bundle URL is available
-- **Best-effort toggle semantics**: activate → restore previous app → hide fallback
+- **Stable-state toggle semantics**: activate immediately, confirm asynchronously, allow toggle-off only from `activeStable`, and avoid restore-away rollback on confirmation failure
 - **Service-level test seams**: system-facing services use small injected clients or existing collaborators so runtime decision logic can be covered without live TCC or app-launch side effects
 - **UsageTracker**: SQLite-backed daily usage aggregation off the main actor
 - **Launch-at-login status modeling**: `LaunchAtLoginStatus` preserves enabled / approval-needed / disabled / not-found states
@@ -203,4 +243,4 @@ Global keyDown event
 - No dedicated per-shortcut toggle history stack (single global previous-app memory is current approach)
 - No test seam around event-tap capture itself (core logic is testable; tap infrastructure requires real macOS)
 - Signed/notarized release build not yet produced (workflow documented in `docs/signing-and-release.md`)
-- Targeted manual macOS validation is still recommended for the 2026-03-21 remediation changes (launch-at-login approval flow, active event-tap startup, Hyper Key failure cases)
+- Targeted manual macOS validation is still required for the 2026-03-24 toggle-stability and event-tap recovery redesign, especially system apps, hidden/minimized window paths, and timeout-stress behavior

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -1,7 +1,13 @@
 # Handoff Notes
 
 ## Current State
-Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. On 2026-03-23, the runtime hardening follow-up added service-level test seams for permission, app discovery, frontmost-app restore, preferences, and activation fallback paths, and replaced the deprecated `activateIgnoringOtherApps` fallback with a modern `NSWorkspace` reopen request. Issue #67's launch-at-login approval-state UX also landed on 2026-03-23, including Settings foreground refresh coverage for launch-at-login state changes, and `swift test`, `swift build`, `swift build -c release`, and `./scripts/package-app.sh` were rerun afterward. Coverage for the newly targeted services is now measurable: `AccessibilityPermissionService` 64.29%, `AppListProvider` 40.78%, `AppPreferences` 72.50%, `FrontmostApplicationTracker` 43.64%, and `AppSwitcher` 10.55%. A deeper macOS runtime investigation later on 2026-03-23 found that toggle semantics are still not stable enough for some system apps such as Home: new post-action logs showed cases where the target app had visible windows while `NSWorkspace.shared.frontmostApplication` remained another bundle, and other cases where `NSRunningApplication.isActive` disagreed with the frontmost-app snapshot during restore. A design follow-up is now in progress to introduce stable activation gating, degraded-success rules for window-weird apps, and stricter event tap recovery observability. A signed and notarized distributable is still unresolved.
+Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. On 2026-03-24, the toggle-stability and event-tap reliability plan's Tasks 1-5 were already present in `main`, and Task 6 updated the architecture/runtime documentation and reran the automated verification suite. The landed runtime now uses `ApplicationObservation` snapshots to decide whether activation is truly stable, keeps per-target toggle state in `ToggleSessionCoordinator`, stores session-owned `previousBundle` values across activation/deactivation phases, invalidates those sessions from `NSWorkspace` notifications, and escalates repeated event-tap timeout storms from in-place re-enable to same-thread recreation and then degraded readiness reporting. A signed and notarized distributable is still unresolved. No new manual macOS runtime claims are made in this task; the targeted post-redesign validation matrix remains pending.
+
+## Automated Verification (2026-03-24)
+- `swift test` passed after the Task 6 documentation update; the suite reported 146 tests passed
+- `swift build` passed after the Task 6 documentation update
+- `swift build -c release` passed after the Task 6 documentation update
+- `./scripts/package-app.sh` passed after the Task 6 documentation update, rebuilt `build/Quickey.app`, and reset TCC approvals for `com.quickey.app` as part of the ad-hoc packaging flow
 
 ## Validated on macOS
 - Broad real-device validation completed on macOS 15.3.1 on 2026-03-20
@@ -9,12 +15,31 @@ Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. On 2026-03-23, the 
 - Dual permission gating, active capture startup, and end-to-end shortcut interception were validated
 - Runtime toggle behavior, restore/hide fallback, and window recovery paths were exercised successfully
 - Insights persistence and restart behavior were confirmed during the macOS pass
+- The 2026-03-24 toggle-stability/event-tap redesign has not yet had its targeted post-landing macOS validation pass
+
+## Implemented Behavioral Guarantees
+- Half-active frontmost mismatches are not promoted to stable: `ActivationObservationSnapshot.isStableActivation` requires target/frontmost agreement, `targetIsActive == true`, `targetIsHidden == false`, and supporting window evidence before `AppSwitcher` can promote a pending activation
+- A second press during pending activation does not toggle off: `pendingActivationState` blocks `shouldToggleOff`, and a repeat accepted trigger refreshes confirmation generation instead of restoring away
+- Confirmation failure does not trigger flicker-inducing restore-away rollback: failed confirmation either advances through the staged recovery path or drops the session back to idle/degraded without restoring the previous app automatically
+- Stable toggle-off now uses session-owned `previousBundle`, attempts restore first, hides as fallback when the post-restore observation is still contradictory, and clears runtime session state coherently
+- Event tap recovery now either recreates the tap successfully on the existing background RunLoop thread or leaves an explicit degraded readiness state after repeated recreation failures
 
 ## Follow-up Requiring macOS Validation
+- Normal apps: Safari, Finder, Terminal
+  Validate stable activation, second-press toggle-off back to the previous app, and coherent `TOGGLE_STABLE` / `TOGGLE_RESTORE_CONFIRMED` diagnostics
+- System or window-weird apps: Home, Clock, System Settings
+  Validate that visible-but-not-frontmost states do not promote to stable and that repeat presses during pending/degraded activation keep re-confirming instead of toggling away
+- Hidden app reactivation
+  Validate that an already-hidden target can return to `activeStable` and still restore the previous app on the next confirmed toggle-off
+- Minimized window recovery
+  Validate that unminimize/recovery stages settle before confirmation promotion and that missing visible-window evidence prevents false stable promotion
+- Fast repeated same-shortcut presses
+  Validate debounce plus pending-session behavior under rapid repeated input for the same target
+- Event tap timeout/recovery stress
+  If reproducible on macOS, trigger timeout churn and confirm: first timeout re-enables in place, 3 timeouts within 30 seconds escalate to recreation, and repeated recreation failures surface degraded readiness/logs
 - Launch-at-login approval flow after the 2026-03-23 issue #67 approval-state UX update, especially `.requiresApproval` -> `.enabled` foreground refresh and `.notFound` behavior on real installs
 - Active event-tap startup and readiness reporting after permission or lifecycle changes
 - AppSwitcher fallback behavior after SkyLight failure now that it re-requests activation via `NSWorkspace`
-- App toggle stability after the 2026-03-23 Home/system-app investigation, especially "visible but not truly frontmost" states and second-trigger behavior during transitional activation
 - Hyper Key failure handling, especially persistence only after `hidutil` succeeds
 - Insights date-window and refresh-race fixes
 - Signed/notarized distributable workflow once a Developer ID certificate is available
@@ -27,8 +52,13 @@ Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. On 2026-03-23, the 
 - If SkyLight activation fails, Quickey now falls back to an `NSWorkspace` reopen request instead of the deprecated `activateIgnoringOtherApps` path
 - Unified logging can hide useful runtime details; file-based debug logs (`~/.config/Quickey/debug.log`) are more reliable for diagnosis
 
+## Residual Risks
+- The new toggle guarantees are covered by code-level tests and by the automated suite, but they still need the targeted macOS matrix above before we can claim runtime correctness for Home, Clock, System Settings, or timeout-stress behavior
+- Event tap recovery semantics are implemented with thresholded escalation and degraded reporting, but a reproducible on-device timeout-stress run is still needed to confirm the live logs are operationally sufficient
+- Signed/notarized release validation is still blocked on Developer ID availability
+
 ## Immediate Next Actions
-1. Turn the approved toggle-stability and event-tap reliability design into an implementation plan before making further runtime behavior changes
-2. Run a targeted macOS validation pass for normal apps and system apps after the stability redesign lands, especially Home, Clock, System Settings, and fast repeat-trigger flows
+1. Run the targeted macOS validation matrix for Safari, Finder, Terminal, Home, Clock, System Settings, hidden/minimized paths, fast repeat-trigger flows, and event-tap timeout stress
+2. Capture the real 2026-03-24 validation results in this file, including any degraded-state logs or app-specific exceptions that remain
 3. Produce a signed and notarized `.app` once a Developer ID certificate is available
 4. Fold any new validation findings back into this note, not into the feature overview docs

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -95,6 +95,28 @@ The first trigger may only have started activation, while the second trigger arr
 **Practical guidance**
 Do not let "activation requested" mean "activation complete". Require a short post-activation confirmation pass and only allow toggle-off from a stable active state. During pending or degraded activation, a repeat trigger should re-confirm or re-attempt activation instead of restoring away immediately.
 
+## Session-Owned Previous App Memory
+
+**Issue**
+Restore confirmation becomes unreliable if previous-app memory is cleared as soon as a restore attempt starts.
+
+**Cause**
+The restore path needs the same `previousBundle` to survive activation, pending confirmation, deactivation, and retry/degraded branches. A destructive read from a lightweight tracker loses that ownership too early.
+
+**Practical guidance**
+Let the toggle session own the durable `previousBundle` once a trigger is accepted. Use `FrontmostApplicationTracker` to capture the current frontmost app and execute restore attempts, but keep the authoritative previous-app value on the coordinator session until the session is reset.
+
+## Notification-Driven Toggle Invalidation
+
+**Issue**
+Stable toggle state can become stale as soon as the user changes apps outside Quickey.
+
+**Cause**
+Polling or one-shot snapshots miss external activation and termination changes, especially while a toggle session is still marked `activeStable` or `deactivating`.
+
+**Practical guidance**
+Use `NSWorkspace.didActivateApplicationNotification` to drop stable/deactivating sessions when another app becomes frontmost, and `NSWorkspace.didTerminateApplicationNotification` to clear sessions for terminated targets. This keeps runtime state aligned with user-visible app focus without adding polling noise.
+
 ## System Apps Need Honest Downgrade Rules
 
 **Issue**
@@ -115,4 +137,4 @@ Re-enabling an event tap after a timeout is necessary but not always sufficient.
 macOS can repeatedly disable the tap with `tapDisabledByTimeout`, which indicates sustained callback or lifecycle pressure rather than a one-off interruption.
 
 **Practical guidance**
-Keep the callback path light and re-enable in place first, but track rolling timeout counts. If repeated timeouts cluster together, escalate from in-place re-enable to full tap recreation and log the recovery tier so later diagnosis does not start from scratch.
+Keep the callback path light and re-enable in place first, but track rolling timeout counts. In Quickey's current recovery ladder, the first timeout stays in-place, 3 timeouts within 30 seconds escalate to full recreation, and 2 recreation failures within 120 seconds mark the tap subsystem degraded. Recreate the tap on the same dedicated background RunLoop thread, using a reusable readiness mechanism so repeated add/remove/recreate cycles do not deadlock.


### PR DESCRIPTION
## Summary
- Update `docs/architecture.md` with ToggleSessionCoordinator, ApplicationObservation, event tap recovery flow, and revised design decisions
- Update `docs/handoff-notes.md` with automated verification results, behavioral guarantees, targeted macOS validation matrix, and residual risks
- Update `docs/lessons-learned.md` with session-owned previous-app memory and notification-driven toggle invalidation patterns

Reflects the work landed in PRs #76-#79.