### PR TITLE
refactor: remove unused PSN/windowID hint fields from RestoreContext

### DIFF
--- a/Sources/Quickey/Models/RestoreContext.swift
+++ b/Sources/Quickey/Models/RestoreContext.swift
@@ -1,25 +1,10 @@
 import AppKit
-import Carbon.HIToolbox
 
 struct RestoreContext: Sendable, Equatable {
     let targetBundleIdentifier: String
     let previousBundleIdentifier: String?
     let previousPID: pid_t?
-    let previousPSNHint: ProcessSerialNumber?
-    let previousWindowIDHint: CGWindowID?
     let previousBundleURL: URL?
     let capturedAt: CFAbsoluteTime
     let generation: Int
-
-    static func == (lhs: RestoreContext, rhs: RestoreContext) -> Bool {
-        lhs.targetBundleIdentifier == rhs.targetBundleIdentifier
-            && lhs.previousBundleIdentifier == rhs.previousBundleIdentifier
-            && lhs.previousPID == rhs.previousPID
-            && lhs.previousPSNHint?.highLongOfPSN == rhs.previousPSNHint?.highLongOfPSN
-            && lhs.previousPSNHint?.lowLongOfPSN == rhs.previousPSNHint?.lowLongOfPSN
-            && lhs.previousWindowIDHint == rhs.previousWindowIDHint
-            && lhs.previousBundleURL == rhs.previousBundleURL
-            && lhs.capturedAt == rhs.capturedAt
-            && lhs.generation == rhs.generation
-    }
 }

