### PR TITLE
[codex] 搭建 toggle runtime 基础类型与配置面

### DIFF
--- a/Sources/Quickey/Models/ActivationCommand.swift
+++ b/Sources/Quickey/Models/ActivationCommand.swift
@@ -1,0 +1,24 @@
+import AppKit
+
+enum ActivationCommand: Sendable {
+    case prepareRestoreContext(targetBundleIdentifier: String, previousBundleIdentifier: String?)
+    case restorePreviousFast(RestoreContext)
+    case restorePreviousCompatible(RestoreContext)
+    case hideTarget(bundleIdentifier: String, pid: pid_t)
+    case raiseWindow(bundleIdentifier: String, pid: pid_t, windowID: CGWindowID)
+}
+
+enum ActivationCommandResult: Sendable, Equatable {
+    case completed(String)
+    case needsFallback(String)
+    case degraded(String)
+    case cancelledByNewerGeneration(Int)
+}
+
+struct ActivationTimeoutBudget: Sendable, Equatable {
+    var prepareRestoreContext: TimeInterval = 0.04
+    var restorePreviousFast: TimeInterval = 0.12
+    var hideTarget: TimeInterval = 0.08
+    var restorePreviousCompatible: TimeInterval = 0.18
+    var raiseWindow: TimeInterval = 0.08
+}

--- a/Sources/Quickey/Models/RestoreContext.swift
+++ b/Sources/Quickey/Models/RestoreContext.swift
@@ -1,0 +1,13 @@
+import AppKit
+import Carbon.HIToolbox
+
+struct RestoreContext: Sendable {
+    let targetBundleIdentifier: String
+    let previousBundleIdentifier: String?
+    let previousPID: pid_t?
+    let previousPSNHint: ProcessSerialNumber?
+    let previousWindowIDHint: CGWindowID?
+    let previousBundleURL: URL?
+    let capturedAt: CFAbsoluteTime
+    let generation: Int
+}

--- a/Sources/Quickey/Services/ToggleRuntime.swift
+++ b/Sources/Quickey/Services/ToggleRuntime.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum ToggleExecutionMode: Sendable, Equatable {
+    case legacyOnly
+    case shadowMode
+    case pipelineEnabled
+}
+
+struct ToggleRuntimeConfiguration: Sendable, Equatable {
+    var executionMode: ToggleExecutionMode = .legacyOnly
+    var fastConfirmationWindow: TimeInterval = 0.075
+    var contextPreparationConcurrencyLimit: Int = 2
+    var fastLaneMissThreshold: Int = 3
+    var fastLaneMissWindow: TimeInterval = 600
+    var temporaryCompatibilityWindow: TimeInterval = 300
+}
+
+@MainActor
+final class ToggleRuntime {
+    let configuration: ToggleRuntimeConfiguration
+
+    init(configuration: ToggleRuntimeConfiguration = .init()) {
+        self.configuration = configuration
+    }
+}
+
+@MainActor
+func normalizedPreviousBundle(
+    targetBundleIdentifier: String,
+    previousBundleIdentifier: String?
+) -> String? {
+    guard previousBundleIdentifier != targetBundleIdentifier else {
+        return nil
+    }
+    return previousBundleIdentifier
+}

--- a/Tests/QuickeyTests/ToggleRuntimeTests.swift
+++ b/Tests/QuickeyTests/ToggleRuntimeTests.swift
@@ -1,0 +1,66 @@
+import AppKit
+import Carbon.HIToolbox
+import Testing
+@testable import Quickey
+
+@Test @MainActor
+func restoreContextCapturesGenerationAndPreviousBundle() {
+    var psn = ProcessSerialNumber()
+    psn.highLongOfPSN = 7
+    psn.lowLongOfPSN = 9
+
+    let context = RestoreContext(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal",
+        previousPID: 42,
+        previousPSNHint: psn,
+        previousWindowIDHint: 314,
+        previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
+        capturedAt: 123.0,
+        generation: 5
+    )
+
+    #expect(context.targetBundleIdentifier == "com.apple.Safari")
+    #expect(context.previousBundleIdentifier == "com.apple.Terminal")
+    #expect(context.previousPID == 42)
+    #expect(context.previousPSNHint?.highLongOfPSN == 7)
+    #expect(context.previousPSNHint?.lowLongOfPSN == 9)
+    #expect(context.previousWindowIDHint == 314)
+    #expect(context.previousBundleURL?.path == "/Applications/Terminal.app")
+    #expect(context.capturedAt == 123.0)
+    #expect(context.generation == 5)
+}
+
+@Test @MainActor
+func toggleRuntimeConfigurationDefaultsToLegacyMode() {
+    let configuration = ToggleRuntimeConfiguration()
+
+    #expect(configuration.executionMode == .legacyOnly)
+    #expect(configuration.fastConfirmationWindow == 0.075)
+    #expect(configuration.contextPreparationConcurrencyLimit == 2)
+    #expect(configuration.fastLaneMissThreshold == 3)
+    #expect(configuration.fastLaneMissWindow == 600)
+    #expect(configuration.temporaryCompatibilityWindow == 300)
+}
+
+@Test @MainActor
+func runtimeInvariantsRejectSelfReferencingPreviousBundle() {
+    #expect(
+        normalizedPreviousBundle(
+            targetBundleIdentifier: "com.apple.Safari",
+            previousBundleIdentifier: "com.apple.Safari"
+        ) == nil
+    )
+    #expect(
+        normalizedPreviousBundle(
+            targetBundleIdentifier: "com.apple.Safari",
+            previousBundleIdentifier: "com.apple.Terminal"
+        ) == "com.apple.Terminal"
+    )
+    #expect(
+        normalizedPreviousBundle(
+            targetBundleIdentifier: "com.apple.Safari",
+            previousBundleIdentifier: nil
+        ) == nil
+    )
+}


### PR DESCRIPTION
## Summary
- add `RestoreContext` as the immutable toggle runtime restore snapshot
- add `ActivationCommand`, `ActivationCommandResult`, and `ActivationTimeoutBudget` with the spec-aligned names and timeout fields
- add `ToggleExecutionMode`, `ToggleRuntimeConfiguration`, a minimal `ToggleRuntime` shell, and the self-referencing previous-bundle normalization helper
- add focused `ToggleRuntimeTests` for restore context capture, legacy default mode, and self-reference normalization

## Why
Issue #87 is the first implementation slice of the toggle-off performance architecture. This PR lands the runtime foundation types and kill-switch surface without changing any current toggle-on or toggle-off behavior.

## Impact
- establishes the shared names and configuration surface that later runtime tasks will build on
- keeps `AppSwitcher` behavior unchanged in this slice
- constrains the change to the exact files and acceptance criteria called out by #87

## Validation
- `swift test --filter ToggleRuntimeTests`
- `swift test`

Closes #87
