### PR TITLE
refactor: replace loop-prompt with babysit-prs skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,15 @@ If a change cannot be verified on Linux, document what must be verified on macOS
 - End-to-end shortcut testing on macOS: `osascript` key events penetrate session-level event taps; `cliclick` does not. Use `osascript -e 'tell application "System Events" to key code ...'` for E2E validation of the full event tap → match → toggle pipeline.
 - `kCGKeyboardEventAutorepeat` (Apple SDK: "non-zero when this is an autorepeat of a key-down") must be filtered in the event tap callback to prevent held-key loops.
 
+## macOS runtime validation policy
+
+Runtime-sensitive changes = event taps, app activation, permissions/TCC, Accessibility/Input Monitoring, login items, launch behavior, packaging/signing.
+
+- Development merges may rely on CI + review gates alone
+- Runtime-sensitive PRs must carry `macOS runtime validation pending` until validated on macOS, then update to `macOS runtime validation complete`
+- Release-candidate signoff requires all pending items validated
+- Never rewrite history to imply pending validation was completed
+
 ## Investigation before implementation
 
 - Do not change code before you understand the failure mode or behavior gap.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ swift test
 Run automated Claude Code sessions to process issues and PRs:
 
 ```
-/loop 30m Follow the instructions in docs/loop-prompt.md
+/loop 30m /babysit-prs
 ```
 
