### PR TITLE
[codex] perf: 引入 TapContextCache 并收拢 previousBundle source of truth

### DIFF
--- a/Sources/Quickey/Services/TapContextCache.swift
+++ b/Sources/Quickey/Services/TapContextCache.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+enum CacheInvalidationReason: String, Sendable, Equatable {
+    case sessionReset
+    case previousAppTerminated
+    case frontmostChanged
+    case sourceOfTruthMismatch
+}
+
+@MainActor
+final class TapContextCache {
+    struct Entry {
+        var restoreContext: RestoreContext
+        var fastLaneEligible: Bool
+        var fastLaneMissCount: Int
+        var fastLaneMissWindowStart: CFAbsoluteTime?
+        var temporaryCompatibilityUntil: CFAbsoluteTime?
+        var lastInvalidationReason: CacheInvalidationReason?
+    }
+
+    private var entries: [String: Entry] = [:]
+    private var invalidationReasons: [String: CacheInvalidationReason] = [:]
+
+    @discardableResult
+    func upsert(
+        targetBundleIdentifier: String,
+        coordinatorPreviousBundle: String?,
+        restoreContext: RestoreContext
+    ) -> Entry {
+        let normalizedPrevious = normalizedPreviousBundle(
+            targetBundleIdentifier: targetBundleIdentifier,
+            previousBundleIdentifier: coordinatorPreviousBundle
+        )
+        var entry = entries[targetBundleIdentifier] ?? Entry(
+            restoreContext: restoreContext,
+            fastLaneEligible: true,
+            fastLaneMissCount: 0,
+            fastLaneMissWindowStart: nil,
+            temporaryCompatibilityUntil: nil,
+            lastInvalidationReason: nil
+        )
+        entry.restoreContext = RestoreContext(
+            targetBundleIdentifier: restoreContext.targetBundleIdentifier,
+            previousBundleIdentifier: normalizedPrevious,
+            previousPID: restoreContext.previousPID,
+            previousPSNHint: restoreContext.previousPSNHint,
+            previousWindowIDHint: restoreContext.previousWindowIDHint,
+            previousBundleURL: restoreContext.previousBundleURL,
+            capturedAt: restoreContext.capturedAt,
+            generation: restoreContext.generation
+        )
+        entry.fastLaneEligible = entry.temporaryCompatibilityUntil == nil
+        entry.lastInvalidationReason = nil
+        entries[targetBundleIdentifier] = entry
+        invalidationReasons.removeValue(forKey: targetBundleIdentifier)
+        return entry
+    }
+
+    func markFastLaneMiss(
+        for targetBundleIdentifier: String,
+        now: CFAbsoluteTime,
+        threshold: Int,
+        window: TimeInterval,
+        quarantine: TimeInterval
+    ) {
+        guard var entry = entries[targetBundleIdentifier] else { return }
+
+        if let temporaryCompatibilityUntil = entry.temporaryCompatibilityUntil,
+           now >= temporaryCompatibilityUntil {
+            entry.temporaryCompatibilityUntil = nil
+            entry.fastLaneEligible = true
+            entry.fastLaneMissCount = 0
+            entry.fastLaneMissWindowStart = nil
+        }
+
+        if let windowStart = entry.fastLaneMissWindowStart,
+           now - windowStart <= window {
+            entry.fastLaneMissCount += 1
+        } else {
+            entry.fastLaneMissWindowStart = now
+            entry.fastLaneMissCount = 1
+        }
+
+        if entry.fastLaneMissCount >= threshold {
+            entry.fastLaneEligible = false
+            entry.temporaryCompatibilityUntil = now + quarantine
+        }
+
+        entries[targetBundleIdentifier] = entry
+    }
+
+    func invalidate(_ targetBundleIdentifier: String, reason: CacheInvalidationReason) {
+        invalidationReasons[targetBundleIdentifier] = reason
+
+        switch reason {
+        case .frontmostChanged:
+            guard var entry = entries[targetBundleIdentifier] else { return }
+            entry.fastLaneEligible = false
+            entry.lastInvalidationReason = reason
+            entries[targetBundleIdentifier] = entry
+        case .sessionReset, .previousAppTerminated, .sourceOfTruthMismatch:
+            entries.removeValue(forKey: targetBundleIdentifier)
+        }
+    }
+
+    func entry(for targetBundleIdentifier: String, now: CFAbsoluteTime) -> Entry? {
+        guard var entry = entries[targetBundleIdentifier] else { return nil }
+
+        if let temporaryCompatibilityUntil = entry.temporaryCompatibilityUntil,
+           now >= temporaryCompatibilityUntil {
+            entry.temporaryCompatibilityUntil = nil
+            entry.fastLaneEligible = true
+            entry.fastLaneMissCount = 0
+            entry.fastLaneMissWindowStart = nil
+            entries[targetBundleIdentifier] = entry
+        }
+
+        return entry
+    }
+
+    func lastInvalidationReason(for targetBundleIdentifier: String) -> CacheInvalidationReason? {
+        invalidationReasons[targetBundleIdentifier]
+    }
+}

