### PR TITLE
fix: add degraded recovery for toggle-off when previous app has no windows

### DIFF
--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -771,6 +771,16 @@ final class AppSwitcher: AppSwitching {
         if !postRestoreSnapshot.targetIsObservedFrontmost {
             frontmostTracker.confirmRestoreAttempt()
         }
+
+        // Degraded recovery: SkyLight restore reported success but produced no
+        // visual change (e.g. previous app is windowless Finder).  Fall back to
+        // NSRunningApplication.hide() so macOS picks the next foreground app
+        // naturally — matching Thor's "hide then let macOS decide" strategy.
+        if postRestoreSnapshot.targetIsObservedFrontmost {
+            let nsHideResult = runningApp.hide()
+            DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: DEGRADED_RECOVERY nsHide=\(nsHideResult) elapsedMs=\(elapsedMilliseconds(since: attemptStartedAt))")
+        }
+
         clearActivationTracking(for: shortcut.bundleIdentifier, resetPreviousTracking: false)
         logPostActionState(
             shortcut: shortcut,
@@ -1028,6 +1038,9 @@ final class AppSwitcher: AppSwitching {
 
         if phase == .postRestoreState {
             let lifecycle: ToggleLifecycle = snapshot.targetIsObservedFrontmost ? .restoreDegraded : .restoreConfirmed
+            if lifecycle == .restoreDegraded, let prevBundle = previousBundle {
+                DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: RESTORE_DEGRADED_DETAIL previousBundle=\(prevBundle) targetHidden=\(snapshot.targetIsHidden)")
+            }
             logToggleLifecycle(
                 for: shortcut,
                 lifecycle: lifecycle,


### PR DESCRIPTION
## Summary

- When toggle-off restores a windowless previous app (e.g. Finder), SkyLight reports success but no visual change occurs — target stays frontmost, causing a ping-pong loop on next keypress
- Adds `NSRunningApplication.hide()` fallback in `performCompatibilityToggle` when post-restore check detects target is still frontmost, letting macOS pick the next foreground app naturally (Thor's "hide then let macOS decide" strategy)
- Adds `RESTORE_DEGRADED_DETAIL` diagnostic log for easier debugging of degraded restore scenarios

Closes #117

## Test plan

- [ ] CI: `swift build && swift test` pass
- [ ] macOS: close all windows except target app → toggle-off → app should hide, macOS shows desktop/Finder
- [ ] macOS: check `debug.log` for `DEGRADED_RECOVERY` entry
- [ ] macOS: regression — toggle-off with windowed previous app should NOT trigger degraded recovery
- [ ] macOS: no ping-pong loop on repeated keypresses

**macOS runtime validation pending**