### PR TITLE
fix: recover fastLaneEligible on successful activation (#126)

### DIFF
--- a/Sources/Quickey/Services/TapContextCache.swift
+++ b/Sources/Quickey/Services/TapContextCache.swift
@@ -41,6 +41,11 @@ final class TapContextCache {
             capturedAt: restoreContext.capturedAt,
             generation: restoreContext.generation
         )
+        // upsert is invoked only on a successful stable activation
+        // (see AppSwitcher.promotePendingActivationIfCurrent), so a fresh
+        // success is the recovery signal that re-enables fast-lane eligibility
+        // for a bundle previously demoted by markFastLaneMiss.
+        entry.fastLaneEligible = true
         entry.lastInvalidationReason = nil
         entries[targetBundleIdentifier] = entry
         invalidationReasons.removeValue(forKey: targetBundleIdentifier)

--- a/Tests/QuickeyTests/TapContextCacheTests.swift
+++ b/Tests/QuickeyTests/TapContextCacheTests.swift
@@ -84,7 +84,7 @@ func frontmostChangePreservesRestoreContextButDisablesFastLane() {
 }
 
 @Test @MainActor
-func singleFastLaneMissPermanentlyDisablesFastLane() {
+func successfulUpsertRecoversFastLaneAfterMiss() {
     let cache = TapContextCache()
     let restoreContext = RestoreContext(
         targetBundleIdentifier: "com.apple.Safari",
@@ -105,11 +105,26 @@ func singleFastLaneMissPermanentlyDisablesFastLane() {
     #expect(entryBefore?.fastLaneEligible == true)
 
     cache.markFastLaneMiss(for: "com.apple.Safari")
+    #expect(cache.entry(for: "com.apple.Safari")?.fastLaneEligible == false)
 
-    let entryAfter = cache.entry(for: "com.apple.Safari")
-    #expect(entryAfter?.fastLaneEligible == false)
-    // Remains disabled — no auto-recovery
-    #expect(entryAfter?.restoreContext.previousBundleIdentifier == "com.apple.Terminal")
+    // A successful activation cycle (upsert) is the recovery signal:
+    // it must re-enable fast-lane eligibility for a previously-missed bundle.
+    let recoveredContext = RestoreContext(
+        targetBundleIdentifier: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal",
+        previousPID: 99,
+        previousBundleURL: URL(fileURLWithPath: "/Applications/Terminal.app"),
+        capturedAt: 200,
+        generation: 2
+    )
+    let recoveredEntry = cache.upsert(
+        targetBundleIdentifier: "com.apple.Safari",
+        coordinatorPreviousBundle: "com.apple.Terminal",
+        restoreContext: recoveredContext
+    )
+
+    #expect(recoveredEntry.fastLaneEligible == true)
+    #expect(cache.entry(for: "com.apple.Safari")?.fastLaneEligible == true)
 }
 
 @Test @MainActor


### PR DESCRIPTION
## Summary
- Fixes #126: a single `markFastLaneMiss` permanently demoted a bundle to compatibility lane because `upsert()` preserved the prior `fastLaneEligible` value via `entries[key] ?? Entry(...)`.
- `upsert()` is only invoked from `AppSwitcher.promotePendingActivationIfCurrent` (i.e. a successful stable activation), so a successful activation cycle is a natural recovery signal. One-line fix: reset `fastLaneEligible = true` in `upsert()`.
- No new state, timers, or decay windows — favors KISS/YAGNI and avoids reintroducing the pattern removed in #125.

## Why this approach
The issue listed three options. Approach #1 (reset on successful activation) is selected because:
1. Zero additional state and no clock dependency.
2. #2 (decay window) would reintroduce the timestamp/quarantine pattern explicitly removed in #125.
3. #3 (call `invalidate` from lifecycle hooks) pushes recovery responsibility onto callers, violating SRP/DIP.

## Test plan
- [x] Rewrote `singleFastLaneMissPermanentlyDisablesFastLane` (which documented the bug) into `successfulUpsertRecoversFastLaneAfterMiss`, asserting recovery.
- [x] Verified neighboring tests still hold by inspection:
  - `pipelineEnabledRespectsQuarantinedCacheEntry`: no re-upsert between miss and decision → still expects compatibility lane.
  - `pipelineEnabledRecoversFastLaneAfterSessionReset`: uses `.sessionReset` invalidation path → unchanged.
  - `frontmostChangePreservesRestoreContextButDisablesFastLane`: only exercises `invalidate(.frontmostChanged)` → unchanged.
- [ ] CI (macos-15) builds and runs the full Swift test suite — cannot validate locally on Linux.