--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -262,8 +262,6 @@ final class AppSwitcher: AppSwitching {
                 targetBundleIdentifier: bundleIdentifier,
                 previousBundleIdentifier: stableActivationState?.previousBundleIdentifier,
                 previousPID: nil,
-                previousPSNHint: nil,
-                previousWindowIDHint: nil,
                 previousBundleURL: nil,
                 capturedAt: now,
                 generation: generation

--- a/Sources/Quickey/Services/TapContextCache.swift
+++ b/Sources/Quickey/Services/TapContextCache.swift
@@ -43,8 +43,6 @@ final class TapContextCache {
             targetBundleIdentifier: restoreContext.targetBundleIdentifier,
             previousBundleIdentifier: normalizedPrevious,
             previousPID: restoreContext.previousPID,
-            previousPSNHint: restoreContext.previousPSNHint,
-            previousWindowIDHint: restoreContext.previousWindowIDHint,
             previousBundleURL: restoreContext.previousBundleURL,
             capturedAt: restoreContext.capturedAt,
             generation: restoreContext.generation

--- a/Sources/Quickey/Services/ToggleRuntime.swift
+++ b/Sources/Quickey/Services/ToggleRuntime.swift
@@ -86,8 +86,6 @@ final class ToggleRuntime {
                 targetBundleIdentifier: targetBundleIdentifier,
                 previousBundleIdentifier: normalizedPrevious,
                 previousPID: hintsMatch ? cacheEntry?.restoreContext.previousPID : nil,
-                previousPSNHint: hintsMatch ? cacheEntry?.restoreContext.previousPSNHint : nil,
-                previousWindowIDHint: hintsMatch ? cacheEntry?.restoreContext.previousWindowIDHint : nil,
                 previousBundleURL: hintsMatch ? cacheEntry?.restoreContext.previousBundleURL : nil,
                 capturedAt: attemptStartedAt,
                 generation: cacheEntry?.restoreContext.generation ?? 0

--- a/Tests/QuickeyTests/ActivationPipelineTests.swift
+++ b/Tests/QuickeyTests/ActivationPipelineTests.swift
@@ -34,8 +34,6 @@ func latestGenerationDropsQueuedMutatingCommandsBeforeExecution() async {
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 42,
-        previousPSNHint: nil,
-        previousWindowIDHint: nil,
         previousBundleURL: nil,
         capturedAt: 100,
         generation: 1
@@ -46,8 +44,6 @@ func latestGenerationDropsQueuedMutatingCommandsBeforeExecution() async {
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 42,
-        previousPSNHint: nil,
-        previousWindowIDHint: nil,
         previousBundleURL: nil,
         capturedAt: 101,
         generation: 2
@@ -106,8 +102,6 @@ func restoreFastTimeoutMapsToNeedsFallback() async {
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 42,
-        previousPSNHint: nil,
-        previousWindowIDHint: nil,
         previousBundleURL: nil,
         capturedAt: 100,
         generation: 1
@@ -226,8 +220,6 @@ func restoreCompatibleTimeoutMapsToDegraded() async {
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 42,
-        previousPSNHint: nil,
-        previousWindowIDHint: nil,
         previousBundleURL: nil,
         capturedAt: 100,
         generation: 1

--- a/Tests/QuickeyTests/TapContextCacheTests.swift
+++ b/Tests/QuickeyTests/TapContextCacheTests.swift
@@ -13,8 +13,6 @@ func coordinatorPreviousBundleWinsWhenCacheMirrorDrifts() {
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Finder",
         previousPID: 42,
-        previousPSNHint: nil,
-        previousWindowIDHint: 314,
         previousBundleURL: URL(fileURLWithPath: "/Applications/Finder.app"),
         capturedAt: 100,
         generation: 1
@@ -41,8 +39,6 @@ func cacheInvalidatesWhenPreviousAppTerminates() {
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 42,
-        previousPSNHint: nil,
-        previousWindowIDHint: 314,
         previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
         capturedAt: 100,
         generation: 1
@@ -67,8 +63,6 @@ func frontmostChangePreservesRestoreContextButDisablesFastLane() {
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 42,
-        previousPSNHint: nil,
-        previousWindowIDHint: 314,
         previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
         capturedAt: 100,
         generation: 1
@@ -96,8 +90,6 @@ func threeFastLaneMissesEnterTemporaryCompatibilityWindow() {
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 42,
-        previousPSNHint: nil,
-        previousWindowIDHint: 314,
         previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
         capturedAt: 100,
         generation: 1

--- a/Tests/QuickeyTests/ToggleRuntimeTests.swift
+++ b/Tests/QuickeyTests/ToggleRuntimeTests.swift
@@ -1,20 +1,13 @@
 import AppKit
-import Carbon.HIToolbox
 import Testing
 @testable import Quickey
 
 @Test @MainActor
 func restoreContextCapturesGenerationAndPreviousBundle() {
-    var psn = ProcessSerialNumber()
-    psn.highLongOfPSN = 7
-    psn.lowLongOfPSN = 9
-
     let context = RestoreContext(
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 42,
-        previousPSNHint: psn,
-        previousWindowIDHint: 314,
         previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
         capturedAt: 123.0,
         generation: 5
@@ -23,9 +16,6 @@ func restoreContextCapturesGenerationAndPreviousBundle() {
     #expect(context.targetBundleIdentifier == "com.apple.Safari")
     #expect(context.previousBundleIdentifier == "com.apple.Terminal")
     #expect(context.previousPID == 42)
-    #expect(context.previousPSNHint?.highLongOfPSN == 7)
-    #expect(context.previousPSNHint?.lowLongOfPSN == 9)
-    #expect(context.previousWindowIDHint == 314)
     #expect(context.previousBundleURL?.path == "/Applications/Terminal.app")
     #expect(context.capturedAt == 123.0)
     #expect(context.generation == 5)
@@ -200,8 +190,6 @@ func pipelineEnabledRespectsQuarantinedCacheEntry() {
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 42,
-        previousPSNHint: nil,
-        previousWindowIDHint: nil,
         previousBundleURL: nil,
         capturedAt: 100,
         generation: 1
@@ -242,8 +230,6 @@ func pipelineEnabledRecoversFastLaneAfterQuarantineExpires() {
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 42,
-        previousPSNHint: nil,
-        previousWindowIDHint: nil,
         previousBundleURL: nil,
         capturedAt: 100,
         generation: 1
@@ -280,16 +266,11 @@ func pipelineEnabledDropsStaleHintsWhenPreviousBundleChanges() {
         tapContextCache: cache
     )
 
-    // Cache entry has Terminal as previous with specific PID/PSN/window hints
-    var terminalPSN = ProcessSerialNumber()
-    terminalPSN.highLongOfPSN = 1
-    terminalPSN.lowLongOfPSN = 42
+    // Cache entry has Terminal as previous with specific PID/URL hints
     let cachedContext = RestoreContext(
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 100,
-        previousPSNHint: terminalPSN,
-        previousWindowIDHint: 999,
         previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
         capturedAt: 50,
         generation: 1
@@ -312,8 +293,6 @@ func pipelineEnabledDropsStaleHintsWhenPreviousBundleChanges() {
         #expect(context.previousBundleIdentifier == "com.apple.Finder")
         // Hints from Terminal cache entry must NOT leak into Finder context
         #expect(context.previousPID == nil)
-        #expect(context.previousPSNHint == nil)
-        #expect(context.previousWindowIDHint == nil)
         #expect(context.previousBundleURL == nil)
     } else {
         Issue.record("Expected fastLane decision, got \(decision)")
@@ -328,15 +307,10 @@ func pipelineEnabledKeepsHintsWhenPreviousBundleMatches() {
         tapContextCache: cache
     )
 
-    var terminalPSN = ProcessSerialNumber()
-    terminalPSN.highLongOfPSN = 1
-    terminalPSN.lowLongOfPSN = 42
     let cachedContext = RestoreContext(
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         previousPID: 100,
-        previousPSNHint: terminalPSN,
-        previousWindowIDHint: 999,
         previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
         capturedAt: 50,
         generation: 1
@@ -358,9 +332,6 @@ func pipelineEnabledKeepsHintsWhenPreviousBundleMatches() {
     if case .execute(.fastLane(let context)) = decision {
         #expect(context.previousBundleIdentifier == "com.apple.Terminal")
         #expect(context.previousPID == 100)
-        #expect(context.previousPSNHint?.highLongOfPSN == 1)
-        #expect(context.previousPSNHint?.lowLongOfPSN == 42)
-        #expect(context.previousWindowIDHint == 999)
         #expect(context.previousBundleURL?.path == "/Applications/Terminal.app")
     } else {
         Issue.record("Expected fastLane decision, got \(decision)")


### PR DESCRIPTION
## Summary

- Removes `previousPSNHint` and `previousWindowIDHint` from `RestoreContext` — these fields were never populated at runtime (AppSwitcher always passed `nil`), making the conditional hint-transfer logic in `ToggleRuntime.decision()` dead code
- Drops manual `Equatable` conformance (synthesized conformance works after PSN removal)
- Removes `Carbon.HIToolbox` import from `RestoreContext.swift` and test files
- Net -67 lines, no behavioral change

Part of the incremental simplification discussed in #120. Follow-up items (temporary quarantine simplification, ObservationBroker escalation simplification) tracked separately.

Refs #120

## Test plan

- [ ] CI: `swift build && swift test` pass
- [ ] `grep -r previousPSNHint` / `previousWindowIDHint` across `.swift` files returns zero matches
- [ ] No behavioral change — toggle-on/toggle-off paths are identical at runtime since these fields were always nil