### PR TITLE
fix: 修正 Hyper Key HID usage code (F13→F19) 并增强诊断

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ build/
 *.o
 *.d
 *.swiftdeps
+scripts/cgevent-helper
 .claude/
 .worktrees/

--- a/Sources/Quickey/Services/EventTapManager.swift
+++ b/Sources/Quickey/Services/EventTapManager.swift
@@ -118,12 +118,19 @@ func handleEventTapEvent(
                 swallowed: true,
                 injectedHyper: false
             )
+            DispatchQueue.global(qos: .utility).async {
+                DiagnosticLog.log("HYPER_F19_DOWN: keyCode=\(keyCode) flags=\(modifierFlags.rawValue) ts=\(eventTimestamp)")
+            }
             return nil
         }
 
         if injectHyper {
             event.flags = event.flags.strippingCapsLock
                 .union([.maskControl, .maskAlternate, .maskShift, .maskCommand])
+            let resultFlags = event.flags.rawValue
+            DispatchQueue.global(qos: .utility).async {
+                DiagnosticLog.log("HYPER_INJECT: keyCode=\(keyCode) resultFlags=\(resultFlags) matched=\(swallow)")
+            }
         }
 
         let flags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
@@ -169,6 +176,13 @@ func handleEventTapEvent(
             return false
         }
         let modifierFlags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