--- a/Sources/Quickey/Services/ToggleSessionCoordinator.swift
+++ b/Sources/Quickey/Services/ToggleSessionCoordinator.swift
@@ -66,6 +66,10 @@ final class ToggleSessionCoordinator {
         session(for: bundleIdentifier)?.previousBundle
     }
 
+    func durablePreviousBundle(for bundleIdentifier: String) -> String? {
+        session(for: bundleIdentifier)?.previousBundle
+    }
+
     // MARK: - Mutations
 
     @discardableResult

--- a/Tests/QuickeyTests/TapContextCacheTests.swift
+++ b/Tests/QuickeyTests/TapContextCacheTests.swift
@@ -1,0 +1,143 @@
+import AppKit
+import Testing
+@testable import Quickey
+
+@Test @MainActor
+func coordinatorPreviousBundleWinsWhenCacheMirrorDrifts() {
+    let coordinator = ToggleSessionCoordinator(now: { 100 })
+    let cache = TapContextCache()
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: "com.apple.Terminal")
+
+    let staleContext = RestoreContext(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Finder",
+        previousPID: 42,
+        previousPSNHint: nil,
+        previousWindowIDHint: 314,
+        previousBundleURL: URL(fileURLWithPath: "/Applications/Finder.app"),
+        capturedAt: 100,
+        generation: 1
+    )
+
+    let entry = cache.upsert(
+        targetBundleIdentifier: "com.apple.Safari",
+        coordinatorPreviousBundle: coordinator.durablePreviousBundle(for: "com.apple.Safari"),
+        restoreContext: staleContext
+    )
+
+    #expect(entry.restoreContext.previousBundleIdentifier == "com.apple.Terminal")
+    #expect(cache.entry(for: "com.apple.Safari", now: 100)?.restoreContext.previousBundleIdentifier == "com.apple.Terminal")
+}
+
+@Test @MainActor
+func cacheInvalidatesWhenPreviousAppTerminates() {
+    let coordinator = ToggleSessionCoordinator(now: { 100 })
+    let cache = TapContextCache()
+
+    coordinator.beginActivation(for: "com.apple.Safari", previousBundle: "com.apple.Terminal")
+
+    let restoreContext = RestoreContext(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal",
+        previousPID: 42,
+        previousPSNHint: nil,
+        previousWindowIDHint: 314,
+        previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
+        capturedAt: 100,
+        generation: 1
+    )
+
+    cache.upsert(
+        targetBundleIdentifier: "com.apple.Safari",
+        coordinatorPreviousBundle: coordinator.durablePreviousBundle(for: "com.apple.Safari"),
+        restoreContext: restoreContext
+    )
+
+    cache.invalidate("com.apple.Safari", reason: .previousAppTerminated)
+
+    #expect(cache.entry(for: "com.apple.Safari", now: 101) == nil)
+    #expect(cache.lastInvalidationReason(for: "com.apple.Safari") == .previousAppTerminated)
+}
+
+@Test @MainActor
+func frontmostChangePreservesRestoreContextButDisablesFastLane() {
+    let cache = TapContextCache()
+    let restoreContext = RestoreContext(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal",
+        previousPID: 42,
+        previousPSNHint: nil,
+        previousWindowIDHint: 314,
+        previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
+        capturedAt: 100,
+        generation: 1
+    )
+
+    cache.upsert(
+        targetBundleIdentifier: "com.apple.Safari",
+        coordinatorPreviousBundle: "com.apple.Terminal",
+        restoreContext: restoreContext
+    )
+
+    cache.invalidate("com.apple.Safari", reason: .frontmostChanged)
+
+    let retainedEntry = cache.entry(for: "com.apple.Safari", now: 101)
+    #expect(retainedEntry?.restoreContext.previousBundleIdentifier == "com.apple.Terminal")
+    #expect(retainedEntry?.fastLaneEligible == false)
+    #expect(retainedEntry?.lastInvalidationReason == .frontmostChanged)
+    #expect(cache.lastInvalidationReason(for: "com.apple.Safari") == .frontmostChanged)
+}
+
+@Test @MainActor
+func threeFastLaneMissesEnterTemporaryCompatibilityWindow() {
+    let cache = TapContextCache()
+    let restoreContext = RestoreContext(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal",
+        previousPID: 42,
+        previousPSNHint: nil,
+        previousWindowIDHint: 314,
+        previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
+        capturedAt: 100,
+        generation: 1
+    )
+
+    cache.upsert(
+        targetBundleIdentifier: "com.apple.Safari",
+        coordinatorPreviousBundle: "com.apple.Terminal",
+        restoreContext: restoreContext
+    )
+
+    cache.markFastLaneMiss(
+        for: "com.apple.Safari",
+        now: 100,
+        threshold: 3,
+        window: 600,
+        quarantine: 300
+    )
+    cache.markFastLaneMiss(
+        for: "com.apple.Safari",
+        now: 120,
+        threshold: 3,
+        window: 600,
+        quarantine: 300
+    )
+    cache.markFastLaneMiss(
+        for: "com.apple.Safari",
+        now: 140,
+        threshold: 3,
+        window: 600,
+        quarantine: 300
+    )
+
+    let quarantinedEntry = cache.entry(for: "com.apple.Safari", now: 141)
+    #expect(quarantinedEntry?.temporaryCompatibilityUntil == 440)
+    #expect(quarantinedEntry?.fastLaneEligible == false)
+
+    let recoveredEntry = cache.entry(for: "com.apple.Safari", now: 441)
+    #expect(recoveredEntry?.temporaryCompatibilityUntil == nil)
+    #expect(recoveredEntry?.fastLaneEligible == true)
+    #expect(recoveredEntry?.fastLaneMissCount == 0)
+    #expect(recoveredEntry?.fastLaneMissWindowStart == nil)
+}


