### PR TITLE
[codex] Refine loop prompt automation policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Run automated Claude Code sessions to process issues and PRs:
 /loop 30m Follow the instructions in docs/loop-prompt.md
 ```
 
-Each iteration uses `/code-review` ([code-review plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review)) and bot reviews as PR-posted quality gates, plus `/codex:review` ([Codex Plugin CC](https://github.com/openai/codex-plugin-cc)) for session-local supplementary review. See [`docs/loop-job-guide.md`](./docs/loop-job-guide.md) for details.
+This loop is for session-local polling, not durable unattended automation. The v2 prompt performs per-iteration preflight checks, creates issue branches explicitly, records missing review tooling instead of assuming it ran, and defers merge until CI plus async bot reviews have settled. Quickey currently treats macOS runtime validation as a release-readiness gate rather than a per-PR merge blocker, so runtime-sensitive changes may merge during development but must carry `macOS runtime validation pending` until validated on macOS. See [`docs/loop-job-guide.md`](./docs/loop-job-guide.md) for details.
 
 ## Documentation
 - [`docs/README.md`](./docs/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,8 @@ This directory maps the maintainer-facing docs for Quickey.
 - [`lessons-learned.md`](./lessons-learned.md)
 
 ## Automation
-- [`loop-prompt.md`](./loop-prompt.md) — autonomous `/loop` iteration prompt
-- [`loop-job-guide.md`](./loop-job-guide.md) — how to run and manage loop jobs
+- [`loop-prompt.md`](./loop-prompt.md) — session-local `/loop` iteration prompt with preflight, branch bootstrap, and deferred merge gates
+- [`loop-job-guide.md`](./loop-job-guide.md) — how to run and manage loop jobs, plus when to prefer Desktop or Cloud scheduling
 
 ## Historical and Process Docs
 - [`archive/`](./archive/)

--- a/docs/loop-job-guide.md
+++ b/docs/loop-job-guide.md
@@ -14,17 +14,31 @@ This schedules a recurring task that fires every 30 minutes. Each iteration foll
 
 ## How /loop Works
 
-`/loop` is a built-in Claude Code skill that creates a cron-based scheduled task within the current session.
+`/loop` is a bundled Claude Code skill that creates a cron-based scheduled task within the current session.
 
 | Property | Value |
 |----------|-------|
 | Runs in | Current Claude Code session (interactive mode) |
-| Skills support | Full — `/code-review`, `/simplify`, `/codex:review`, etc. are available |
+| Commands and plugins | Inherits the current session's built-in commands, skills, and loaded plugins |
 | Minimum interval | 1 minute |
 | Priority | Low — runs between your turns, never interrupts |
 | Persistence | Session-scoped — gone when you exit |
 | Auto-expiry | 3 days after creation |
 | Max concurrent tasks | 50 |
+
+## Preflight and Prerequisites
+
+Before relying on the loop job:
+
+- Confirm Claude Code is new enough: `claude --version`
+- Confirm GitHub auth works: `gh auth status`
+- Confirm the repo starts in a safe git state: `git status --short --branch`
+- Confirm review tooling is actually available in the session:
+  - `/plugin` to inspect installed plugins
+  - `/reload-plugins` after installing or enabling anything
+  - `/code-review`, `/codex:review`, and `/simplify` should be treated as optional gates that must be present to run, not assumed silently
+
+The v2 prompt now performs this preflight inside each iteration as well, so missing tools become an explicit degraded state instead of an implicit pass.
 
 ### Interval syntax
 
@@ -38,14 +52,20 @@ Supported units: `s` (seconds, rounded to nearest minute), `m` (minutes), `h` (h
 
 ### Skills in /loop
 
-`/loop` runs prompts in interactive mode, so all skills work natively:
+`/loop` runs prompts in interactive mode, so built-in skills and any already-loaded plugin commands work natively:
 
 ```
 /loop 20m /code-review          # review PRs every 20 minutes
 /loop 1h /simplify              # simplify code every hour
 ```
 
-The prompt in `docs/loop-prompt.md` uses `/simplify` (pre-commit code quality), `/code-review` ([code-review plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review); posts findings as PR comments), and `/codex:review --base main --background` ([Codex Plugin CC](https://github.com/openai/codex-plugin-cc); session-local, retrieve with `/codex:status` + `/codex:result`).
+The prompt in `docs/loop-prompt.md` uses `/simplify` when available for pre-commit code quality, `/code-review` ([code-review plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review); posts findings as PR comments), and `/codex:review --base main --background` ([Codex Plugin CC](https://github.com/openai/codex-plugin-cc); session-local, retrieve with `/codex:status` + `/codex:result`). If any of those commands are unavailable in the current session, the prompt records the missing gate and defers merge rather than silently treating it as clean.
+
+The current Quickey policy is intentionally development-stage biased:
+
+- CI, review gates, and async bot feedback are the merge gate for `/loop`
+- Runtime-sensitive macOS validation is still tracked, but as a release-readiness gate rather than a per-PR merge blocker
+- Runtime-sensitive PRs must still carry an explicit `macOS runtime validation pending` note until they are validated on macOS
 
 ## Managing Tasks
 
@@ -61,8 +81,11 @@ Under the hood, Claude uses `CronList` and `CronDelete` tools.
 The task prompt (`docs/loop-prompt.md`) defines:
 
 1. **Safety constraints** — NEVER rules for dangerous operations
-2. **Workflow steps** — what to do each iteration (process PRs → select issue → implement → verify)
-3. **Review gates** — `/simplify` before commit, `/code-review` and `/codex:review --base main --background` after PR creation
+2. **Preflight** — version/auth/plugin/git-state checks before each iteration
+3. **Workflow steps** — process PRs → select issue → create branch → implement → verify
+4. **Review gates** — `/simplify` before commit, `/code-review` and `/codex:review --base main --background` after PR creation when available
+5. **Merge timing** — no merge in the same iteration that creates or updates a PR; async bot review and CI must settle first
+6. **Platform awareness** — non-macOS runs can complete automated verification; runtime-sensitive changes may still merge during development, but must carry `macOS runtime validation pending` until release validation is complete
 
 Keep prompts generic. Project-specific context belongs in `CLAUDE.md` / `AGENTS.md`.
 
@@ -73,4 +96,4 @@ Keep prompts generic. Project-specific context belongs in `CLAUDE.md` / `AGENTS.
 - **3-day expiry**: Recreate if needed for longer runs
 - **No custom error handling**: `/loop` has no exponential backoff or circuit breaker
 
