### PR TITLE
simplify: remove contradiction detection in ObservationBroker escalation

### DIFF
--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -649,8 +649,6 @@ final class AppSwitcher: AppSwitching {
                 frontmostBundleIdentifier: { [weak self] in
                     self?.frontmostTracker.currentFrontmostBundleIdentifier()
                 },
-                targetIsHidden: { runningApp.isHidden },
-                targetIsActive: { runningApp.isActive },
                 targetClassification: { preActionSnapshot.classification },
                 escalatedSnapshot: { [weak self] in
                     guard let self else {

--- a/Sources/Quickey/Services/ObservationBroker.swift
+++ b/Sources/Quickey/Services/ObservationBroker.swift
@@ -10,8 +10,6 @@ final class ObservationBroker {
 
     struct Client {
         let frontmostBundleIdentifier: () -> String?
-        let targetIsHidden: () -> Bool
-        let targetIsActive: () -> Bool
         let targetClassification: () -> ApplicationClassification
         let escalatedSnapshot: () -> ActivationObservationSnapshot
         let now: () -> CFAbsoluteTime
@@ -60,31 +58,19 @@ final class ObservationBroker {
             client.pollOnce(pollInterval)
 
             let currentFrontmost = client.frontmostBundleIdentifier()
-            let frontmostIsTarget = currentFrontmost == nil || currentFrontmost == targetBundleIdentifier
 
             // Clear confirmation: target is no longer frontmost
-            if !frontmostIsTarget {
+            if currentFrontmost != nil, currentFrontmost != targetBundleIdentifier {
                 return ConfirmationResult(
                     confirmed: true,
                     usedEscalatedObservation: false,
                     frontmostBundleAfterRestore: currentFrontmost
                 )
             }
-
-            // Only fetch hidden/active when frontmost is ambiguous (avoids redundant IPC on happy path)
-            let targetHidden = client.targetIsHidden()
-            let targetActive = client.targetIsActive()
-            if isContradictory(frontmostIsTarget: true, targetHidden: targetHidden, targetActive: targetActive) {
-                return escalateToObservation()
-            }
         }
 
-        // 4. Timeout: not confirmed
-        return ConfirmationResult(
-            confirmed: false,
-            usedEscalatedObservation: false,
-            frontmostBundleAfterRestore: client.frontmostBundleIdentifier()
-        )
+        // 4. Timeout: escalate to full observation
+        return escalateToObservation()
     }
 
     // MARK: - Compatibility lane confirmation
@@ -105,17 +91,5 @@ final class ObservationBroker {
             usedEscalatedObservation: true,
             frontmostBundleAfterRestore: snapshot.observedFrontmostBundleIdentifier
         )
-    }
-
-    private func isContradictory(
-        frontmostIsTarget: Bool,
-        targetHidden: Bool,
-        targetActive: Bool
-    ) -> Bool {
-        // Target reports hidden but is still frontmost
-        if frontmostIsTarget && targetHidden { return true }
-        // Target is not frontmost but still reports active and not hidden
-        if !frontmostIsTarget && targetActive && !targetHidden { return true }
-        return false
     }
 }

--- a/Tests/QuickeyTests/ObservationBrokerTests.swift
+++ b/Tests/QuickeyTests/ObservationBrokerTests.swift
@@ -8,8 +8,6 @@ import Testing
 func cheapConfirmationSucceedsFromFrontmostChangeWithoutEscalation() {
     let broker = ObservationBroker(client: .init(
         frontmostBundleIdentifier: { "com.apple.Terminal" },
-        targetIsHidden: { false },
-        targetIsActive: { false },
         targetClassification: { .regularWindowed },
         escalatedSnapshot: { fatalError("should not escalate") },
         now: { 100 },
@@ -27,14 +25,26 @@ func cheapConfirmationSucceedsFromFrontmostChangeWithoutEscalation() {
 }
 
 @Test @MainActor
-func cheapConfirmationTimesOutWhenTargetRemainsFrontmost() {
+func cheapConfirmationTimesOutAndEscalates() {
     var time: CFAbsoluteTime = 100.0
+    let escalatedSnapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Safari",
+        observedFrontmostBundleIdentifier: "com.apple.Safari",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 1,
+        hasFocusedWindow: true,
+        hasMainWindow: true,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .regularWindowed,
+        classificationReason: "visible focused main window"
+    )
+
     let broker = ObservationBroker(client: .init(
         frontmostBundleIdentifier: { "com.apple.Safari" },
-        targetIsHidden: { false },
-        targetIsActive: { true },
         targetClassification: { .regularWindowed },
-        escalatedSnapshot: { fatalError("should not escalate") },
+        escalatedSnapshot: { escalatedSnapshot },
         now: { time },
         pollOnce: { interval in time += interval }
     ))
@@ -44,8 +54,9 @@ func cheapConfirmationTimesOutWhenTargetRemainsFrontmost() {
         previousBundleIdentifier: "com.apple.Terminal"
     )
 
+    // Timeout now escalates to observation instead of returning unconfirmed
     #expect(result.confirmed == false)
-    #expect(result.usedEscalatedObservation == false)
+    #expect(result.usedEscalatedObservation == true)
     #expect(result.frontmostBundleAfterRestore == "com.apple.Safari")
 }
 
@@ -58,8 +69,6 @@ func cheapConfirmationSucceedsDuringPollingWindow() {
             // After 3 polls, frontmost changes
             pollCount > 3 ? "com.apple.Terminal" : "com.apple.Safari"
         },
-        targetIsHidden: { false },
-        targetIsActive: { pollCount <= 3 },
         targetClassification: { .regularWindowed },
         escalatedSnapshot: { fatalError("should not escalate") },
         now: { time },
@@ -78,45 +87,6 @@ func cheapConfirmationSucceedsDuringPollingWindow() {
     #expect(result.usedEscalatedObservation == false)
     #expect(result.frontmostBundleAfterRestore == "com.apple.Terminal")
     #expect(pollCount == 4)
-}
-
-// MARK: - Contradiction escalation
-
-@Test @MainActor
-func contradictoryStateEscalatesToWindowObservation() {
-    var time: CFAbsoluteTime = 100.0
-    let escalatedSnapshot = ActivationObservationSnapshot(
-        targetBundleIdentifier: "com.apple.Safari",
-        observedFrontmostBundleIdentifier: "com.apple.Terminal",
-        targetIsActive: false,
-        targetIsHidden: true,
-        visibleWindowCount: 0,
-        hasFocusedWindow: false,
-        hasMainWindow: false,
-        windowObservationSucceeded: true,
-        windowObservationFailureReason: nil,
-        classification: .regularWindowed,
-        classificationReason: "visible focused main window"
-    )
-
-    let broker = ObservationBroker(client: .init(
-        frontmostBundleIdentifier: { "com.apple.Safari" },
-        targetIsHidden: { true },
-        targetIsActive: { true },
-        targetClassification: { .regularWindowed },
-        escalatedSnapshot: { escalatedSnapshot },
-        now: { time },
-        pollOnce: { interval in time += interval }
-    ))
-
-    let result = broker.confirmFastRestore(
-        targetBundleIdentifier: "com.apple.Safari",
-        previousBundleIdentifier: "com.apple.Terminal"
-    )
-
-    #expect(result.confirmed == true)
-    #expect(result.usedEscalatedObservation == true)
-    #expect(result.frontmostBundleAfterRestore == "com.apple.Terminal")
 }
 
 // MARK: - Classification-based escalation
@@ -139,8 +109,6 @@ func systemUtilitySkipsCheapConfirmationAndEscalates() {
 
     let broker = ObservationBroker(client: .init(
         frontmostBundleIdentifier: { "com.apple.systempreferences" },
-        targetIsHidden: { false },
-        targetIsActive: { true },
         targetClassification: { .systemUtility },
         escalatedSnapshot: { escalatedSnapshot },
         now: { 100 },
@@ -174,8 +142,6 @@ func windowlessOrAccessoryEscalatesImmediately() {
 
     let broker = ObservationBroker(client: .init(
         frontmostBundleIdentifier: { "com.apple.Home" },
-        targetIsHidden: { false },
-        targetIsActive: { true },
         targetClassification: { .windowlessOrAccessory },
         escalatedSnapshot: { escalatedSnapshot },
         now: { 100 },
@@ -212,8 +178,6 @@ func compatibilityLaneAlwaysUsesEscalatedObservation() {
 
     let broker = ObservationBroker(client: .init(
         frontmostBundleIdentifier: { "com.apple.Terminal" },
-        targetIsHidden: { true },
-        targetIsActive: { false },
         targetClassification: { .regularWindowed },
         escalatedSnapshot: { escalatedSnapshot },
         now: { 100 },
@@ -236,8 +200,6 @@ func compatibilityLaneAlwaysUsesEscalatedObservation() {
 func nilPreviousBundleHandledGracefully() {
     let broker = ObservationBroker(client: .init(
         frontmostBundleIdentifier: { "com.apple.Finder" },
-        targetIsHidden: { false },
-        targetIsActive: { false },
         targetClassification: { .regularWindowed },
         escalatedSnapshot: { fatalError("should not escalate") },
         now: { 100 },


### PR DESCRIPTION
## Summary

- Remove `isContradictory()` method and per-iteration `targetIsHidden`/`targetIsActive` IPC calls from the poll loop
- Remove `targetIsHidden`/`targetIsActive` from `ObservationBroker.Client` struct
- Simplify poll loop to only check `frontmostBundleIdentifier`
- Change timeout path to `escalateToObservation()` instead of returning unconfirmed

### Trade-off (per issue)

- **Loses**: Early escalation on contradictory state (~10-50ms savings on rare edge cases)
- **Gains**: ~15 lines removed, eliminates per-iteration IPC on unhappy path, simpler logic
- **Net latency impact**: Minimal — contradiction cases are rare, 75ms polling window is already short

## Test plan

- [x] Update `cheapConfirmationTimesOutAndEscalates` to verify timeout now escalates
- [x] Remove `contradictoryStateEscalatesToWindowObservation` test (path no longer exists)
- [x] All remaining ObservationBroker tests updated for simplified Client
- [ ] CI build and test pass on macOS

Closes #124