### PR TITLE
feat: implement ObservationBroker cheap confirmation (#90)

### DIFF
--- a/Sources/Quickey/Services/ObservationBroker.swift
+++ b/Sources/Quickey/Services/ObservationBroker.swift
@@ -1,0 +1,121 @@
+import AppKit
+
+@MainActor
+final class ObservationBroker {
+    struct ConfirmationResult: Equatable, Sendable {
+        let confirmed: Bool
+        let usedEscalatedObservation: Bool
+        let frontmostBundleAfterRestore: String?
+    }
+
+    struct Client {
+        let frontmostBundleIdentifier: () -> String?
+        let targetIsHidden: () -> Bool
+        let targetIsActive: () -> Bool
+        let targetClassification: () -> ApplicationClassification
+        let escalatedSnapshot: () -> ActivationObservationSnapshot
+        let now: () -> CFAbsoluteTime
+        let pollOnce: (TimeInterval) -> Void
+    }
+
+    private let client: Client
+    private let confirmationWindow: TimeInterval
+    private let pollInterval: TimeInterval
+
+    init(client: Client, confirmationWindow: TimeInterval = 0.075, pollInterval: TimeInterval = 0.01) {
+        self.client = client
+        self.confirmationWindow = confirmationWindow
+        self.pollInterval = pollInterval
+    }
+
+    // MARK: - Fast lane confirmation
+
+    func confirmFastRestore(
+        targetBundleIdentifier: String,
+        previousBundleIdentifier: String?
+    ) -> ConfirmationResult {
+        // 1. Immediate cheap check
+        let initialFrontmost = client.frontmostBundleIdentifier()
+        if initialFrontmost != nil, initialFrontmost != targetBundleIdentifier {
+            return ConfirmationResult(
+                confirmed: true,
+                usedEscalatedObservation: false,
+                frontmostBundleAfterRestore: initialFrontmost
+            )
+        }
+
+        // 2. Non-regular classifications skip cheap confirmation → escalate immediately
+        let classification = client.targetClassification()
+        switch classification {
+        case .systemUtility, .nonStandardWindowed, .windowlessOrAccessory:
+            return escalateToObservation()
+        case .regularWindowed:
+            break
+        }
+
+        // 3. Bounded polling within confirmation window (max 75ms)
+        let deadline = client.now() + confirmationWindow
+
+        while client.now() < deadline {
+            client.pollOnce(pollInterval)
+
+            let currentFrontmost = client.frontmostBundleIdentifier()
+            let frontmostIsTarget = currentFrontmost == nil || currentFrontmost == targetBundleIdentifier
+
+            // Clear confirmation: target is no longer frontmost
+            if !frontmostIsTarget {
+                return ConfirmationResult(
+                    confirmed: true,
+                    usedEscalatedObservation: false,
+                    frontmostBundleAfterRestore: currentFrontmost
+                )
+            }
+
+            // Only fetch hidden/active when frontmost is ambiguous (avoids redundant IPC on happy path)
+            let targetHidden = client.targetIsHidden()
+            let targetActive = client.targetIsActive()
+            if isContradictory(frontmostIsTarget: true, targetHidden: targetHidden, targetActive: targetActive) {
+                return escalateToObservation()
+            }
+        }
+
+        // 4. Timeout: not confirmed
+        return ConfirmationResult(
+            confirmed: false,
+            usedEscalatedObservation: false,
+            frontmostBundleAfterRestore: client.frontmostBundleIdentifier()
+        )
+    }
+
+    // MARK: - Compatibility lane confirmation
+
+    func confirmCompatibilityRestore(
+        targetBundleIdentifier: String,
+        previousBundleIdentifier: String?
+    ) -> ConfirmationResult {
+        escalateToObservation()
+    }
+
+    // MARK: - Private
+
+    private func escalateToObservation() -> ConfirmationResult {
+        let snapshot = client.escalatedSnapshot()
+        return ConfirmationResult(
+            confirmed: !snapshot.targetIsObservedFrontmost,
+            usedEscalatedObservation: true,
+            frontmostBundleAfterRestore: snapshot.observedFrontmostBundleIdentifier
+        )
+    }
+
+    private func isContradictory(
+        frontmostIsTarget: Bool,
+        targetHidden: Bool,
+        targetActive: Bool
+    ) -> Bool {
+        // Target reports hidden but is still frontmost
+        if frontmostIsTarget && targetHidden { return true }
+        // Target is not frontmost but still reports active and not hidden
+        if !frontmostIsTarget && targetActive && !targetHidden { return true }
+        return false
+    }
+}

--- a/Tests/QuickeyTests/ObservationBrokerTests.swift
+++ b/Tests/QuickeyTests/ObservationBrokerTests.swift
@@ -1,0 +1,254 @@
+import CoreFoundation
+import Testing
+@testable import Quickey
+
+// MARK: - Cheap confirmation
+
+@Test @MainActor
+func cheapConfirmationSucceedsFromFrontmostChangeWithoutEscalation() {
+    let broker = ObservationBroker(client: .init(
+        frontmostBundleIdentifier: { "com.apple.Terminal" },
+        targetIsHidden: { false },
+        targetIsActive: { false },
+        targetClassification: { .regularWindowed },
+        escalatedSnapshot: { fatalError("should not escalate") },
+        now: { 100 },
+        pollOnce: { _ in }
+    ))
+
+    let result = broker.confirmFastRestore(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal"
+    )
+
+    #expect(result.confirmed == true)
+    #expect(result.usedEscalatedObservation == false)
+    #expect(result.frontmostBundleAfterRestore == "com.apple.Terminal")
+}
+
+@Test @MainActor
+func cheapConfirmationTimesOutWhenTargetRemainsFrontmost() {
+    var time: CFAbsoluteTime = 100.0
+    let broker = ObservationBroker(client: .init(
+        frontmostBundleIdentifier: { "com.apple.Safari" },
+        targetIsHidden: { false },
+        targetIsActive: { true },
+        targetClassification: { .regularWindowed },
+        escalatedSnapshot: { fatalError("should not escalate") },
+        now: { time },
+        pollOnce: { interval in time += interval }
+    ))
+
+    let result = broker.confirmFastRestore(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal"
+    )
+
+    #expect(result.confirmed == false)
+    #expect(result.usedEscalatedObservation == false)
+    #expect(result.frontmostBundleAfterRestore == "com.apple.Safari")
+}
+
+@Test @MainActor
+func cheapConfirmationSucceedsDuringPollingWindow() {
+    var time: CFAbsoluteTime = 100.0
+    var pollCount = 0
+    let broker = ObservationBroker(client: .init(
+        frontmostBundleIdentifier: {
+            // After 3 polls, frontmost changes
+            pollCount > 3 ? "com.apple.Terminal" : "com.apple.Safari"
+        },
+        targetIsHidden: { false },
+        targetIsActive: { pollCount <= 3 },
+        targetClassification: { .regularWindowed },
+        escalatedSnapshot: { fatalError("should not escalate") },
+        now: { time },
+        pollOnce: { interval in
+            time += interval
+            pollCount += 1
+        }
+    ))
+
+    let result = broker.confirmFastRestore(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal"
+    )
+
+    #expect(result.confirmed == true)
+    #expect(result.usedEscalatedObservation == false)
+    #expect(result.frontmostBundleAfterRestore == "com.apple.Terminal")
+    #expect(pollCount == 4)
+}
+
+// MARK: - Contradiction escalation
+
+@Test @MainActor
+func contradictoryStateEscalatesToWindowObservation() {
+    var time: CFAbsoluteTime = 100.0
+    let escalatedSnapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Safari",
+        observedFrontmostBundleIdentifier: "com.apple.Terminal",
+        targetIsActive: false,
+        targetIsHidden: true,
+        visibleWindowCount: 0,
+        hasFocusedWindow: false,
+        hasMainWindow: false,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .regularWindowed,
+        classificationReason: "visible focused main window"
+    )
+
+    let broker = ObservationBroker(client: .init(
+        frontmostBundleIdentifier: { "com.apple.Safari" },
+        targetIsHidden: { true },
+        targetIsActive: { true },
+        targetClassification: { .regularWindowed },
+        escalatedSnapshot: { escalatedSnapshot },
+        now: { time },
+        pollOnce: { interval in time += interval }
+    ))
+
+    let result = broker.confirmFastRestore(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal"
+    )
+
+    #expect(result.confirmed == true)
+    #expect(result.usedEscalatedObservation == true)
+    #expect(result.frontmostBundleAfterRestore == "com.apple.Terminal")
+}
+
+// MARK: - Classification-based escalation
+
+@Test @MainActor
+func systemUtilitySkipsCheapConfirmationAndEscalates() {
+    let escalatedSnapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.systempreferences",
+        observedFrontmostBundleIdentifier: "com.apple.Terminal",
+        targetIsActive: false,
+        targetIsHidden: false,
+        visibleWindowCount: 0,
+        hasFocusedWindow: false,
+        hasMainWindow: false,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .systemUtility,
+        classificationReason: "activation policy is accessory"
+    )
+
+    let broker = ObservationBroker(client: .init(
+        frontmostBundleIdentifier: { "com.apple.systempreferences" },
+        targetIsHidden: { false },
+        targetIsActive: { true },
+        targetClassification: { .systemUtility },
+        escalatedSnapshot: { escalatedSnapshot },
+        now: { 100 },
+        pollOnce: { _ in fatalError("should not poll") }
+    ))
+
+    let result = broker.confirmFastRestore(
+        targetBundleIdentifier: "com.apple.systempreferences",
+        previousBundleIdentifier: "com.apple.Terminal"
+    )
+
+    #expect(result.confirmed == true)
+    #expect(result.usedEscalatedObservation == true)
+}
+
+@Test @MainActor
+func windowlessOrAccessoryEscalatesImmediately() {
+    let escalatedSnapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Home",
+        observedFrontmostBundleIdentifier: "com.apple.Home",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 0,
+        hasFocusedWindow: false,
+        hasMainWindow: false,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .windowlessOrAccessory,
+        classificationReason: "no visible windows"
+    )
+
+    let broker = ObservationBroker(client: .init(
+        frontmostBundleIdentifier: { "com.apple.Home" },
+        targetIsHidden: { false },
+        targetIsActive: { true },
+        targetClassification: { .windowlessOrAccessory },
+        escalatedSnapshot: { escalatedSnapshot },
+        now: { 100 },
+        pollOnce: { _ in fatalError("should not poll") }
+    ))
+
+    let result = broker.confirmFastRestore(
+        targetBundleIdentifier: "com.apple.Home",
+        previousBundleIdentifier: "com.apple.Terminal"
+    )
+
+    // Not confirmed because escalated snapshot shows target is still frontmost
+    #expect(result.confirmed == false)
+    #expect(result.usedEscalatedObservation == true)
+}
+
+// MARK: - Compatibility lane
+
+@Test @MainActor
+func compatibilityLaneAlwaysUsesEscalatedObservation() {
+    let escalatedSnapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Safari",
+        observedFrontmostBundleIdentifier: "com.apple.Terminal",
+        targetIsActive: false,
+        targetIsHidden: true,
+        visibleWindowCount: 0,
+        hasFocusedWindow: false,
+        hasMainWindow: false,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .regularWindowed,
+        classificationReason: "visible focused main window"
+    )
+
+    let broker = ObservationBroker(client: .init(
+        frontmostBundleIdentifier: { "com.apple.Terminal" },
+        targetIsHidden: { true },
+        targetIsActive: { false },
+        targetClassification: { .regularWindowed },
+        escalatedSnapshot: { escalatedSnapshot },
+        now: { 100 },
+        pollOnce: { _ in }
+    ))
+
+    let result = broker.confirmCompatibilityRestore(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal"
+    )
+
+    #expect(result.confirmed == true)
+    #expect(result.usedEscalatedObservation == true)
+    #expect(result.frontmostBundleAfterRestore == "com.apple.Terminal")
+}
+
+// MARK: - Nil previous bundle
+
+@Test @MainActor
+func nilPreviousBundleHandledGracefully() {
+    let broker = ObservationBroker(client: .init(
+        frontmostBundleIdentifier: { "com.apple.Finder" },
+        targetIsHidden: { false },
+        targetIsActive: { false },
+        targetClassification: { .regularWindowed },
+        escalatedSnapshot: { fatalError("should not escalate") },
+        now: { 100 },
+        pollOnce: { _ in }
+    ))
+
+    let result = broker.confirmFastRestore(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: nil
+    )
+
+    #expect(result.confirmed == true)
+    #expect(result.frontmostBundleAfterRestore == "com.apple.Finder")
+}


### PR DESCRIPTION
Closes #90

## Summary
- Implement `ObservationBroker` with bounded 75ms cheap confirmation window for fast lane toggle-off
- Cheap confirmation: immediate frontmost check → classification-based escalation → bounded polling → timeout
- Non-regular classifications (systemUtility, windowlessOrAccessory, nonStandardWindowed) skip polling and escalate immediately
- Contradiction detection (hidden-but-frontmost, active-but-not-frontmost) triggers AX observation escalation
- 8 tests covering all confirmation paths: cheap success, polling timeout, mid-poll success, contradiction escalation, classification escalation, compatibility lane, nil previous bundle

## Verification
- Automated: swift build ✓, swift test (184 tests pass) ✓, swift build -c release ✓
- macOS runtime validation pending (confirmation window interacts with NSWorkspace notifications at runtime)

## Remaining (future iterations)
- Task 4: `confirmCompatibilityRestore` with more conservative confirmation (currently delegates to escalated observation)
- Task 5: `ApplicationObservation` helper additions (`cheapSnapshot`)
- Task 7: `ApplicationObservationTests` additions
- Production `Client` wiring (RunLoop-based `pollOnce`)