### PR DESCRIPTION
## Summary
- add `TapContextCache` as the runtime-only fast-lane context mirror for toggle-off
- keep `ToggleSessionCoordinator.previousBundle` as the durable source of truth via an explicit read helper
- add focused tests for source-of-truth drift, previous-app termination invalidation, frontmost-change degradation, and temporary compatibility quarantine

## Why
Issue #88 is about introducing the cache boundary needed for the future fast lane without turning the cache into a second source of truth. The restore target still has to come from the coordinator, while the cache only carries read-optimized hints and runtime-only compatibility state.

This branch also includes the CR follow-up that keeps cached restore context on `frontmostChanged` while disabling fast-lane eligibility, instead of dropping the entire entry.

## Impact
- mirror drift between cache and coordinator now resolves in favor of the coordinator
- previous app termination records `previousAppTerminated` and clears the cached entry
- repeated fast-lane misses can enter and later leave a temporary compatibility window in memory only
- frontmost changes degrade fast-lane eligibility without discarding the restore context immediately

## Validation
- `swift test --filter TapContextCacheTests`
- `swift test --filter ToggleRuntimeTests`
- `swift test --filter ToggleSessionCoordinatorTests`

## Notes
- Refs #88
- No macOS runtime behavior is claimed here; this PR covers unit-tested runtime foundations only
