### PR TITLE
fix: 修复非 Hyper Key 快捷键 toggle-off 失效及修饰键归一化不对称

### DIFF
--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -426,11 +426,37 @@ final class AppSwitcher: AppSwitching {
             if let trackerPrevious = frontmostTracker.lastNonTargetBundleIdentifier, trackerPrevious != previousApp {
                 DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: RESTORE_DIVERGENCE resolvedPrevious=\(previousApp ?? "nil") trackerPrevious=\(trackerPrevious)")
             }
-            let restoreAttempt = frontmostTracker.restorePreviousAppIfPossible()
-            let hidden = runningApp.hide()
-            let restored = restoreAttempt.restoreAccepted
+            // 1. Hide the current app via AX first.  NSRunningApplication.hide()
+            //    returns false from an LSUIElement/accessory app on macOS 15, so we
+            //    use the Accessibility API (kAXHiddenAttribute) which works with
+            //    the existing Accessibility permission.  Hiding first forces macOS
+            //    to activate another app, making the subsequent SkyLight activation
+            //    of the specific previous app immediate.
+            let axTarget = AXUIElementCreateApplication(runningApp.processIdentifier)
+            let axHideResult = AXUIElementSetAttributeValue(
+                axTarget,
+                kAXHiddenAttribute as CFString,
+                kCFBooleanTrue as CFTypeRef
+            )
+            let hidden = (axHideResult == .success)
+
+            // 2. Activate the previous app via full three-layer SkyLight (same as
+            //    forward activation) so the correct app comes to front.
+            let restored: Bool
+            let restoredBundle: String?
+            if let prevBundle = previousApp,
+               let prevApp = NSRunningApplication.runningApplications(withBundleIdentifier: prevBundle).first {
+                restoredBundle = prevBundle
+                if prevApp.isHidden { prevApp.unhide() }
+                let prevWindows = applicationObservation.windowObservation(for: prevApp)
+                restored = activateViaWindowServer(prevApp, windows: prevWindows.windows)
+            } else {
+                let restoreAttempt = frontmostTracker.restorePreviousAppIfPossible()
+                restored = restoreAttempt.restoreAccepted
+                restoredBundle = restoreAttempt.bundleIdentifier
+            }
             logger.info("TOGGLE[\(shortcut.appName)]: IS ACTIVE → restored=\(restored), hidden=\(hidden)")
-            DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: IS ACTIVE → restored=\(restored) (prev=\(restoreAttempt.bundleIdentifier ?? previousApp ?? "nil")), hidden=\(hidden)")
+            DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: IS ACTIVE → restored=\(restored) (prev=\(restoredBundle ?? previousApp ?? "nil")), hidden=\(hidden)")
             let postRestoreWindowObservation = applicationObservation.windowObservation(for: runningApp)
             let postRestoreSnapshot = applicationObservation.snapshot(
                 for: runningApp,
@@ -444,7 +470,7 @@ final class AppSwitcher: AppSwitching {
                 shortcut: shortcut,
                 phase: .postRestoreState,
                 snapshot: postRestoreSnapshot,
-                previousBundle: restoreAttempt.bundleIdentifier ?? previousApp,
+                previousBundle: restoredBundle ?? previousApp,
                 activationPath: .restorePrevious,
                 elapsedMilliseconds: elapsedMilliseconds(since: attemptStartedAt)
             )
@@ -457,7 +483,13 @@ final class AppSwitcher: AppSwitching {
         if runningApp.isActive, preActionSnapshot.isStableActivation,
            stableActivationState?.bundleIdentifier != shortcut.bundleIdentifier,
            pendingActivationState?.bundleIdentifier != shortcut.bundleIdentifier {
-            let hidden = runningApp.hide()
+            let axUntrackedTarget = AXUIElementCreateApplication(runningApp.processIdentifier)
+            let axUntrackedResult = AXUIElementSetAttributeValue(
+                axUntrackedTarget,
+                kAXHiddenAttribute as CFString,
+                kCFBooleanTrue as CFTypeRef
+            )
+            let hidden = (axUntrackedResult == .success)
             logger.info("TOGGLE[\(shortcut.appName)]: ACTIVE_UNTRACKED → hiding, hidden=\(hidden)")
             logToggleLifecycle(
                 for: shortcut,

--- a/Sources/Quickey/Services/EventTapManager.swift
+++ b/Sources/Quickey/Services/EventTapManager.swift
@@ -96,7 +96,7 @@ func handleEventTapEvent(
             let flags = NSEvent.ModifierFlags(rawValue: UInt(currentFlags.rawValue))
             let keyPress = KeyPress(
                 keyCode: keyCode,
-                modifiers: flags.intersection(.deviceIndependentFlagsMask)
+                modifiers: KeyMatcher.normalizedFlags(from: flags)
             )
             let shouldSwallow = box._registeredShortcuts.contains(keyPress)
             // Clear deferred keyUp state on any non-F19 keyDown. The current
@@ -109,12 +109,32 @@ func handleEventTapEvent(
             return (shouldSwallow, hyper)
         }
 
+        #if DEBUG
+        // Near-miss diagnostic: log when keyCode matches a registered shortcut
+        // but modifiers differ (e.g. spurious numericPad/help/undocumented bits).
+        if !swallow && !injectHyper {
+            let rawFlags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
+            let rawDeviceIndep = rawFlags.intersection(.deviceIndependentFlagsMask).rawValue
+            let normalized = KeyMatcher.normalizedFlags(from: rawFlags).rawValue
+            if rawDeviceIndep != normalized {
+                let hasKeyCodeMatch = box.withLock {
+                    box._registeredShortcuts.contains { $0.keyCode == keyCode }
+                }
+                if hasKeyCodeMatch {
+                    DispatchQueue.global(qos: .utility).async {
+                        DiagnosticLog.log("NEAR_MISS: keyCode=\(keyCode) rawDeviceIndep=\(rawDeviceIndep) normalized=\(normalized) delta=\(rawDeviceIndep ^ normalized)")
+                    }
+                }
+            }
+        }
+        #endif
+
         if swallow && keyCode == HyperKeyService.f19KeyCode {
             let modifierFlags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
             box.recordObservedEvent(
                 type: .keyDown,
                 keyCode: keyCode,
-                modifierFlags: modifierFlags.intersection(.deviceIndependentFlagsMask),
+                modifierFlags: KeyMatcher.normalizedFlags(from: modifierFlags),
                 swallowed: true,
                 injectedHyper: false
             )
@@ -136,7 +156,7 @@ func handleEventTapEvent(
         let flags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
         let keyPress = KeyPress(
             keyCode: keyCode,
-            modifiers: flags.intersection(.deviceIndependentFlagsMask)
+            modifiers: KeyMatcher.normalizedFlags(from: flags)
         )
         box.recordObservedEvent(
             type: .keyDown,
@@ -186,7 +206,7 @@ func handleEventTapEvent(
         box.recordObservedEvent(
             type: .keyUp,
             keyCode: keyCode,
-            modifierFlags: modifierFlags.intersection(.deviceIndependentFlagsMask),
+            modifierFlags: KeyMatcher.normalizedFlags(from: modifierFlags),
             swallowed: swallowUp,
             injectedHyper: false
         )
@@ -197,8 +217,9 @@ func handleEventTapEvent(
         // instead of keyDown/keyUp on some macOS versions. Handle it here so the
         // Hyper key works regardless of which event type the system produces.
         let flagsKeyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
-        let flagsRaw = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
-            .intersection(.deviceIndependentFlagsMask)
+        let flagsRaw = KeyMatcher.normalizedFlags(
+            from: NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
+        )
         let hasCapsLock = event.flags.contains(.maskAlphaShift)
         let swallowFlags = box.withLock { () -> Bool in
             guard box._hyperKeyEnabled && flagsKeyCode == HyperKeyService.f19KeyCode else {

--- a/Sources/Quickey/Services/KeyMatcher.swift
+++ b/Sources/Quickey/Services/KeyMatcher.swift
@@ -12,8 +12,7 @@ struct KeyMatcher {
     }
 
     func trigger(for keyPress: KeyPress) -> ShortcutTrigger {
-        let mask = keyPress.modifiers.intersection(NSEvent.ModifierFlags.deviceIndependentFlagsMask)
-        return ShortcutTrigger(keyCode: keyPress.keyCode, modifierMask: normalizedMask(from: mask))
+        ShortcutTrigger(keyCode: keyPress.keyCode, modifierMask: Self.normalizedMask(from: keyPress.modifiers))
     }
 
     func trigger(for shortcut: AppShortcut) -> ShortcutTrigger {
@@ -78,7 +77,16 @@ struct KeyMatcher {
         Self.keyEquivalentToCode[keyEquivalent.lowercased()] ?? CGKeyCode(UInt16.max)
     }
 
-    private func normalizedMask(from flags: NSEvent.ModifierFlags) -> UInt {
+    /// Extract only the five recognised modifier bits (command, option, control,
+    /// shift, function), discarding numericPad, help, capsLock, and any
+    /// undocumented device-independent bits that macOS may set.
+    ///
+    /// Industry best practice (skhd, Hammerspoon, KeyboardShortcuts) – never
+    /// compare raw `deviceIndependentFlagsMask` for hotkey matching because it
+    /// includes bits that are set automatically by the OS (e.g. numericPad on
+    /// arrow keys, function on F-keys) and can vary across focus/input-source
+    /// changes.
+    static func normalizedMask(from flags: NSEvent.ModifierFlags) -> UInt {
         var mask: UInt = 0
         if flags.contains(.command) { mask |= NSEvent.ModifierFlags.command.rawValue }
         if flags.contains(.option) { mask |= NSEvent.ModifierFlags.option.rawValue }
@@ -86,6 +94,11 @@ struct KeyMatcher {
         if flags.contains(.shift) { mask |= NSEvent.ModifierFlags.shift.rawValue }
         if flags.contains(.function) { mask |= NSEvent.ModifierFlags.function.rawValue }
         return mask
+    }
+
+    /// Convenience returning `NSEvent.ModifierFlags` for use in EventTapManager.
+    static func normalizedFlags(from flags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+        NSEvent.ModifierFlags(rawValue: normalizedMask(from: flags))
     }
 
     private func normalizedMask(from modifiers: [String]) -> UInt {

--- a/Tests/QuickeyTests/QuickeyTests.swift
+++ b/Tests/QuickeyTests/QuickeyTests.swift
@@ -399,6 +399,107 @@ struct EventTapManagerDeliveryTests {
     }
 }
 
+// MARK: - Modifier normalization
+
+@Suite("KeyMatcher modifier normalization")
+struct KeyMatcherNormalizationTests {
+    @Test
+    func normalizedFlagsStripsExtraBits() {
+        // numericPad (0x200000) and help (0x400000) should be stripped
+        let dirty = NSEvent.ModifierFlags([.command, .shift, .numericPad])
+        let normalized = KeyMatcher.normalizedFlags(from: dirty)
+        #expect(normalized == NSEvent.ModifierFlags([.command, .shift]))
+    }
+
+    @Test
+    func normalizedFlagsPreservesFiveKnownBits() {
+        let allFive = NSEvent.ModifierFlags([.command, .option, .control, .shift, .function])
+        let normalized = KeyMatcher.normalizedFlags(from: allFive)
+        #expect(normalized == allFive)
+    }
+
+    @Test
+    func normalizedFlagsStripsHelpAndUndocumentedBits() {
+        // help (0x400000) + undocumented bit 24 (0x1000000)
+        let flags = NSEvent.ModifierFlags(rawValue: NSEvent.ModifierFlags.command.rawValue | 0x00400000 | 0x01000000)
+        let normalized = KeyMatcher.normalizedFlags(from: flags)
+        #expect(normalized == NSEvent.ModifierFlags([.command]))
+    }
+}
+
+// MARK: - Extra modifier bits regression
+
+@Suite("EventTapManager extra modifier bits")
+struct EventTapManagerExtraBitsTests {
+    @Test
+    func extraModifierBitsDoNotBreakMatching() {
+        // Regression test: event has numericPad bit (0x200000) in addition to
+        // command+shift. Before the fix, this would fail to match because
+        // deviceIndependentFlagsMask passed numericPad through but the
+        // registered shortcut's normalizedMask did not include it.
+        let shortcut = KeyPress(
+            keyCode: CGKeyCode(kVK_ANSI_S),
+            modifiers: [.command, .shift]
+        )
+        let event = CGEvent(
+            keyboardEventSource: nil,
+            virtualKey: CGKeyCode(kVK_ANSI_S),
+            keyDown: true
+        )!
+        // command + shift + numericPad (extra bit that can leak on some keyboards/input sources)
+        event.flags = CGEventFlags(rawValue: UInt64(
+            NSEvent.ModifierFlags([.command, .shift, .numericPad]).rawValue
+        ))
+
+        let box = EventTapBox()
+        box.registeredShortcuts = [shortcut]
+
+        let result = handleEventTapEvent(type: .keyDown, event: event, box: box)
+        #expect(result == nil, "Extra numericPad bit should not prevent shortcut matching")
+    }
+
+    @Test
+    func functionModifierIsPreservedInMatching() {
+        // function is one of the 5 known bits and SHOULD participate in matching
+        let shortcutWithFn = KeyPress(
+            keyCode: CGKeyCode(kVK_ANSI_A),
+            modifiers: [.command, .function]
+        )
+        let shortcutWithoutFn = KeyPress(
+            keyCode: CGKeyCode(kVK_ANSI_A),
+            modifiers: [.command]
+        )
+        let eventWithFn = CGEvent(
+            keyboardEventSource: nil,
+            virtualKey: CGKeyCode(kVK_ANSI_A),
+            keyDown: true
+        )!
+        eventWithFn.flags = CGEventFlags(rawValue: UInt64(
+            NSEvent.ModifierFlags([.command, .function]).rawValue
+        ))
+
+        // Should match Cmd+Fn+A
+        let box1 = EventTapBox()
+        box1.registeredShortcuts = [shortcutWithFn]
+        let result1 = handleEventTapEvent(type: .keyDown, event: eventWithFn, box: box1)
+        #expect(result1 == nil, "Cmd+Fn+A should match registered Cmd+Fn+A")
+
+        // Should NOT match Cmd+A (function bit matters)
+        let box2 = EventTapBox()
+        box2.registeredShortcuts = [shortcutWithoutFn]
+        let eventWithFn2 = CGEvent(
+            keyboardEventSource: nil,
+            virtualKey: CGKeyCode(kVK_ANSI_A),
+            keyDown: true
+        )!
+        eventWithFn2.flags = CGEventFlags(rawValue: UInt64(
+            NSEvent.ModifierFlags([.command, .function]).rawValue
+        ))
+        let result2 = handleEventTapEvent(type: .keyDown, event: eventWithFn2, box: box2)
+        #expect(result2 != nil, "Cmd+Fn+A should NOT match registered Cmd+A")
+    }
+}
+
 private final class SendableCounter: @unchecked Sendable {
     var value = 0
 }


### PR DESCRIPTION
## Summary

- **修饰键归一化不对称**：事件侧 `.deviceIndependentFlagsMask` 含 16 位（numericPad、help、未文档化位等），注册侧只提取 5 个已知修饰键位，焦点切换后额外位可能导致快捷键无声穿透。统一使用 `KeyMatcher.normalizedFlags()` 归一化，与 skhd/Hammerspoon/KeyboardShortcuts 最佳实践一致
- **Toggle-off 失效**：`NSRunningApplication.hide()` 从 LSUIElement app 始终返回 false（macOS 15）；恢复前一 app 仅用单层 SkyLight 无 windowID。改为 AX API (`kAXHiddenAttribute`) 隐藏 + 全三层 SkyLight 激活，先隐后激确保即时切换
- 新增 6 个回归测试覆盖归一化行为

## Changed files

- `KeyMatcher.swift` — `normalizedMask` 提升为 static，新增 `normalizedFlags` 便捷方法
- `EventTapManager.swift` — 5 处 `.deviceIndependentFlagsMask` 替换为 `normalizedFlags`，新增 DEBUG 近似匹配诊断
- `AppSwitcher.swift` — toggle-off 改用 AX 隐藏 + 三层 SkyLight 激活前一 app
- `QuickeyTests.swift` — 6 个新测试

## Test plan

- [x] `swift test` 157 tests passed
- [x] 手动验证 ⇧⌘S toggle Safari 可正常 on/off
- [ ] 验证 Hyper Key 快捷键不受影响
- [ ] 验证 toggle-off 响应速度是否有改善空间（后续优化）