### PR TITLE
fix: Hyper Key 兼容 macOS Caps Lock 底层怪癖

### DIFF
--- a/Sources/Quickey/Services/EventTapManager.swift
+++ b/Sources/Quickey/Services/EventTapManager.swift
@@ -13,8 +13,8 @@ private extension CGEventFlags {
 }
 
 /// Caps Lock hardware may fire keyDown+keyUp within this window on a single
-/// physical press (toggle quirk). Mach absolute ticks, ~1 ns/tick on Apple silicon.
-private let hyperKeyToggleQuirkThresholdTicks: UInt64 = 80_000_000
+/// physical press (toggle quirk). Nanoseconds (CGEvent.timestamp unit, per CGEventTypes.h).
+private let hyperKeyToggleQuirkThresholdNs: UInt64 = 80_000_000
 
 struct EventTapDiagnosticsSnapshot: Equatable, Sendable {
     let reason: CGEventType
@@ -84,6 +84,7 @@ func handleEventTapEvent(
             if box._hyperKeyEnabled && keyCode == HyperKeyService.f19KeyCode {
                 box._isHyperHeld = true
                 box._hyperKeyDownTimestamp = eventTimestamp
+                box._f19ReceivedViaKeyDown = true
                 return (true, false)
             }
             let hyper = box._isHyperHeld
@@ -98,10 +99,10 @@ func handleEventTapEvent(
                 modifiers: flags.intersection(.deviceIndependentFlagsMask)
             )
             let shouldSwallow = box._registeredShortcuts.contains(keyPress)
-            // Only clear the deferred keyUp when the Hyper combo was actually
-            // consumed; otherwise an unregistered key would eat the held state
-            // and inject Hyper flags into a normal keystroke.
-            if hyper && box._hyperKeyUpDeferred && shouldSwallow {
+            // Clear deferred keyUp state on any non-F19 keyDown. The current
+            // keystroke still sees hyper=true (captured above), but subsequent
+            // keystrokes will not have Hyper injected.
+            if hyper && box._hyperKeyUpDeferred {
                 box._isHyperHeld = false
                 box._hyperKeyUpDeferred = false
             }
@@ -157,7 +158,7 @@ func handleEventTapEvent(
                 // keyDown, keep _isHyperHeld true — it will be cleared when the next
                 // non-F19 keyDown is processed or by a later "real" keyUp.
                 let elapsed = event.timestamp - box._hyperKeyDownTimestamp
-                if elapsed > hyperKeyToggleQuirkThresholdTicks {
+                if elapsed > hyperKeyToggleQuirkThresholdNs {
                     box._isHyperHeld = false
                     box._hyperKeyUpDeferred = false
                 } else {
@@ -188,6 +189,11 @@ func handleEventTapEvent(
         let swallowFlags = box.withLock { () -> Bool in
             guard box._hyperKeyEnabled && flagsKeyCode == HyperKeyService.f19KeyCode else {
                 return false
+            }
+            // If the keyDown/keyUp path has already handled F19, defer to that
+            // path to avoid double-toggling _isHyperHeld.
+            if box._f19ReceivedViaKeyDown {
+                return true
             }
             // Detect press vs release by observing the capsLock flag TRANSITION,
             // not its absolute value. This handles the case where Caps Lock was
@@ -713,12 +719,15 @@ final class EventTapBox {
     fileprivate var _registeredShortcuts: Set<KeyPress> = []
     fileprivate var _hyperKeyEnabled: Bool = false
     fileprivate var _isHyperHeld: Bool = false
-    /// Mach absolute timestamp of the most recent F19 keyDown, used to detect
-    /// Caps Lock's instant keyDown+keyUp toggle quirk.
+    /// CGEvent.timestamp (nanoseconds since startup) of the most recent F19
+    /// keyDown, used to detect Caps Lock's instant keyDown+keyUp toggle quirk.
     fileprivate var _hyperKeyDownTimestamp: UInt64 = 0
     /// When true, an instant F19 keyUp was ignored; the next non-F19 keyDown
-    /// that consumes the Hyper combo should clear _isHyperHeld.
+    /// should clear _isHyperHeld regardless of whether the combo is registered.
     fileprivate var _hyperKeyUpDeferred: Bool = false
+    /// True once F19 has been received via keyDown; prevents the flagsChanged
+    /// handler from double-toggling _isHyperHeld.
+    fileprivate var _f19ReceivedViaKeyDown: Bool = false
     /// Tracks the last observed capsLock flag state so the flagsChanged handler
     /// can detect transitions (edge) rather than relying on absolute level.
     fileprivate var _prevCapsLockFlag: Bool = false
@@ -750,6 +759,8 @@ final class EventTapBox {
             if !enabled {
                 _isHyperHeld = false
                 _hyperKeyUpDeferred = false
+                _hyperKeyDownTimestamp = 0
+                _f19ReceivedViaKeyDown = false
             }
             _prevCapsLockFlag = false
         }

--- a/Sources/Quickey/Services/HyperKeyService.swift
+++ b/Sources/Quickey/Services/HyperKeyService.swift
@@ -94,7 +94,8 @@ final class HyperKeyService {
 
     private func applyMapping() -> Bool {
         // CapsLockDelayOverride=0 removes the ~100ms press-duration threshold
-        // that macOS 15+ requires before a Caps Lock press registers (Apple TN2450).
+        // that macOS 15+ requires before a Caps Lock press registers.
+        // (Undocumented hidutil property; see CapsLockNoDelay, Karabiner-Elements #3949.)
         let json = """
         {"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":\(Self.capsLockUsage),"HIDKeyboardModifierMappingDst":\(Self.f19Usage)}],"CapsLockDelayOverride":0}
         """
@@ -102,6 +103,8 @@ final class HyperKeyService {
     }
 
     private func clearMapping() -> Bool {
+        // CapsLockDelayOverride is not explicitly reset here. hidutil properties
+        // do not survive reboot (Apple TN2450), so the override clears naturally.
         return runner(["property", "--set", "{\"UserKeyMapping\":[]}"])
     }
 }

--- a/Tests/QuickeyTests/QuickeyTests.swift
+++ b/Tests/QuickeyTests/QuickeyTests.swift
@@ -287,6 +287,85 @@ struct EventTapManagerDeliveryTests {
     }
 
     @Test
+    func hyperKeyDeferredKeyUpClearsOnUnregisteredKey() {
+        // After instant keyDown+keyUp (deferred), pressing an UNREGISTERED key
+        // should clear the held state so subsequent keys are not Hyper-injected.
+        let keyDown = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: true)
+        let keyUp = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: false)
+        keyUp.timestamp = keyDown.timestamp + 1_000_000  // 1ms → deferred
+
+        let box = EventTapBox()
+        box.setHyperKey(enabled: true)
+        let hyperA = KeyPress(
+            keyCode: CGKeyCode(kVK_ANSI_A),
+            modifiers: [.command, .option, .control, .shift]
+        )
+        box.registeredShortcuts = [hyperA]
+
+        let _ = handleEventTapEvent(type: .keyDown, event: keyDown, box: box)
+        let _ = handleEventTapEvent(type: .keyUp, event: keyUp, box: box)
+        #expect(box.isHyperHeld == true, "Deferred: should still be held")
+
+        // Press X (unregistered) → should pass through, and clear deferred state
+        let xEvent = makeKeyEvent(CGKeyCode(kVK_ANSI_X), modifiers: [], keyDown: true)
+        let xResult = handleEventTapEvent(type: .keyDown, event: xEvent, box: box)
+        #expect(xResult != nil, "Unregistered key should pass through")
+        #expect(box.isHyperHeld == false, "Deferred state should be cleared after unregistered key")
+
+        // Next key should NOT have Hyper injected
+        let yEvent = makeKeyEvent(CGKeyCode(kVK_ANSI_Y), modifiers: [], keyDown: true)
+        let yResult = handleEventTapEvent(type: .keyDown, event: yEvent, box: box)
+        #expect(yResult != nil, "Y should pass through without Hyper")
+    }
+
+    @Test
+    func setHyperKeyDisabledClearsDeferredState() {
+        let keyDown = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: true)
+        let keyUp = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: false)
+        keyUp.timestamp = keyDown.timestamp + 1_000_000  // 1ms → deferred
+
+        let box = EventTapBox()
+        box.setHyperKey(enabled: true)
+
+        let _ = handleEventTapEvent(type: .keyDown, event: keyDown, box: box)
+        let _ = handleEventTapEvent(type: .keyUp, event: keyUp, box: box)
+        #expect(box.isHyperHeld == true)
+
+        // Disable Hyper Key → should clear all deferred state
+        box.setHyperKey(enabled: false)
+        #expect(box.isHyperHeld == false)
+
+        // Re-enable and press A → should NOT be swallowed (no Hyper held)
+        box.setHyperKey(enabled: true)
+        box.registeredShortcuts = [KeyPress(
+            keyCode: CGKeyCode(kVK_ANSI_A),
+            modifiers: [.command, .option, .control, .shift]
+        )]
+        let aEvent = makeKeyEvent(CGKeyCode(kVK_ANSI_A), modifiers: [], keyDown: true)
+        let result = handleEventTapEvent(type: .keyDown, event: aEvent, box: box)
+        #expect(result != nil, "A should pass through — no Hyper held after disable")
+    }
+
+    @Test
+    func flagsChangedSkippedWhenKeyDownPathActive() {
+        // When F19 keyDown has been received (keyDown path active),
+        // a subsequent flagsChanged should NOT toggle isHyperHeld.
+        let keyDown = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: true)
+        let box = EventTapBox()
+        box.setHyperKey(enabled: true)
+
+        // F19 keyDown → isHyperHeld = true via keyDown path
+        let _ = handleEventTapEvent(type: .keyDown, event: keyDown, box: box)
+        #expect(box.isHyperHeld == true)
+
+        // flagsChanged for F19 with capsLock flag → should NOT toggle to false
+        let flagsEvent = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: .capsLock, keyDown: true)
+        let flagsResult = handleEventTapEvent(type: .flagsChanged, event: flagsEvent, box: box)
+        #expect(flagsResult == nil, "flagsChanged for F19 should still be swallowed")
+        #expect(box.isHyperHeld == true, "flagsChanged should not toggle state when keyDown path is active")
+    }
+
+    @Test
     func registeredShortcutSwallowsEventAndDeliversKeyPress() async {
         let keyPress = KeyPress(keyCode: CGKeyCode(kVK_ANSI_A), modifiers: [.command])
         let event = makeKeyEvent(keyPress.keyCode, modifiers: keyPress.modifiers, keyDown: true)

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -194,6 +194,28 @@ Compared Quickey's toggle implementation with alt-tab-macos (https://github.com/
 **Practical guidance**
 Quickey 的三层激活方案（SkyLight + 0xf8 makeKeyWindow + AXRaise）是三个参考项目中最完整的，与 alt-tab 一致，优于 Hammerspoon 的双层方案。toggle 状态机（pending/stable/degraded）是 Quickey 独有的需求（alt-tab 和 Hammerspoon 都不做 toggle），设计合理。后台线程 event tap 优于 Hammerspoon 的主线程方案。可优化方向：SkyLight/AX 调用可考虑移至后台队列（alt-tab 做法），但需评估 @MainActor 约束。
 
+## CGEvent.timestamp Is Nanoseconds, Not Mach Ticks
+
+**Issue**
+Code comments or variable names may refer to `CGEvent.timestamp` as "Mach absolute ticks", leading to incorrect unit assumptions.
+
+**Cause**
+Apple's `CGEventTypes.h` defines `CGEventTimestamp` as "roughly, nanoseconds since startup." On Apple Silicon, raw `mach_absolute_time()` ticks are ~41.67 ns/tick (24 MHz clock, per QA1398), which is a different unit. `CGEvent.timestamp` is pre-converted to nanoseconds by the system.
+
+**Practical guidance**
+Always treat `CGEvent.timestamp` values as nanoseconds. When computing elapsed time between events (e.g., for the 80ms Caps Lock toggle quirk threshold), use `80_000_000` (80M nanoseconds), not Mach ticks. Note that test-created CGEvents via `CGEvent(keyboardEventSource:virtualKey:keyDown:)` may have a timestamp of 0, so do not use timestamp `> 0` as a sentinel for "has been set."
+
+## Dual Event Paths for Remapped Keys Need Mutual Exclusion
+
+**Issue**
+When Caps Lock is remapped to F19 via `hidutil`, the system may generate both `keyDown`/`keyUp` and `flagsChanged` events for the same physical key press.
+
+**Cause**
+`hidutil` remapping changes the key code but does not fully suppress the modifier-flag machinery. On some macOS versions, the remapped key produces `keyDown`/`keyUp` (primary path), while the underlying Caps Lock toggle still fires `flagsChanged` events.
+
+**Practical guidance**
+If both event types are handled in a CGEvent tap callback, the two code paths must be mutually exclusive for the same key code. Use a flag (e.g., `_f19ReceivedViaKeyDown`) to detect which path is active and skip the other. The `flagsChanged` path should still swallow the event (return nil) to prevent it from reaching applications, but must not modify shared state that the `keyDown`/`keyUp` path owns. Reset the mutual-exclusion flag when the feature is disabled so the fallback path remains available after re-enable.
+
 ## Event Tap Timeout Recovery Needs Escalation
 
 **Issue**


### PR DESCRIPTION
## Summary

- **flagsChanged 兼容**：Caps Lock→F19 在部分 macOS 版本产生 `flagsChanged` 而非 `keyDown`，新增 F19 keyCode 检测与边沿检测（transition detection）判断按下/释放
- **maskAlphaShift 剥离**：Caps Lock toggle 标志泄漏导致修饰符不匹配（`0x1F0000` vs `0x1E0000`），提取 `CGEventFlags.strippingCapsLock` 扩展统一处理
- **瞬时 toggle 防御**：Caps Lock 硬件单次按压同时产生 keyDown+keyUp，添加 80ms 时间窗口（`hyperKeyToggleQuirkThresholdTicks`）防止 `isHyperHeld` 被立即重置
- **macOS 15 延迟移除**：通过 `CapsLockDelayOverride=0` 禁用 Sequoia 引入的 ~100ms Caps Lock 最低按压门槛
- **4 个新测试**覆盖 flagsChanged 路径、capsLock flag 泄漏、瞬时 keyUp 延迟

### 技术依据
- Apple TN2450, QA1519
- Karabiner-Elements #753, #1541, #3949
- CapsLockNoDelay: CapsLockDelayOverride 属性

## Test plan
- [x] `swift test` 149 tests passed
- [ ] 真机测试：启用 Hyper Key → Caps Lock + A 打开 IINA
- [ ] 测试 macOS 15 上快速点按 Caps Lock 是否响应
- [ ] 测试 Caps Lock 已开启状态下启用 Hyper Key