### PR TITLE
simplify: replace temporary quarantine with simple confidence decay

### DIFF
--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -709,13 +709,7 @@ final class AppSwitcher: AppSwitching {
         }
 
         DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: FAST_LANE_MISS lane=fast fallbackCount=1 cacheInvalidationReason=\(cacheInvalidationReason ?? "nil") elapsedMs=\(elapsedMilliseconds(since: attemptStartedAt))")
-        toggleRuntime.tapContextCache.markFastLaneMiss(
-            for: shortcut.bundleIdentifier,
-            now: confirmationClient.now(),
-            threshold: toggleRuntime.configuration.fastLaneMissThreshold,
-            window: toggleRuntime.configuration.fastLaneMissWindow,
-            quarantine: toggleRuntime.configuration.temporaryCompatibilityWindow
-        )
+        toggleRuntime.tapContextCache.markFastLaneMiss(for: shortcut.bundleIdentifier)
 
         return performCompatibilityToggle(
             shortcut: shortcut,

--- a/Sources/Quickey/Services/TapContextCache.swift
+++ b/Sources/Quickey/Services/TapContextCache.swift
@@ -12,9 +12,6 @@ final class TapContextCache {
     struct Entry {
         var restoreContext: RestoreContext
         var fastLaneEligible: Bool
-        var fastLaneMissCount: Int
-        var fastLaneMissWindowStart: CFAbsoluteTime?
-        var temporaryCompatibilityUntil: CFAbsoluteTime?
         var lastInvalidationReason: CacheInvalidationReason?
     }
 
@@ -34,9 +31,6 @@ final class TapContextCache {
         var entry = entries[targetBundleIdentifier] ?? Entry(
             restoreContext: restoreContext,
             fastLaneEligible: true,
-            fastLaneMissCount: 0,
-            fastLaneMissWindowStart: nil,
-            temporaryCompatibilityUntil: nil,
             lastInvalidationReason: nil
         )
         entry.restoreContext = RestoreContext(
@@ -47,43 +41,15 @@ final class TapContextCache {
             capturedAt: restoreContext.capturedAt,
             generation: restoreContext.generation
         )
-        entry.fastLaneEligible = entry.temporaryCompatibilityUntil == nil
         entry.lastInvalidationReason = nil
         entries[targetBundleIdentifier] = entry
         invalidationReasons.removeValue(forKey: targetBundleIdentifier)
         return entry
     }
 
-    func markFastLaneMiss(
-        for targetBundleIdentifier: String,
-        now: CFAbsoluteTime,
-        threshold: Int,
-        window: TimeInterval,
-        quarantine: TimeInterval
-    ) {
+    func markFastLaneMiss(for targetBundleIdentifier: String) {
         guard var entry = entries[targetBundleIdentifier] else { return }
-
-        if let temporaryCompatibilityUntil = entry.temporaryCompatibilityUntil,
-           now >= temporaryCompatibilityUntil {
-            entry.temporaryCompatibilityUntil = nil
-            entry.fastLaneEligible = true
-            entry.fastLaneMissCount = 0
-            entry.fastLaneMissWindowStart = nil
-        }
-
-        if let windowStart = entry.fastLaneMissWindowStart,
-           now - windowStart <= window {
-            entry.fastLaneMissCount += 1
-        } else {
-            entry.fastLaneMissWindowStart = now
-            entry.fastLaneMissCount = 1
-        }
-
-        if entry.fastLaneMissCount >= threshold {
-            entry.fastLaneEligible = false
-            entry.temporaryCompatibilityUntil = now + quarantine
-        }
-
+        entry.fastLaneEligible = false
         entries[targetBundleIdentifier] = entry
     }
 
@@ -101,19 +67,8 @@ final class TapContextCache {
         }
     }
 
-    func entry(for targetBundleIdentifier: String, now: CFAbsoluteTime) -> Entry? {
-        guard var entry = entries[targetBundleIdentifier] else { return nil }
-
-        if let temporaryCompatibilityUntil = entry.temporaryCompatibilityUntil,
-           now >= temporaryCompatibilityUntil {
-            entry.temporaryCompatibilityUntil = nil
-            entry.fastLaneEligible = true
-            entry.fastLaneMissCount = 0
-            entry.fastLaneMissWindowStart = nil
-            entries[targetBundleIdentifier] = entry
-        }
-
-        return entry
+    func entry(for targetBundleIdentifier: String) -> Entry? {
+        entries[targetBundleIdentifier]
     }
 
     func lastInvalidationReason(for targetBundleIdentifier: String) -> CacheInvalidationReason? {

--- a/Sources/Quickey/Services/ToggleRuntime.swift
+++ b/Sources/Quickey/Services/ToggleRuntime.swift
@@ -10,9 +10,6 @@ struct ToggleRuntimeConfiguration: Sendable, Equatable {
     var executionMode: ToggleExecutionMode = .legacyOnly
     var fastConfirmationWindow: TimeInterval = 0.075
     var contextPreparationConcurrencyLimit: Int = 2
-    var fastLaneMissThreshold: Int = 3
-    var fastLaneMissWindow: TimeInterval = 600
-    var temporaryCompatibilityWindow: TimeInterval = 300
 }
 
 enum ToggleRuntimeDecision: Equatable {
@@ -60,7 +57,7 @@ final class ToggleRuntime {
                 targetBundleIdentifier: targetBundleIdentifier,
                 previousBundleIdentifier: previousBundleIdentifier
             )
-            let cacheEntry = tapContextCache.entry(for: targetBundleIdentifier, now: attemptStartedAt)
+            let cacheEntry = tapContextCache.entry(for: targetBundleIdentifier)
             let fastLaneEligible = cacheEntry?.fastLaneEligible ?? true
             let wouldUseFastLane = fastLaneEligible
                 && normalizedPrevious != nil
@@ -77,7 +74,7 @@ final class ToggleRuntime {
                 targetBundleIdentifier: targetBundleIdentifier,
                 previousBundleIdentifier: previousBundleIdentifier
             )
-            let cacheEntry = tapContextCache.entry(for: targetBundleIdentifier, now: attemptStartedAt)
+            let cacheEntry = tapContextCache.entry(for: targetBundleIdentifier)
             let fastLaneEligible = cacheEntry?.fastLaneEligible ?? true
 
             let hintsMatch = normalizedPrevious != nil

--- a/Tests/QuickeyTests/TapContextCacheTests.swift
+++ b/Tests/QuickeyTests/TapContextCacheTests.swift
@@ -25,7 +25,7 @@ func coordinatorPreviousBundleWinsWhenCacheMirrorDrifts() {
     )
 
     #expect(entry.restoreContext.previousBundleIdentifier == "com.apple.Terminal")
-    #expect(cache.entry(for: "com.apple.Safari", now: 100)?.restoreContext.previousBundleIdentifier == "com.apple.Terminal")
+    #expect(cache.entry(for: "com.apple.Safari")?.restoreContext.previousBundleIdentifier == "com.apple.Terminal")
 }
 
 @Test @MainActor
@@ -52,7 +52,7 @@ func cacheInvalidatesWhenPreviousAppTerminates() {
 
     cache.invalidate("com.apple.Safari", reason: .previousAppTerminated)
 
-    #expect(cache.entry(for: "com.apple.Safari", now: 101) == nil)
+    #expect(cache.entry(for: "com.apple.Safari") == nil)
     #expect(cache.lastInvalidationReason(for: "com.apple.Safari") == .previousAppTerminated)
 }
 
@@ -76,7 +76,7 @@ func frontmostChangePreservesRestoreContextButDisablesFastLane() {
 
     cache.invalidate("com.apple.Safari", reason: .frontmostChanged)
 
-    let retainedEntry = cache.entry(for: "com.apple.Safari", now: 101)
+    let retainedEntry = cache.entry(for: "com.apple.Safari")
     #expect(retainedEntry?.restoreContext.previousBundleIdentifier == "com.apple.Terminal")
     #expect(retainedEntry?.fastLaneEligible == false)
     #expect(retainedEntry?.lastInvalidationReason == .frontmostChanged)
@@ -84,7 +84,7 @@ func frontmostChangePreservesRestoreContextButDisablesFastLane() {
 }
 
 @Test @MainActor
-func threeFastLaneMissesEnterTemporaryCompatibilityWindow() {
+func singleFastLaneMissPermanentlyDisablesFastLane() {
     let cache = TapContextCache()
     let restoreContext = RestoreContext(
         targetBundleIdentifier: "com.apple.Safari",
@@ -101,35 +101,46 @@ func threeFastLaneMissesEnterTemporaryCompatibilityWindow() {
         restoreContext: restoreContext
     )
 
-    cache.markFastLaneMiss(
-        for: "com.apple.Safari",
-        now: 100,
-        threshold: 3,
-        window: 600,
-        quarantine: 300
-    )
-    cache.markFastLaneMiss(
-        for: "com.apple.Safari",
-        now: 120,
-        threshold: 3,
-        window: 600,
-        quarantine: 300
-    )
-    cache.markFastLaneMiss(
-        for: "com.apple.Safari",
-        now: 140,
-        threshold: 3,
-        window: 600,
-        quarantine: 300
+    let entryBefore = cache.entry(for: "com.apple.Safari")
+    #expect(entryBefore?.fastLaneEligible == true)
+
+    cache.markFastLaneMiss(for: "com.apple.Safari")
+
+    let entryAfter = cache.entry(for: "com.apple.Safari")
+    #expect(entryAfter?.fastLaneEligible == false)
+    // Remains disabled — no auto-recovery
+    #expect(entryAfter?.restoreContext.previousBundleIdentifier == "com.apple.Terminal")
+}
+
+@Test @MainActor
+func sessionResetRestoresFastLaneEligibility() {
+    let cache = TapContextCache()
+    let restoreContext = RestoreContext(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal",
+        previousPID: 42,
+        previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
+        capturedAt: 100,
+        generation: 1
     )
 
-    let quarantinedEntry = cache.entry(for: "com.apple.Safari", now: 141)
-    #expect(quarantinedEntry?.temporaryCompatibilityUntil == 440)
-    #expect(quarantinedEntry?.fastLaneEligible == false)
+    cache.upsert(
+        targetBundleIdentifier: "com.apple.Safari",
+        coordinatorPreviousBundle: "com.apple.Terminal",
+        restoreContext: restoreContext
+    )
 
-    let recoveredEntry = cache.entry(for: "com.apple.Safari", now: 441)
-    #expect(recoveredEntry?.temporaryCompatibilityUntil == nil)
-    #expect(recoveredEntry?.fastLaneEligible == true)
-    #expect(recoveredEntry?.fastLaneMissCount == 0)
-    #expect(recoveredEntry?.fastLaneMissWindowStart == nil)
+    cache.markFastLaneMiss(for: "com.apple.Safari")
+    #expect(cache.entry(for: "com.apple.Safari")?.fastLaneEligible == false)
+
+    // Session reset clears the entry entirely — next upsert starts fresh with fastLaneEligible=true
+    cache.invalidate("com.apple.Safari", reason: .sessionReset)
+    #expect(cache.entry(for: "com.apple.Safari") == nil)
+
+    let freshEntry = cache.upsert(
+        targetBundleIdentifier: "com.apple.Safari",
+        coordinatorPreviousBundle: "com.apple.Terminal",
+        restoreContext: restoreContext
+    )
+    #expect(freshEntry.fastLaneEligible == true)
 }

--- a/Tests/QuickeyTests/ToggleRuntimeTests.swift
+++ b/Tests/QuickeyTests/ToggleRuntimeTests.swift
@@ -28,9 +28,6 @@ func toggleRuntimeConfigurationDefaultsToLegacyMode() {
     #expect(configuration.executionMode == .legacyOnly)
     #expect(configuration.fastConfirmationWindow == 0.075)
     #expect(configuration.contextPreparationConcurrencyLimit == 2)
-    #expect(configuration.fastLaneMissThreshold == 3)
-    #expect(configuration.fastLaneMissWindow == 600)
-    #expect(configuration.temporaryCompatibilityWindow == 300)
 }
 
 @Test @MainActor
@@ -199,10 +196,8 @@ func pipelineEnabledRespectsQuarantinedCacheEntry() {
         coordinatorPreviousBundle: "com.apple.Terminal",
         restoreContext: restoreContext
     )
-    // 3 misses → quarantine
-    for t in stride(from: 100.0, through: 140.0, by: 20.0) {
-        cache.markFastLaneMiss(for: "com.apple.Safari", now: t, threshold: 3, window: 600, quarantine: 300)
-    }
+    // Single miss → permanently ineligible
+    cache.markFastLaneMiss(for: "com.apple.Safari")
 
     let decision = runtime.decision(
         targetBundleIdentifier: "com.apple.Safari",
@@ -212,14 +207,14 @@ func pipelineEnabledRespectsQuarantinedCacheEntry() {
     )
 
     if case .execute(.compatibilityLane) = decision {
-        // expected: quarantined, so not fast-lane eligible
+        // expected: miss marked, so not fast-lane eligible
     } else {
-        Issue.record("Expected compatibilityLane for quarantined app, got \(decision)")
+        Issue.record("Expected compatibilityLane for miss-marked app, got \(decision)")
     }
 }
 
 @Test @MainActor
-func pipelineEnabledRecoversFastLaneAfterQuarantineExpires() {
+func pipelineEnabledRecoversFastLaneAfterSessionReset() {
     let cache = TapContextCache()
     let runtime = ToggleRuntime(
         configuration: ToggleRuntimeConfiguration(executionMode: .pipelineEnabled),
@@ -239,22 +234,27 @@ func pipelineEnabledRecoversFastLaneAfterQuarantineExpires() {
         coordinatorPreviousBundle: "com.apple.Terminal",
         restoreContext: restoreContext
     )
-    for t in stride(from: 100.0, through: 140.0, by: 20.0) {
-        cache.markFastLaneMiss(for: "com.apple.Safari", now: t, threshold: 3, window: 600, quarantine: 300)
-    }
+    cache.markFastLaneMiss(for: "com.apple.Safari")
 
-    // After quarantine expires (140 + 300 = 440)
+    // Session reset clears the entry; re-upsert starts fresh
+    cache.invalidate("com.apple.Safari", reason: .sessionReset)
+    cache.upsert(
+        targetBundleIdentifier: "com.apple.Safari",
+        coordinatorPreviousBundle: "com.apple.Terminal",
+        restoreContext: restoreContext
+    )
+
     let decision = runtime.decision(
         targetBundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.apple.Terminal",
         classification: .regularWindowed,
-        attemptStartedAt: 441.0
+        attemptStartedAt: 200.0
     )
 
     if case .execute(.fastLane) = decision {
-        // expected: quarantine expired, fast lane recovered
+        // expected: session reset restored fast lane eligibility
     } else {
-        Issue.record("Expected fastLane after quarantine expired, got \(decision)")
+        Issue.record("Expected fastLane after session reset, got \(decision)")
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace time-windowed 3-strike quarantine in `TapContextCache` with immediate permanent fast-lane demotion on first miss
- Remove 3 `Entry` fields (`fastLaneMissCount`, `fastLaneMissWindowStart`, `temporaryCompatibilityUntil`) and 3 configuration parameters (`fastLaneMissThreshold`, `fastLaneMissWindow`, `temporaryCompatibilityWindow`)
- Simplify `markFastLaneMiss` to parameter-less single-shot demotion; remove `now` parameter from `entry(for:)`
- Recovery path unchanged: session reset / app termination clears entry → next upsert starts fresh with `fastLaneEligible=true`

Net: **-43 lines**, 3 fewer config params, simpler mental model, more predictable behavior.

Closes #123

## Test plan

- [ ] Verify CI passes (build + tests on macOS)
- [ ] Confirm `singleFastLaneMissPermanentlyDisablesFastLane` test validates immediate demotion
- [ ] Confirm `sessionResetRestoresFastLaneEligibility` test validates recovery after session reset
- [ ] Confirm `pipelineEnabledRespectsQuarantinedCacheEntry` (renamed behavior) validates miss-marked entry routes to compatibility lane
- [ ] Confirm `pipelineEnabledRecoversFastLaneAfterSessionReset` validates session reset restores fast lane
- [ ] macOS runtime validation pending (toggle-off fast lane miss → permanent demotion until session reset)