+        if swallowUp {
+            let elapsed = event.timestamp - box.withLock({ box._hyperKeyDownTimestamp })
+            let deferred = box.withLock({ box._hyperKeyUpDeferred })
+            DispatchQueue.global(qos: .utility).async {
+                DiagnosticLog.log("HYPER_F19_UP: keyCode=\(keyCode) elapsed=\(elapsed) deferred=\(deferred)")
+            }
+        }
         box.recordObservedEvent(
             type: .keyUp,
             keyCode: keyCode,

--- a/Sources/Quickey/Services/HyperKeyService.swift
+++ b/Sources/Quickey/Services/HyperKeyService.swift
@@ -30,8 +30,8 @@ final class HyperKeyService {
     typealias HidutilRunner = @Sendable ([String]) -> Bool
 
     /// HID usage codes (Apple TN2450)
-    nonisolated static let capsLockUsage: UInt64 = 0x700000039
-    nonisolated static let f19Usage: UInt64 = 0x700000068
+    nonisolated static let capsLockUsage: UInt64 = 0x700000039  // Keyboard CapsLock
+    nonisolated static let f19Usage: UInt64 = 0x70000006E       // Keyboard F19 (0x6E = 110)
     /// F19 virtual keyCode (Carbon Events)
     nonisolated static let f19KeyCode: CGKeyCode = 80  // kVK_F19 = 0x50
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -216,6 +216,46 @@ When Caps Lock is remapped to F19 via `hidutil`, the system may generate both `k
 **Practical guidance**
 If both event types are handled in a CGEvent tap callback, the two code paths must be mutually exclusive for the same key code. Use a flag (e.g., `_f19ReceivedViaKeyDown`) to detect which path is active and skip the other. The `flagsChanged` path should still swallow the event (return nil) to prevent it from reaching applications, but must not modify shared state that the `keyDown`/`keyUp` path owns. Reset the mutual-exclusion flag when the feature is disabled so the fallback path remains available after re-enable.
 
+## osascript `key code` 无法模拟按住按键
+
+**Issue**
+E2E 测试中 `send_hyper_combo` 用 osascript `key code 80; key code 0` 测 Hyper Key，测试"偶然"通过但实际没测到真实场景。
+
+**Cause**
+osascript `key code N` 发送完整的 keyDown+keyUp 对，无法模拟"按住 F19 同时按字母"。旧测试能通过纯粹是因为 deferred keyUp 机制（80ms 阈值）恰好兜住了 F19 的瞬时 keyUp。一旦 osascript 处理延迟 >80ms，测试就会失败。
+
+**Practical guidance**
+需要独立控制 keyDown/keyUp 时，用编译的 Swift helper 通过 `CGEvent.post(tap: .cghidEventTap)` 发送事件。遵循业界做法：
+- **Event Source**: `CGEventSource(stateID: .hidSystemState)`（Karabiner-Elements、KeyboardSimulator 均使用）
+- **Tap Location**: `.cghidEventTap`（Apple CGEvent.h: 事件从 HID 层流过所有下游 session tap）
+- **Timing**: modifier→key 10ms, key down→up 1ms（Karabiner-Elements appendix/cg_post_event 的模式）
+- **Combo 序列**: holdKey↓ → 10ms → tapKey↓ → 1ms → tapKey↑ → 10ms → holdKey↑
+
+参考项目：Karabiner-Elements (`appendix/cg_post_event`)、Hammerspoon (`eventtap/libeventtap.m`)、skhd (`src/synthesize.c`)。
+
+## HID Usage Code ≠ Carbon Virtual KeyCode
+
+**Issue**
+hidutil `UserKeyMapping` 声称映射 Caps Lock → F19，`hidutil property --get` 也显示映射活跃，但物理 Caps Lock 按键在 CGEvent tap 中产生 F13 (keyCode=105) 而非 F19 (keyCode=80)。
+
+**Cause**
+HID usage code 和 Carbon virtual key code 是两套完全不同的编码系统。常见陷阱：
+- F13 HID usage = `0x68` → 完整 HID usage = `0x700000068`
+- F19 HID usage = `0x6E` → 完整 HID usage = `0x70000006E`
+- F13 Carbon keyCode = `105` (kVK_F13 = 0x69)
+- F19 Carbon keyCode = `80` (kVK_F19 = 0x50)
+
+原始代码将 `f19Usage` 错误设为 `0x700000068`（实际是 F13），导致 hidutil 把 Caps Lock 映射到 F13，但 event tap 在监听 keyCode=80 (F19)。两者完全不匹配。
+
+**Practical guidance**
+在 Apple TN2450 的 HID usage table 中查找正确的 usage 值。不要混淆 HID usage (0x07 page) 和 Carbon virtual key code (Events.h)。编写映射代码时，用物理按键测试验证映射结果——osascript `key code N` 直接注入 CGEvent，绕过 HID 层，无法测出 HID usage 错误。验证 hidutil 映射时，必须使用物理按键 + event tap 日志确认实际收到的 keyCode。
+
+**Reference**
+- Apple TN2450: HID usage codes (0x07 page)
+- Carbon Events.h: virtual key codes (kVK_*)
+- HID Keyboard page: F13=0x68, F14=0x69, F15=0x6A, F16=0x6B, F17=0x6C, F18=0x6D, F19=0x6E, F20=0x6F
+- Carbon: kVK_F13=0x69(105), kVK_F19=0x50(80)
+
 ## Event Tap Timeout Recovery Needs Escalation
 
 **Issue**

--- a/scripts/cgevent-helper.swift
+++ b/scripts/cgevent-helper.swift
@@ -1,0 +1,75 @@
+#!/usr/bin/swift
+// Standalone CGEvent sender for e2e tests.
+// Usage:
+//   cgevent-helper down <keyCode>            — keyDown
+//   cgevent-helper up   <keyCode>            — keyUp
+//   cgevent-helper combo <holdKeyCode> <tapKeyCode>
+//       — holdKey down → tapKey down → tapKey up → holdKey up
+//
+// Events are posted at .cghidEventTap so they flow through
+// session-level event taps (matching real hardware input).
+//
+// References:
+//   - Apple CGEvent.h: CGEventCreateKeyboardEvent, CGEventPost
+//   - Apple CGEventTypes.h: kCGHIDEventTap
+//   - Karabiner-Elements appendix/cg_post_event: uses kCGHIDEventTap
+//     with kCGEventSourceStateHIDSystemState, 10ms modifier→key delay
+//   - Hammerspoon eventtap: uses kCGHIDEventTap for keyStrokes
+
+import Foundation
+import ApplicationServices
+
+// Use HID system state source (same as Karabiner-Elements / KeyboardSimulator).
+// This ties events to the HID subsystem rather than creating an anonymous source,
+// ensuring they are indistinguishable from real hardware input.
+let source = CGEventSource(stateID: .hidSystemState)
+
+func postKey(_ keyCode: UInt16, keyDown: Bool) {
+    guard let event = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(keyCode), keyDown: keyDown) else {
+        fputs("Failed to create CGEvent for keyCode=\(keyCode) keyDown=\(keyDown)\n", stderr)
+        exit(1)
+    }
+    // Post at HID tap so the event flows through session-level event taps
+    // (Apple docs: "the event passes through any such taps").
+    event.post(tap: .cghidEventTap)
+}
+
+let args = CommandLine.arguments
+guard args.count >= 3 else {
+    fputs("Usage: cgevent-helper <down|up|combo> <keyCode> [tapKeyCode]\n", stderr)
+    exit(1)
+}
+
+let action = args[1]
+guard let keyCode = UInt16(args[2]) else {
+    fputs("Invalid keyCode: \(args[2])\n", stderr)
+    exit(1)
+}
+
+switch action {
+case "down":
+    postKey(keyCode, keyDown: true)
+
+case "up":
+    postKey(keyCode, keyDown: false)
+
+case "combo":
+    // combo <holdKeyCode> <tapKeyCode>
+    // Simulates: hold key down → tap key down → tap key up → hold key up
+    // Timing follows Karabiner-Elements pattern: 10ms between modifier and key.
+    guard args.count >= 4, let tapCode = UInt16(args[3]) else {
+        fputs("combo requires two keyCodes\n", stderr)
+        exit(1)
+    }
+    postKey(keyCode, keyDown: true)
+    usleep(10_000)  // 10ms hold→tap (Karabiner uses 10ms for modifier→key)
+    postKey(tapCode, keyDown: true)
+    usleep(1_000)   // 1ms tap down→up (Karabiner uses 1ms for key down→up)
+    postKey(tapCode, keyDown: false)
+    usleep(10_000)  // 10ms tap→release
+    postKey(keyCode, keyDown: false)
+
+default:
+    fputs("Unknown action: \(action). Use down, up, or combo.\n", stderr)
+    exit(1)
+}

--- a/scripts/e2e-full-test.sh
+++ b/scripts/e2e-full-test.sh
@@ -25,7 +25,7 @@ echo ""
 MODULES=(
     "e2e-test-startup.sh:Startup & Lifecycle"
     "e2e-test-standard-toggle.sh:Standard Toggle ON/OFF"
-    "e2e-test-hyper-key.sh:Hyper Key (F19 + Deferred)"
+    "e2e-test-hyper-key.sh:Hyper Key (CGEvent hold)"
     "e2e-test-debounce.sh:Debounce & Cooldown"
     "e2e-test-loop-prevention.sh:Toggle Loop Prevention"
     "e2e-test-multi-shortcut.sh:Multi-Shortcut Isolation"

--- a/scripts/e2e-lib.sh
+++ b/scripts/e2e-lib.sh
@@ -10,6 +10,17 @@ PROJECT_DIR="$(cd "$E2E_LIB_DIR/.." && pwd)"
 APP_PATH="$PROJECT_DIR/build/Quickey.app"
 LOG_FILE="$HOME/.config/Quickey/debug.log"
 QUICKEY_BUNDLE_ID="com.quickey.app"
+CGEVENT_HELPER="$E2E_LIB_DIR/cgevent-helper"
+CGEVENT_SRC="$E2E_LIB_DIR/cgevent-helper.swift"
+
+# Build CGEvent helper if source is newer than binary (or binary missing)
+if [ ! -x "$CGEVENT_HELPER" ] || [ "$CGEVENT_SRC" -nt "$CGEVENT_HELPER" ]; then
+    echo "  Building cgevent-helper..."
+    swiftc -O "$CGEVENT_SRC" -o "$CGEVENT_HELPER" || {
+        echo "ERROR: failed to compile cgevent-helper.swift" >&2
+        exit 1
+    }
+fi
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -169,14 +180,47 @@ send_keycode() {
     osascript -e "tell application \"System Events\" to key code $code"
 }
 
-# Send F19 followed immediately by a key code (Hyper Key testing)
+# Send F19 held + key tap for Hyper Key testing.
+# Strategy: try CGEvent helper first (real hold simulation); fall back to
+# osascript if CGEvent.post() fails (requires calling process to have
+# Accessibility permission — not always available in CI/IDE terminals).
+# The osascript fallback tests the deferred-keyUp path, which is the same
+# code path triggered by real Caps Lock hardware (toggle quirk).
 send_hyper_combo() {
     local letter_code="$1"
-    osascript -e "tell application \"System Events\"
+    if [ "$_HYPER_USE_OSASCRIPT" = "1" ]; then
+        osascript -e "tell application \"System Events\"
     key code 80
     key code $letter_code
 end tell"
+    else
+        "$CGEVENT_HELPER" combo 80 "$letter_code"
+    fi
 }
+
+# Probe once whether CGEvent posting reaches the event tap.
+# If not, fall back to osascript for the rest of the session.
+_HYPER_USE_OSASCRIPT="0"
+_probe_cgevent() {
+    if [ ! -f "$LOG_FILE" ]; then _HYPER_USE_OSASCRIPT="1"; return; fi
+    local pre
+    pre=$(wc -l < "$LOG_FILE" | tr -d ' ')
+    "$CGEVENT_HELPER" down 80 2>/dev/null
+    usleep 50000 2>/dev/null || sleep 0.05
+    "$CGEVENT_HELPER" up 80 2>/dev/null
+    usleep 50000 2>/dev/null || sleep 0.05
+    local slice
+    slice=$(tail -n +"$((pre + 1))" "$LOG_FILE" 2>/dev/null || true)
+    if echo "$slice" | grep -q "keyCode=80\|HYPER_FLAGS_CHANGED" 2>/dev/null; then
+        _HYPER_USE_OSASCRIPT="0"
+    else
+        _HYPER_USE_OSASCRIPT="1"
+    fi
+}
+
+# Send individual keyDown or keyUp via CGEvent (for precise event control)
+send_cgevent_down() { "$CGEVENT_HELPER" down "$1"; }
+send_cgevent_up()   { "$CGEVENT_HELPER" up "$1"; }
 
 # Send N rapid keystrokes in a single osascript (accurate sub-200ms timing)
 send_rapid_keystrokes() {

--- a/scripts/e2e-test-hyper-key.sh
+++ b/scripts/e2e-test-hyper-key.sh
@@ -2,7 +2,7 @@
 # E2E Test Module 3: Hyper Key (Issue #83)
 source "$(dirname "$0")/e2e-lib.sh"
 
-MODULE_NAME="Hyper Key (F19 + Deferred)"
+MODULE_NAME="Hyper Key (CGEvent hold)"
 e2e_maybe_launch "$MODULE_NAME"
 
 echo ""
@@ -14,12 +14,20 @@ if ! is_hyper_key_enabled; then
     exit 0
 fi
 
-# --- Part 1: F19 + A -> IINA ---
+# Probe CGEvent delivery; fall back to osascript if needed
+_probe_cgevent
+if [ "$_HYPER_USE_OSASCRIPT" = "1" ]; then
+    echo -e "    ${YELLOW}NOTE${NC}: CGEvent.post() not available, using osascript (deferred-keyUp path)"
+else
+    echo -e "    ${GREEN}NOTE${NC}: Using CGEvent helper (real hold simulation)"
+fi
+
+# --- Part 1: Hold F19 + tap A -> IINA ---
 echo ""
-echo "  -- Part 1: F19 + A -> IINA (deferred keyUp mechanism) --"
+echo "  -- Part 1: Hold F19 + tap A -> IINA (real hold simulation) --"
 
 PRE=$(log_line_count)
-send_hyper_combo 0  # key code 0 = A
+send_hyper_combo 0  # key code 0 = A  (combo: F19 down, A down, A up, F19 up)
 sleep 3
 
 SLICE=$(get_log_slice "$PRE")
@@ -40,6 +48,21 @@ echo "  -- Part 2: Verify Hyper modifier injection --"
 
 # 1966080 = Ctrl+Opt+Shift+Cmd (0x1E0000)
 assert_contains "$SLICE" "EVENT_TAP_SWALLOW:.*keyCode=0.*modifiers=1966080" "All 4 Hyper modifiers injected"
+
+ensure_app_stopped "IINA"
+
+# --- Part 3: Verify F19 hold/release lifecycle ---
+echo ""
+echo "  -- Part 3: F19 held state is cleared after combo --"
+
+# Send another combo and verify no stale hyper state
+PRE2=$(log_line_count)
+send_hyper_combo 0  # Hyper+A again
+sleep 3
+
+SLICE2=$(get_log_slice "$PRE2")
+assert_count_ge "$SLICE2" "MATCHED: IINA" 1 "Second Hyper+A also triggers IINA"
+assert_not_contains "$SLICE2" "DEBOUNCE_BLOCKED" "No debounce block (separate combos)"
 
 ensure_app_stopped "IINA"
 

--- a/scripts/e2e-test-multi-shortcut.sh
+++ b/scripts/e2e-test-multi-shortcut.sh
@@ -25,6 +25,7 @@ assert_not_contains "$SLICE" "MATCHED: IINA" "IINA not triggered by Safari short
 
 # --- Step 2: Hyper+A -> only IINA ---
 if is_hyper_key_enabled; then
+    _probe_cgevent
     echo ""
     echo "  -- Step 2: Hyper+A -> only IINA --"
     sleep 2

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -54,10 +54,20 @@ else
 PLIST
 fi
 
-echo "==> Resetting TCC permissions (ad-hoc signing changes hash on each build)..."
-tccutil reset Accessibility "$BUNDLE_ID" 2>/dev/null || true
-tccutil reset ListenEvent "$BUNDLE_ID" 2>/dev/null || true
-echo "    Permissions reset. App will re-request on launch."
+# Sign with a stable identity if available; fall back to ad-hoc.
+# A stable identity (e.g. "Quickey Dev" self-signed cert) lets TCC
+# permissions survive across rebuilds. Create one via:
+#   Keychain Access → Certificate Assistant → Create a Certificate
+#   Name: "Quickey Dev", Type: Code Signing
+SIGN_IDENTITY="Quickey"
+if security find-identity -v -p codesigning 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
+    echo "==> Signing with '$SIGN_IDENTITY' (TCC permissions will persist across builds)..."
+    codesign --force --sign "$SIGN_IDENTITY" --identifier "$BUNDLE_ID" "$APP_DIR" 2>&1
+else
+    echo "==> Ad-hoc signed (no '$SIGN_IDENTITY' cert found)."
+    echo "    TCC permissions may need re-granting after each rebuild."
+    echo "    To fix: create a self-signed cert named '$SIGN_IDENTITY' in Keychain Access."
+fi
 
 echo "==> Done: $APP_DIR"
 echo "    Run with: open $APP_DIR"


### PR DESCRIPTION
f19Usage 错误使用 0x700000068 (F13) 而非 0x70000006E (F19)， 导致 hidutil 将 Caps Lock 映射到 F13，event tap 监听 F19，
物理按键完全无法触发 Hyper Key。osascript 测试绕过 HID 层
无法暴露此问题。

- 修正 HyperKeyService.f19Usage 为正确的 F19 HID usage (0x6E)
- EventTapManager 添加 HYPER_F19_DOWN/UP/INJECT 诊断日志
- 新增 cgevent-helper.swift 用于 e2e 真实按键模拟
- e2e-lib.sh 增加 CGEvent helper 自动编译和 fallback 探测
- package-app.sh 用稳定证书签名替代每次 tccutil reset
- 记录 HID usage vs Carbon keyCode 混淆的经验教训