-Each iteration uses `/code-review` ([code-review plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review)) and bot reviews as PR-posted quality gates, plus `/codex:review` ([Codex Plugin CC](https://github.com/openai/codex-plugin-cc)) for session-local supplementary review. See [`docs/loop-job-guide.md`](./docs/loop-job-guide.md) for details.
+Each iteration runs preflight checks, processes open PRs, selects an issue, implements with review gates, and defers merge until CI and async reviews settle. See [`docs/loop-job-guide.md`](./docs/loop-job-guide.md) for details.
 
 ## Documentation
 - [`docs/README.md`](./docs/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,8 @@ This directory maps the maintainer-facing docs for Quickey.
 - [`lessons-learned.md`](./lessons-learned.md)
 
 ## Automation
-- [`loop-prompt.md`](./loop-prompt.md) — autonomous `/loop` iteration prompt
-- [`loop-job-guide.md`](./loop-job-guide.md) — how to run and manage loop jobs
+- [`loop-prompt.md`](./loop-prompt.md) — reference and migration note; active automation is the `/babysit-prs` skill
+- [`loop-job-guide.md`](./loop-job-guide.md) — how to run and manage loop jobs with `/loop 30m /babysit-prs`
 
 ## Historical and Process Docs
 - [`archive/`](./archive/)

--- a/docs/loop-job-guide.md
+++ b/docs/loop-job-guide.md
@@ -7,45 +7,60 @@ How to run automated Claude Code sessions for recurring project work using `/loo
 In a Claude Code interactive session, run:
 
 ```
-/loop 30m Follow the instructions in docs/loop-prompt.md
+/loop 30m /babysit-prs
 ```
 
-This schedules a recurring task that fires every 30 minutes. Each iteration follows the workflow defined in `docs/loop-prompt.md`.
+This schedules a recurring task that fires every 30 minutes. Each iteration follows the pipeline defined in the `babysit-prs` skill (`~/.claude/skills/babysit-prs/SKILL.md`).
 
 ## How /loop Works
 
-`/loop` is a built-in Claude Code skill that creates a cron-based scheduled task within the current session.
+`/loop` is a bundled Claude Code skill that creates a cron-based scheduled task within the current session.
 
 | Property | Value |
 |----------|-------|
 | Runs in | Current Claude Code session (interactive mode) |
-| Skills support | Full — `/code-review`, `/simplify`, `/codex:review`, etc. are available |
+| Commands and plugins | Inherits the current session's built-in commands, skills, and loaded plugins |
 | Minimum interval | 1 minute |
 | Priority | Low — runs between your turns, never interrupts |
 | Persistence | Session-scoped — gone when you exit |
 | Auto-expiry | 3 days after creation |
 | Max concurrent tasks | 50 |
 
+## Preflight and Prerequisites
+
+Before relying on the loop job:
+
+- Confirm Claude Code is new enough: `claude --version`
+- Confirm GitHub auth works: `gh auth status`
+- Confirm the repo starts in a safe git state: `git status --short --branch`
+- Confirm review tooling is available in the session:
+  - `/plugin` to inspect installed plugins
+  - `/reload-plugins` after installing or enabling anything
+  - `/code-review`, `/codex:review`, and `/simplify` should be treated as optional gates that must be present to run, not assumed silently
+
+The `babysit-prs` skill performs a Session Init check on its first iteration and caches tool availability for the session.
+
 ### Interval syntax
 
 ```
-/loop 30m <prompt>              # leading interval
-/loop <prompt> every 2 hours    # trailing interval
-/loop <prompt>                  # defaults to 10 minutes
+/loop 30m /babysit-prs             # leading interval
+/loop /babysit-prs every 2 hours   # trailing interval
+/loop /babysit-prs                 # defaults to 10 minutes
 ```
 
 Supported units: `s` (seconds, rounded to nearest minute), `m` (minutes), `h` (hours), `d` (days).
 
 ### Skills in /loop
 
-`/loop` runs prompts in interactive mode, so all skills work natively:
+`/loop` runs prompts in interactive mode, so built-in skills and any already-loaded plugin commands work natively:
 
 ```
 /loop 20m /code-review          # review PRs every 20 minutes
 /loop 1h /simplify              # simplify code every hour
+/loop 30m /babysit-prs          # full autonomous PR/issue pipeline
 ```
 
-The prompt in `docs/loop-prompt.md` uses `/simplify` (pre-commit code quality), `/code-review` ([code-review plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review); posts findings as PR comments), and `/codex:review --base main --background` ([Codex Plugin CC](https://github.com/openai/codex-plugin-cc); session-local, retrieve with `/codex:status` + `/codex:result`).
+The `babysit-prs` skill uses `/simplify` when available for pre-commit code quality, `/code-review` ([code-review plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review); posts findings as PR comments), and `/codex:review --base main --background` ([Codex Plugin CC](https://github.com/openai/codex-plugin-cc); session-local, retrieve with `/codex:status` + `/codex:result`). If any of those commands are unavailable in the current session, the skill records the missing gate and defers merge rather than silently treating it as clean.
 
 ## Managing Tasks
 
@@ -56,15 +71,31 @@ cancel the loop job                # cancel by description
 
 Under the hood, Claude uses `CronList` and `CronDelete` tools.
 
-## Prompt Design
+## Skill Design
 
-The task prompt (`docs/loop-prompt.md`) defines:
+The `babysit-prs` skill uses progressive disclosure:
 
-1. **Safety constraints** — NEVER rules for dangerous operations
-2. **Workflow steps** — what to do each iteration (process PRs → select issue → implement → verify)
-3. **Review gates** — `/simplify` before commit, `/code-review` and `/codex:review --base main --background` after PR creation
+1. **`SKILL.md`** — main pipeline: safety constraints, iteration guard, session init, workflow steps (process PRs → select issue → create branch → implement → verify)
+2. **`references/review-gates.md`** — three-tier review tool behavior, confidence thresholds, degraded-tooling handling
+3. **`references/macos-runtime-policy.md`** — runtime-sensitive change definition, `macOS runtime validation pending/complete` tracking, merge vs release gate
 
-Keep prompts generic. Project-specific context belongs in `CLAUDE.md` / `AGENTS.md`.
+Keep the skill generic. Project-specific context belongs in `CLAUDE.md` / `AGENTS.md`.
+
+## Development-Stage Policy
+
+The current Quickey policy is intentionally development-stage biased:
+
+- CI, review gates, and async bot feedback are the merge gate for `/loop`
+- Runtime-sensitive macOS validation is tracked but as a release-readiness gate, not a per-PR merge blocker
+- Runtime-sensitive PRs must carry `macOS runtime validation pending` until validated on macOS (see `AGENTS.md` § macOS runtime validation policy)
+
+## Release-Readiness Note
+
+`/loop` is allowed to optimize for development throughput. It is not allowed to erase release obligations.
+
+- Runtime-sensitive changes may merge before macOS runtime validation is complete.
+- Before any release, packaging/signing handoff, or release-candidate signoff, all open `macOS runtime validation pending` items must be validated on macOS and updated to `macOS runtime validation complete`.
+- Never rewrite history or PR descriptions to imply a pending runtime validation was completed when it was not.
 
 ## Limitations
 
@@ -73,4 +104,4 @@ Keep prompts generic. Project-specific context belongs in `CLAUDE.md` / `AGENTS.
 - **3-day expiry**: Recreate if needed for longer runs
 - **No custom error handling**: `/loop` has no exponential backoff or circuit breaker
 
-For durable scheduling that survives restarts, consider [Cloud scheduled tasks](https://code.claude.com/docs/en/web-scheduled-tasks) or [Desktop scheduled tasks](https://code.claude.com/docs/en/desktop#schedule-recurring-tasks).
+Use `/loop` for session-local polling and light autonomous maintenance while a session stays open. For recurring work that must survive restarts or run unattended for longer periods, prefer [Desktop scheduled tasks](https://code.claude.com/docs/en/desktop#schedule-recurring-tasks), [Cloud scheduled tasks](https://code.claude.com/docs/en/web-scheduled-tasks), or GitHub Actions.

--- a/docs/loop-prompt.md
+++ b/docs/loop-prompt.md
@@ -1,165 +1,25 @@
-You are an autonomous developer working on the Quickey project. No human is in the loop. All decisions, merges, and reviews are your responsibility within the safety constraints below.
+# Loop Automation Prompt
 
-## Terminology
+This file is retained for reference. The active loop automation is now delivered as a skill: `/babysit-prs`.
 
-- **NEXT ITERATION**: End the current iteration. Return control to the /loop scheduler. The next scheduled fire will start a fresh iteration.
-- **STOP LOOP**: Halt all work entirely. Only use this if a safety constraint is violated or the repository is in a broken state that you cannot recover from.
-
-## Turn budget
-
-Each iteration has a budget of **25 turns**. Track your approximate turn count. If you reach 25 turns without completing the current step:
-1. Comment on the issue or PR describing what remains and what blocked progress.
-2. Proceed to **NEXT ITERATION**.
-
-Do NOT spend additional turns trying to finish. The next iteration will pick up where you left off.
-
-## Safety constraints
-
-- NEVER push directly to main branch. Always work on feature branches.
-- NEVER delete branches unless they have been merged. Clean up merged branches after PR merge.
-- NEVER modify CLAUDE.md or AGENTS.md core rules and architecture sections.
-- You MAY append new entries to docs/lessons-learned.md when discovering operational insights.
-- NEVER run destructive commands (rm -rf, git reset --hard, git clean -f).
-- NEVER modify CI/CD workflows or GitHub Actions configs.
-- If an issue is ambiguous or requires architectural decisions, add label `arch-decision` and skip it.
-
-## Each iteration
-
-### Step 1: Process existing PRs (PRs before new issues)
-
-Query open PRs:
-```
-gh pr list --state open --json number,title,headRefName,statusCheckRollup,labels,reviews
-```
-
-Process each PR using the rules below. Spend at most **2 PRs** per iteration to avoid consuming the entire turn budget on PR maintenance.
-
-For each open PR, process in order: **1b → 1c → 1a** (fix CI first, then address reviews, then evaluate merge eligibility).
-
-#### 1b. PRs with CI failures
-
-- Check the failure: `gh pr checks <number>`
-- Attempt to fix the failure (checkout the branch, diagnose, push a fix).
-- **Max 2 fix attempts per PR per iteration.** If CI still fails after 2 attempts:
-  - Add label `needs-human-review`: `gh pr edit <number> --add-label needs-human-review`
-  - Comment on the PR describing the failure and what you tried.
-  - Move on to the next PR.
-
-#### 1c. PRs with review feedback
-
-PRs may have feedback from three sources:
-- **`/code-review` comments** ([code-review plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review)) — posts PR comments with confidence-scored findings (≥80 threshold); readable via `gh pr view <number> --comments`
-- **Bot reviews** (e.g., `@chatgpt-codex-connector[bot]` Codex Review) — these post PR comments with priority-tagged findings like `P0`, `P1`, `P2`
-- **`/codex:review` findings** ([Codex Plugin CC](https://github.com/openai/codex-plugin-cc)) — session-local delegated review via OpenAI Codex (results live in session memory, not on the PR)
-
-Handling rules:
-- Read PR comments for `/code-review` and bot review findings: `gh pr view <number> --comments`
-- For `/codex:review`: check session memory for findings from prior iterations (session context persists across `/loop` firings).
-- To run `/codex:review` on an existing PR: checkout the branch first, then run `/codex:review --base main --background`. Use `/codex:status` to check progress and `/codex:result` to retrieve findings.
-- **High-confidence `/code-review` findings (≥80)**, **P0/P1 bot findings**, and **critical `/codex:review` findings**: treat as must-fix. Address them and push fixes.
-- **P2+ bot findings** and **minor `/codex:review` findings**: evaluate — fix if straightforward, otherwise note in a reply comment explaining why it was skipped (e.g., false positive, out of scope).
-- After fixing, run `/code-review` and `/codex:review --base main --background` once more. If new high-confidence issues appear that you cannot resolve in **2 attempts**:
-  - Add label `needs-human-review`.
-  - Comment describing unresolved findings.
-  - Move on.
-- Maximum of **2 invocations per review tool** (`/code-review`, `/codex:review`) **per PR per iteration**.
-- Do NOT merge PRs that have `needs-human-review` or `arch-decision` labels.
-
-#### 1a. PRs ready to auto-merge
-
-A PR is eligible for auto-merge when ALL of these are true:
-- CI status checks pass (all checks in `statusCheckRollup` are `SUCCESS` or `NEUTRAL`)
-- No unresolved high-confidence `/code-review` findings (≥80) on the PR
-- No unresolved P0/P1 bot review findings (e.g., Codex Review) on the PR
-- No unresolved critical `/codex:review` findings in session memory
-- The PR does NOT have label `needs-human-review` or `arch-decision`
-
-If eligible: merge with `gh pr merge <number> --squash --delete-branch` and proceed to the next PR.
-
-### Step 2: Select next issue
+## Usage
 
 ```
-gh issue list --state open --json number,title,labels,body --limit 50
+/loop 30m /babysit-prs
 ```
 
-Selection rules:
-- Prioritize: P0-critical > P1-high > P2-medium > P3-low > unlabeled
-- Skip issues with label `arch-decision`
-- Skip issues that already have an open PR linked (check with `gh pr list --search "Closes #<number>"`)
-- Pick **ONE** issue per iteration
+The skill lives at `~/.claude/skills/babysit-prs/SKILL.md` and uses progressive disclosure:
 
-If no eligible issues exist, proceed to **NEXT ITERATION**.
+- `SKILL.md` — main pipeline: safety constraints, iteration guard, workflow steps
+- `references/review-gates.md` — three-tier review tool behavior and degraded-tooling rules
+- `references/macos-runtime-policy.md` — runtime-sensitive change tracking policy
 
-### Step 3: Classify and implement (two-round strategy)
+## Why a Skill Instead of This File
 
-Check your remaining turn budget before starting implementation. If fewer than 10 turns remain, comment on the issue that implementation is deferred due to turn budget, and proceed to **NEXT ITERATION**.
+The original `loop-prompt.md` was passed as raw text to CronCreate, causing:
 
-- **Simple issues** (single-file change, bug fix, docs update): Implement with TDD directly in this iteration.
-- **Complex issues** (multi-file architecture change, new public API, estimated 200+ lines):
-  - If no plan exists: write a plan to `docs/superpowers/plans/<topic>.md`, comment on the issue linking the plan, and proceed to **NEXT ITERATION**. Do not start implementation in the same iteration as planning.
-  - If a plan exists: implement ONE sub-task from the plan. Do not attempt the entire plan in a single iteration.
+1. **Prompt duplication**: CronCreate repeated the 1,300-word prompt 5 times in a single fire (see `docs/lessons-learned.md`)
+2. **Silent tool skips**: Missing review plugins were treated as clean passes instead of degraded gates
+3. **Prompt bloat**: PR #107's improvements grew the prompt 55%, worsening the duplication issue
 
-### Step 4: Verify and submit
-
-#### 4a. Build and test
-
-Run the full CI check locally:
-```bash
-swift build && swift test && swift build -c release
-```
-- **Max 3 fix-build-test cycles.** If build or tests still fail after 3 attempts, comment on the issue describing the failure, switch back to main (`git checkout main`), and proceed to **NEXT ITERATION**.
-
-#### 4b. Code quality
-
-Run `/simplify` to review code quality before committing. Address any issues found in a single pass. Do not loop on `/simplify`.
-
-#### 4c. Commit and create PR
-
-Commit your changes, push the branch, and create the PR with explicit flags:
-
-```bash
-git push -u origin HEAD
-gh pr create \
-  --title "<concise title under 70 chars>" \
-  --body "Closes #<N>
-
-## Summary
-<1-3 bullet points describing what changed and why>
-
-## Test plan
-- CI: swift build, swift test, swift build -c release, package-app.sh" \
-  --base main
-```
-
-#### 4d. Review gate (bounded)
-
-Run **three review passes** on the PR you just created:
-
-1. `/code-review` — [code-review plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review) (posts findings as PR comments; confidence ≥80 threshold)
-2. `/codex:review --base main --background` — [Codex Plugin CC](https://github.com/openai/codex-plugin-cc) delegated review against main (session-local; check `/codex:status`, retrieve with `/codex:result`)
-3. Bot reviews (`@chatgpt-codex-connector[bot]`) may arrive asynchronously — if not yet available, they will be handled in Step 1c of a future iteration
-
-Then:
-
-- **Round 1**: If `/code-review` or `/codex:review` reports high-confidence / critical issues, fix them and push. Re-run `/code-review` and `/codex:review --base main --background`.
-- **Round 2**: If issues persist after fixes:
-  - If you can resolve them in 1-2 more changes, do so and push. Do NOT run a third round.
-  - If the issues are architectural or unclear, add label `needs-human-review` and comment on the PR with the unresolved findings.
-
-Maximum of **2 invocations per review tool** (`/code-review`, `/codex:review`) **per PR per iteration**. No exceptions.
-
-#### 4e. Auto-merge gate
-
-After the review gate, evaluate whether to merge:
-
-- **Merge now** if: CI passes AND no unresolved high-confidence `/code-review` findings on the PR AND no unresolved critical `/codex:review` findings in session memory. (Bot review findings may not yet be available on a newly created PR — they will be checked in Step 1a of a future iteration.)
-  ```
-  gh pr merge <number> --squash --delete-branch
-  ```
-- **Defer** if: the PR has label `needs-human-review` or CI is still pending/failing. Leave it open for the next iteration or human attention.
-
-Proceed to **NEXT ITERATION**.
-
----
-
-One issue per iteration. Keep PRs small and focused.
+The skill approach solves all three: CronCreate stores only `/babysit-prs` (a few characters), the skill content loads on demand, and progressive disclosure keeps the main pipeline concise while policy details live in `references/`.


### PR DESCRIPTION
Supersedes #107

## Summary
- Replace `docs/loop-prompt.md` (1,323-word raw CronCreate prompt) with a `/babysit-prs` skill (`~/.claude/skills/babysit-prs/`)
- CronCreate now stores only `/babysit-prs` — eliminates prompt duplication issue (commit f43e839 lesson)
- Skill uses progressive disclosure: `SKILL.md` (main pipeline) + `references/review-gates.md` + `references/macos-runtime-policy.md`
- Add `macOS runtime validation policy` section to AGENTS.md
- Absorb PR #107's key improvements: iteration guard, same-iteration merge prevention, degraded tooling recording, explicit branch creation, review parallelization

## Motivation
Three issues drove this change:
1. **Prompt dedup**: CronCreate sent the 1,323-word prompt 5x in a single fire
2. **Silent tool skips**: `/codex:review` was silently skipped when the plugin wasn't installed
3. **Prompt bloat**: PR #107's fixes grew the prompt 55%, worsening issue 1

## Test plan
- Invoke `/babysit-prs` in a Claude Code session to verify skill loads correctly
- Run `/loop 30m /babysit-prs` to confirm CronCreate stores only the short skill reference
- `swift build && swift test` (docs-only change, no code impact)