-For durable scheduling that survives restarts, consider [Cloud scheduled tasks](https://code.claude.com/docs/en/web-scheduled-tasks) or [Desktop scheduled tasks](https://code.claude.com/docs/en/desktop#schedule-recurring-tasks).
+Use `/loop` for session-local polling and light autonomous maintenance while a session stays open. For recurring work that must survive restarts or run unattended for longer periods, prefer [Desktop scheduled tasks](https://code.claude.com/docs/en/desktop#schedule-recurring-tasks), [Cloud scheduled tasks](https://code.claude.com/docs/en/web-scheduled-tasks), or GitHub Actions.

--- a/docs/loop-prompt.md
+++ b/docs/loop-prompt.md
@@ -1,9 +1,10 @@
-You are an autonomous developer working on the Quickey project. No human is in the loop. All decisions, merges, and reviews are your responsibility within the safety constraints below.
+You are an autonomous developer working on the Quickey project inside a session-local `/loop` task. No human is expected to intervene during this iteration, but `/loop` is a polling tool, not a durable unattended scheduler. Work within the safety constraints below and leave clear breadcrumbs for the next iteration.
 
 ## Terminology
 
 - **NEXT ITERATION**: End the current iteration. Return control to the /loop scheduler. The next scheduled fire will start a fresh iteration.
 - **STOP LOOP**: Halt all work entirely. Only use this if a safety constraint is violated or the repository is in a broken state that you cannot recover from.
+- **Runtime-sensitive change**: Any change that touches event taps, app activation, permissions/TCC, Accessibility or Input Monitoring behavior, login items, launch behavior, packaging/signing, or other macOS-only runtime behavior that cannot be fully validated off macOS.
 
 ## Turn budget
 
@@ -22,8 +23,31 @@ Do NOT spend additional turns trying to finish. The next iteration will pick up 
 - NEVER run destructive commands (rm -rf, git reset --hard, git clean -f).
 - NEVER modify CI/CD workflows or GitHub Actions configs.
 - If an issue is ambiguous or requires architectural decisions, add label `arch-decision` and skip it.
+- NEVER merge a PR in the same iteration that created it or pushed new commits to it.
+- NEVER treat a missing review tool as a clean review. Missing tooling is a degraded gate that must be recorded explicitly.
+- NEVER claim macOS runtime correctness from non-macOS verification alone.
+- Development-stage merges may rely on CI and review gates. macOS runtime validation is a release-readiness gate, not a per-PR merge blocker.
 
 ## Each iteration
+
+### Step 0: Preflight
+
+Before touching PRs or issues, verify that this session is safe to use:
+
+1. Check tool and host readiness:
+   - `claude --version`
+   - `gh auth status`
+   - `uname -s`
+   - `git status --short --branch`
+2. Confirm the repo is in a safe git state:
+   - If the worktree has unrelated uncommitted changes, or the current state cannot be understood safely, do not mix new work into it.
+   - If the checkout is detached HEAD, that is acceptable only as a state to recover from before starting new issue work.
+3. Confirm review tooling availability before relying on it:
+   - If needed, use `/plugin` to inspect installed plugins and `/reload-plugins` once after installing or enabling anything.
+   - Determine whether `/simplify`, `/code-review`, and `/codex:review` are available in this session.
+   - If one is unavailable, treat that gate as unavailable rather than clean. Record the missing tool in the relevant PR or issue comment before proceeding past that gate.
+
+If `gh auth status` fails, Claude Code is too old for `/loop`, or the repo state cannot be made safe, leave a short comment where appropriate and **STOP LOOP**.
 
 ### Step 1: Process existing PRs (PRs before new issues)
 
@@ -44,6 +68,7 @@ For each open PR, process in order: **1b → 1c → 1a** (fix CI first, then add
   - Add label `needs-human-review`: `gh pr edit <number> --add-label needs-human-review`
   - Comment on the PR describing the failure and what you tried.
   - Move on to the next PR.
+- If you push a CI fix, leave the PR open for a later iteration. Do not merge in the same iteration as the push.
 
 #### 1c. PRs with review feedback
 
@@ -56,9 +81,11 @@ Handling rules:
 - Read PR comments for `/code-review` and bot review findings: `gh pr view <number> --comments`
 - For `/codex:review`: check session memory for findings from prior iterations (session context persists across `/loop` firings).
 - To run `/codex:review` on an existing PR: checkout the branch first, then run `/codex:review --base main --background`. Use `/codex:status` to check progress and `/codex:result` to retrieve findings.
+- If `/code-review` is unavailable, comment on the PR that the `/code-review` gate was unavailable in this session and leave the PR open.
+- If `/codex:review` is unavailable, comment on the PR that the `/codex:review` gate was unavailable in this session and leave the PR open.
 - **High-confidence `/code-review` findings (≥80)**, **P0/P1 bot findings**, and **critical `/codex:review` findings**: treat as must-fix. Address them and push fixes.
 - **P2+ bot findings** and **minor `/codex:review` findings**: evaluate — fix if straightforward, otherwise note in a reply comment explaining why it was skipped (e.g., false positive, out of scope).
-- After fixing, run `/code-review` and `/codex:review --base main --background` once more. If new high-confidence issues appear that you cannot resolve in **2 attempts**:
+- After fixing, re-run each available review tool once more. If new high-confidence issues appear that you cannot resolve in **2 attempts**:
   - Add label `needs-human-review`.
   - Comment describing unresolved findings.
   - Move on.
@@ -72,9 +99,14 @@ A PR is eligible for auto-merge when ALL of these are true:
 - No unresolved high-confidence `/code-review` findings (≥80) on the PR
 - No unresolved P0/P1 bot review findings (e.g., Codex Review) on the PR
 - No unresolved critical `/codex:review` findings in session memory
+- The PR was not created in this iteration and has not received a push in this iteration
+- All asynchronous bot reviews expected for the latest head commit have already landed, or there is explicit evidence on the PR that no further bot review is pending
+- If the change is runtime-sensitive, the PR or linked issue explicitly records one of these statuses: `macOS runtime validation complete` or `macOS runtime validation pending`
+- No required review gate is currently unavailable for the latest head commit
 - The PR does NOT have label `needs-human-review` or `arch-decision`
 
 If eligible: merge with `gh pr merge <number> --squash --delete-branch` and proceed to the next PR.
+If CI is pending, bot review has not landed yet, or review tooling was unavailable, leave the PR open for a later iteration.
 
 ### Step 2: Select next issue
 
@@ -90,7 +122,18 @@ Selection rules:
 
 If no eligible issues exist, proceed to **NEXT ITERATION**.
 
-### Step 3: Classify and implement (two-round strategy)
+### Step 3: Create or switch to the issue branch
+
+Before editing files for the selected issue:
+
+1. Refresh the base branch:
+   - `git fetch origin`
+   - `git checkout main`
+   - `git pull --ff-only`
+2. Create and switch to a feature branch named `loop/issue-<number>-<slug>`.
+3. If branch creation or switching fails, comment on the issue describing the git state and proceed to **NEXT ITERATION**.
+
+### Step 4: Classify and implement (two-round strategy)
 
 Check your remaining turn budget before starting implementation. If fewer than 10 turns remain, comment on the issue that implementation is deferred due to turn budget, and proceed to **NEXT ITERATION**.
 
@@ -98,22 +141,29 @@ Check your remaining turn budget before starting implementation. If fewer than 1
 - **Complex issues** (multi-file architecture change, new public API, estimated 200+ lines):
   - If no plan exists: write a plan to `docs/superpowers/plans/<topic>.md`, comment on the issue linking the plan, and proceed to **NEXT ITERATION**. Do not start implementation in the same iteration as planning.
   - If a plan exists: implement ONE sub-task from the plan. Do not attempt the entire plan in a single iteration.
+- If the change is runtime-sensitive and the current host is not macOS, you may still implement, review, and merge after automated checks, but you must carry forward a `macOS runtime validation pending` note on the issue and PR.
 
-### Step 4: Verify and submit
+### Step 5: Verify and submit
 
-#### 4a. Build and test
+#### 5a. Build and test
 
-Run the full CI check locally:
+Detect the host first with `uname -s`.
+
+- On macOS, run the full CI check locally:
 ```bash
 swift build && swift test && swift build -c release
 ```
-- **Max 3 fix-build-test cycles.** If build or tests still fail after 3 attempts, comment on the issue describing the failure, switch back to main (`git checkout main`), and proceed to **NEXT ITERATION**.
+- On non-macOS hosts, run the same automated verification that is available, but treat it as automated coverage only, not runtime validation.
+- If the diff is runtime-sensitive and the current host is not macOS, comment on the issue with the exact phrase `macOS runtime validation pending` before creating or updating the PR.
+- If the diff is runtime-sensitive and the current host is macOS and you actually performed the runtime checks, comment with `macOS runtime validation complete`.
+- **Max 3 fix-build-test cycles.** If build or tests still fail after 3 attempts, comment on the issue describing the failure and proceed to **NEXT ITERATION**.
 
-#### 4b. Code quality
+#### 5b. Code quality
 
-Run `/simplify` to review code quality before committing. Address any issues found in a single pass. Do not loop on `/simplify`.
+- If `/simplify` is available, run it once before committing. Address any issues found in a single pass. Do not loop on `/simplify`.
+- If `/simplify` is unavailable, note that explicitly in the PR body or a PR comment. Do not claim that gate ran.
 
-#### 4c. Commit and create PR
+#### 5c. Commit and create PR
 
 Commit your changes, push the branch, and create the PR with explicit flags:
 
@@ -126,37 +176,47 @@ gh pr create \
 ## Summary
 <1-3 bullet points describing what changed and why>
 
-## Test plan
-- CI: swift build, swift test, swift build -c release, package-app.sh" \
+## Verification
+- Automated: swift build, swift test, swift build -c release
+- Platform: macOS runtime validation complete | macOS runtime validation pending
+- Review tooling: /simplify <ran|unavailable>, /code-review <ran|unavailable>, /codex:review <ran|unavailable>" \
   --base main
 ```
 
-#### 4d. Review gate (bounded)
+If the issue or diff is runtime-sensitive, ensure the issue and PR both explicitly state either `macOS runtime validation pending` or `macOS runtime validation complete`.
+
+#### 5d. Review gate (bounded)
 
 Run **three review passes** on the PR you just created:
 
-1. `/code-review` — [code-review plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review) (posts findings as PR comments; confidence ≥80 threshold)
-2. `/codex:review --base main --background` — [Codex Plugin CC](https://github.com/openai/codex-plugin-cc) delegated review against main (session-local; check `/codex:status`, retrieve with `/codex:result`)
+1. `/code-review` — if available. If unavailable, note the missing gate on the PR and leave the PR open.
+2. `/codex:review --base main --background` — if available. If unavailable, note the missing gate on the PR and leave the PR open.
 3. Bot reviews (`@chatgpt-codex-connector[bot]`) may arrive asynchronously — if not yet available, they will be handled in Step 1c of a future iteration
 
 Then:
 
-- **Round 1**: If `/code-review` or `/codex:review` reports high-confidence / critical issues, fix them and push. Re-run `/code-review` and `/codex:review --base main --background`.
+- **Round 1**: If an available review tool reports high-confidence or critical issues, fix them and push. Re-run each available review tool once.
 - **Round 2**: If issues persist after fixes:
   - If you can resolve them in 1-2 more changes, do so and push. Do NOT run a third round.
   - If the issues are architectural or unclear, add label `needs-human-review` and comment on the PR with the unresolved findings.
 
 Maximum of **2 invocations per review tool** (`/code-review`, `/codex:review`) **per PR per iteration**. No exceptions.
+After any push in this review gate, leave the PR open for a later iteration so CI and async bot reviews can settle.
 
-#### 4e. Auto-merge gate
+#### 5e. Auto-merge gate
 
-After the review gate, evaluate whether to merge:
+Do not merge a PR created or updated in this iteration.
 
-- **Merge now** if: CI passes AND no unresolved high-confidence `/code-review` findings on the PR AND no unresolved critical `/codex:review` findings in session memory. (Bot review findings may not yet be available on a newly created PR — they will be checked in Step 1a of a future iteration.)
-  ```
-  gh pr merge <number> --squash --delete-branch
-  ```
-- **Defer** if: the PR has label `needs-human-review` or CI is still pending/failing. Leave it open for the next iteration or human attention.
+- Newly created PRs and PRs that received a push in this iteration must remain open.
+- Existing PRs may be merged only in Step 1a of a later iteration after CI and async bot reviews have settled. Runtime-sensitive changes may merge with `macOS runtime validation pending`, but that note must remain visible until release validation closes it out.
+
+### Release-readiness note
+
+`/loop` is allowed to optimize for development throughput. It is not allowed to erase release obligations.
+
+- Runtime-sensitive changes may merge before macOS runtime validation is complete.
+- Before any release, packaging/signing handoff, or release-candidate signoff, all open `macOS runtime validation pending` items must be validated on macOS and updated to `macOS runtime validation complete`.
+- Never rewrite history or PR descriptions to imply a pending runtime validation was completed when it was not.
 
 Proceed to **NEXT ITERATION**.
 


### PR DESCRIPTION
## Summary
- tighten the `/loop` docs around preflight, explicit issue-branch creation, and deferred same-iteration merges
- make review tooling availability explicit so missing plugin gates are recorded instead of being treated as implicit passes
- document the development-stage policy that allows CI-first merges while carrying `macOS runtime validation pending` through to release validation

## Why
The previous loop prompt mixed durable and session-local assumptions, had no branch bootstrap for issue work, and allowed ambiguity around plugin availability and macOS validation policy.

## Impact
Maintainers now have a clearer session-local `/loop` workflow with safer PR timing, explicit degraded-tooling behavior, and a documented distinction between development merge gates and release-readiness validation.

## Checks
- `git diff --check`
- verified the updated wording with `git diff`
- verified key policy phrases with `rg`
