### PR TITLE
[codex] Implement toggle reliability recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ Each iteration runs preflight checks, processes open PRs, selects an issue, impl
 - [`docs/signing-and-release.md`](./docs/signing-and-release.md)
 
 ## Project Status
-Quickey is feature-complete. Broad macOS validation has landed, Safari/Hyper relaunch behavior was revalidated on 2026-04-08 after the capture/activation/hide refactor, local DMG packaging and GitHub release automation are now in place, broader app-matrix revalidation is still pending, and credential-backed notarized release validation is still pending.
+Quickey is feature-complete. Broad macOS validation has landed, the 2026-04-09 toggle reliability recovery and transport-aware E2E updates are in place, packaged-app manual validation has clean recent toggle traces for both standard and Hyper coverage, local DMG packaging and GitHub release automation are now in place, broader app-matrix revalidation is still pending, and credential-backed notarized release validation is still pending.

--- a/Sources/Quickey/AppController.swift
+++ b/Sources/Quickey/AppController.swift
@@ -12,7 +12,8 @@ final class AppController {
         shortcutStore: shortcutStore,
         persistenceService: persistenceService,
         appSwitcher: appSwitcher,
-        usageTracker: usageTracker
+        usageTracker: usageTracker,
+        diagnosticClient: .live
     )
     private lazy var menuBarController = MenuBarController(
         onOpenSettings: { [weak self] in self?.openSettings() },
@@ -34,11 +35,15 @@ final class AppController {
         // Reference: alt-tab-macos
         AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide(), 1.0)
 
-        shortcutStore.replaceAll(with: persistenceService.load())
-        hyperKeyService.reapplyIfNeeded()
-        shortcutManager.start()
-        shortcutManager.setHyperKeyEnabled(hyperKeyService.isEnabled)
-        menuBarController.install()
+        Self.runStartupSequence(
+            loadShortcuts: { persistenceService.load() },
+            replaceShortcuts: { shortcutStore.replaceAll(with: $0) },
+            reapplyHyperIfNeeded: { hyperKeyService.reapplyIfNeeded() },
+            isHyperEnabled: { hyperKeyService.isEnabled },
+            setHyperKeyEnabled: { shortcutManager.setHyperKeyEnabled($0) },
+            startShortcutManager: { shortcutManager.start() },
+            installMenuBar: { menuBarController.install() }
+        )
     }
 
     func stop() {
@@ -49,5 +54,21 @@ final class AppController {
     private func openSettings() {
         settingsWindowController.show()
         NSApp.activate()
+    }
+
+    static func runStartupSequence(
+        loadShortcuts: @MainActor () -> [AppShortcut],
+        replaceShortcuts: @MainActor ([AppShortcut]) -> Void,
+        reapplyHyperIfNeeded: @MainActor () -> Void,
+        isHyperEnabled: @MainActor () -> Bool,
+        setHyperKeyEnabled: @MainActor (Bool) -> Void,
+        startShortcutManager: @MainActor () -> Void,
+        installMenuBar: @MainActor () -> Void
+    ) {
+        replaceShortcuts(loadShortcuts())
+        reapplyHyperIfNeeded()
+        setHyperKeyEnabled(isHyperEnabled())
+        startShortcutManager()
+        installMenuBar()
     }
 }

--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -145,11 +145,20 @@ final class AppSwitcher: AppSwitching {
     }
 
     struct FallbackActivationClient {
-        let openApplication: (URL, NSWorkspace.OpenConfiguration, @escaping @Sendable (Error?) -> Void) -> Void
+        let openApplication: (
+            URL,
+            NSWorkspace.OpenConfiguration,
+            @escaping @Sendable (NSRunningApplication?, Error?) -> Void
+        ) -> Void
     }
 
     struct HideRequestClient {
         let hideApplication: (NSRunningApplication) -> Bool
+    }
+
+    struct AppLookupClient {
+        let runningApplications: (String) -> [NSRunningApplication]
+        let applicationURL: (String) -> URL?
     }
 
     struct ConfirmationClient {
@@ -162,12 +171,9 @@ final class AppSwitcher: AppSwitching {
     private let activationClient: ActivationClient
     private let fallbackActivationClient: FallbackActivationClient
     private let hideRequestClient: HideRequestClient
+    private let appLookupClient: AppLookupClient
     private let confirmationClient: ConfirmationClient
     private let sessionCoordinator: ToggleSessionCoordinator
-    private var nextPendingGeneration = 0
-    private(set) var pendingActivationState: PendingActivationState?
-    private(set) var pendingDeactivationState: PendingDeactivationState?
-    private(set) var stableActivationState: StableActivationState?
 
     /// Re-entry guard: prevents nested calls to toggleApplication on the same run loop turn.
     private var isToggling = false
@@ -188,17 +194,19 @@ final class AppSwitcher: AppSwitching {
         activationClient: ActivationClient = .live,
         fallbackActivationClient: FallbackActivationClient = .live,
         hideRequestClient: HideRequestClient = .live,
+        appLookupClient: AppLookupClient = .live,
         confirmationClient: ConfirmationClient = .live,
-        sessionCoordinator: ToggleSessionCoordinator = ToggleSessionCoordinator()
+        sessionCoordinator: ToggleSessionCoordinator? = nil
     ) {
         self.frontmostTracker = frontmostTracker
         self.applicationObservation = applicationObservation
         self.activationClient = activationClient
         self.fallbackActivationClient = fallbackActivationClient
         self.hideRequestClient = hideRequestClient
+        self.appLookupClient = appLookupClient
         self.confirmationClient = confirmationClient
-        self.sessionCoordinator = sessionCoordinator
-        sessionCoordinator.startObservingWorkspaceNotifications()
+        self.sessionCoordinator = sessionCoordinator ?? ToggleSessionCoordinator(now: confirmationClient.now)
+        self.sessionCoordinator.startObservingWorkspaceNotifications()
         workspaceHideObserver = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didHideApplicationNotification,
             object: nil,
@@ -216,25 +224,98 @@ final class AppSwitcher: AppSwitching {
         }
     }
 
+    var pendingActivationState: PendingActivationState? {
+        pendingActivationState(for: nil)
+    }
+
+    var pendingDeactivationState: PendingDeactivationState? {
+        pendingDeactivationState(for: nil)
+    }
+
+    var stableActivationState: StableActivationState? {
+        stableActivationState(for: nil)
+    }
+
+    private func pendingActivationState(for bundleIdentifier: String?) -> PendingActivationState? {
+        let session = sessionCoordinator.pendingActivationSession(for: bundleIdentifier)
+        return session.map {
+            PendingActivationState(
+                bundleIdentifier: $0.bundleIdentifier,
+                previousBundleIdentifier: $0.previousBundle,
+                generation: $0.generation,
+                startedAt: $0.activationStartedAt
+            )
+        }
+    }
+
+    private func pendingDeactivationState(for bundleIdentifier: String?) -> PendingDeactivationState? {
+        let session = sessionCoordinator.pendingDeactivationSession(for: bundleIdentifier)
+        guard let session, let appName = session.appName else {
+            return nil
+        }
+        return PendingDeactivationState(
+            bundleIdentifier: session.bundleIdentifier,
+            appName: appName,
+            previousBundleIdentifier: session.previousBundle,
+            activationPath: session.activationPath,
+            generation: session.generation,
+            startedAt: session.phaseStartedAt
+        )
+    }
+
+    private func stableActivationState(for bundleIdentifier: String?) -> StableActivationState? {
+        let session = sessionCoordinator.stableSession(for: bundleIdentifier)
+        guard let session, let confirmedAt = session.confirmedAt else {
+            return nil
+        }
+        return StableActivationState(
+            bundleIdentifier: session.bundleIdentifier,
+            previousBundleIdentifier: session.previousBundle,
+            generation: session.generation,
+            startedAt: session.activationStartedAt,
+            confirmedAt: confirmedAt
+        )
+    }
+
     @discardableResult
     func acceptPendingActivation(
         for bundleIdentifier: String,
         previousBundleIdentifier: String?,
-        startedAt: CFAbsoluteTime
+        startedAt: CFAbsoluteTime,
+        pid: pid_t? = nil
     ) -> PendingActivationState {
-        nextPendingGeneration += 1
-        let state = PendingActivationState(
-            bundleIdentifier: bundleIdentifier,
-            previousBundleIdentifier: previousBundleIdentifier,
-            generation: nextPendingGeneration,
+        let session = sessionCoordinator.beginActivation(
+            for: bundleIdentifier,
+            previousBundle: previousBundleIdentifier,
+            pid: pid,
             startedAt: startedAt
         )
-        pendingActivationState = state
-        if stableActivationState?.bundleIdentifier == bundleIdentifier {
-            stableActivationState = nil
-        }
-        sessionCoordinator.beginActivation(for: bundleIdentifier, previousBundle: previousBundleIdentifier)
-        return state
+        return PendingActivationState(
+            bundleIdentifier: session.bundleIdentifier,
+            previousBundleIdentifier: session.previousBundle,
+            generation: session.generation,
+            startedAt: startedAt
+        )
+    }
+
+    @discardableResult
+    private func acceptPendingLaunch(
+        for shortcut: AppShortcut,
+        previousBundleIdentifier: String?,
+        startedAt: CFAbsoluteTime
+    ) -> PendingActivationState {
+        let session = sessionCoordinator.beginLaunch(
+            for: shortcut.bundleIdentifier,
+            appName: shortcut.appName,
+            previousBundle: previousBundleIdentifier,
+            startedAt: startedAt
+        )
+        return PendingActivationState(
+            bundleIdentifier: session.bundleIdentifier,
+            previousBundleIdentifier: session.previousBundle,
+            generation: session.generation,
+            startedAt: startedAt
+        )
     }
 
     @discardableResult
@@ -257,20 +338,35 @@ final class AppSwitcher: AppSwitching {
         appName: String,
         previousBundleIdentifier: String?,
         activationPath: ActivationPath,
-        startedAt: CFAbsoluteTime
+        startedAt: CFAbsoluteTime,
+        pid: pid_t? = nil
     ) -> PendingDeactivationState {
-        nextPendingGeneration += 1
-        let state = PendingDeactivationState(
-            bundleIdentifier: bundleIdentifier,
+        let session = sessionCoordinator.beginDeactivation(
+            for: bundleIdentifier,
             appName: appName,
-            previousBundleIdentifier: previousBundleIdentifier,
+            previousBundle: previousBundleIdentifier,
             activationPath: activationPath,
-            generation: nextPendingGeneration,
+            pid: pid,
             startedAt: startedAt
         )
-        pendingDeactivationState = state
-        sessionCoordinator.beginDeactivation(for: bundleIdentifier)
-        return state
+        guard let session else {
+            return PendingDeactivationState(
+                bundleIdentifier: bundleIdentifier,
+                appName: appName,
+                previousBundleIdentifier: previousBundleIdentifier,
+                activationPath: activationPath,
+                generation: pendingDeactivationState?.generation ?? -1,
+                startedAt: startedAt
+            )
+        }
+        return PendingDeactivationState(
+            bundleIdentifier: session.bundleIdentifier,
+            appName: session.appName ?? appName,
+            previousBundleIdentifier: session.previousBundle,
+            activationPath: session.activationPath,
+            generation: session.generation,
+            startedAt: startedAt
+        )
     }
 
     func shouldToggleOff(bundleIdentifier: String, runningAppIsActive: Bool) -> Bool {
@@ -289,7 +385,6 @@ final class AppSwitcher: AppSwitching {
         }
         guard coordinatorPhase == .activeStable else {
             DiagnosticLog.log("TOGGLE[\(stableActivationState.bundleIdentifier)]: stableState invalidated by coordinator, phase=\(coordinatorPhase?.rawValue ?? "no_session")")
-            self.stableActivationState = nil
             return false
         }
         return true
@@ -308,16 +403,7 @@ final class AppSwitcher: AppSwitching {
             return false
         }
 
-        stableActivationState = StableActivationState(
-            bundleIdentifier: bundleIdentifier,
-            previousBundleIdentifier: pendingActivationState.previousBundleIdentifier,
-            generation: generation,
-            startedAt: pendingActivationState.startedAt,
-            confirmedAt: confirmationClient.now()
-        )
-        self.pendingActivationState = nil
-        sessionCoordinator.markStable(for: bundleIdentifier)
-        return true
+        return sessionCoordinator.markStable(for: bundleIdentifier, generation: generation) != nil
     }
 
     func schedulePendingConfirmation(
@@ -372,10 +458,43 @@ final class AppSwitcher: AppSwitching {
                 generation: state.generation,
                 snapshot: snapshot
             ) {
+                self.logToggleTrace(
+                    family: .confirmation,
+                    bundleIdentifier: state.bundleIdentifier,
+                    event: "confirmed",
+                    reason: "activation_stable",
+                    activationPath: activationPath,
+                    previousBundle: pendingActivationState.previousBundleIdentifier
+                )
                 return
             }
 
+            if snapshot.targetIsObservedFrontmost,
+               snapshot.targetIsActive,
+               !snapshot.targetIsHidden,
+               !snapshot.allowsWindowlessStableActivation,
+               !snapshot.targetHasVisibleWindows,
+               !snapshot.hasFocusedWindow,
+               !snapshot.hasMainWindow {
+                self.logToggleTrace(
+                    family: .confirmation,
+                    bundleIdentifier: state.bundleIdentifier,
+                    event: "awaiting_window_evidence",
+                    reason: "frontmost_without_window_evidence",
+                    activationPath: activationPath,
+                    previousBundle: pendingActivationState.previousBundleIdentifier
+                )
+            }
+
             guard let nextRecoveryStage = self.nextRecoveryStage(for: snapshot, candidate: nextRecoveryStage) else {
+                self.logToggleTrace(
+                    family: .reset,
+                    bundleIdentifier: state.bundleIdentifier,
+                    event: "session_cleared",
+                    reason: "activation_recovery_exhausted",
+                    activationPath: activationPath,
+                    previousBundle: pendingActivationState.previousBundleIdentifier
+                )
                 self.clearActivationTracking(for: state.bundleIdentifier, resetPreviousTracking: true)
                 return
             }
@@ -441,6 +560,14 @@ final class AppSwitcher: AppSwitching {
 
             if confirmed {
                 self.completePendingDeactivation(for: state.bundleIdentifier)
+                self.logToggleTrace(
+                    family: .confirmation,
+                    bundleIdentifier: state.bundleIdentifier,
+                    event: "confirmed",
+                    reason: "hide_confirmed",
+                    activationPath: activationPath,
+                    previousBundle: previousBundle
+                )
                 self.logToggleLifecycle(
                     for: shortcut,
                     lifecycle: .hideConfirmed,
@@ -454,6 +581,14 @@ final class AppSwitcher: AppSwitching {
 
             if self.confirmationClient.now() - state.startedAt >= self.deactivationConfirmationTimeout {
                 self.cancelPendingDeactivation(for: state.bundleIdentifier)
+                self.logToggleTrace(
+                    family: .confirmation,
+                    bundleIdentifier: state.bundleIdentifier,
+                    event: "degraded",
+                    reason: "partial_hide_degraded",
+                    activationPath: activationPath,
+                    previousBundle: previousBundle
+                )
                 self.logToggleLifecycle(
                     for: shortcut,
                     lifecycle: .hideDegraded,
@@ -477,20 +612,7 @@ final class AppSwitcher: AppSwitching {
     }
 
     private func canPromoteToStable(with snapshot: ActivationObservationSnapshot) -> Bool {
-        guard snapshot.targetIsObservedFrontmost,
-              snapshot.targetIsActive,
-              !snapshot.targetIsHidden else {
-            return false
-        }
-
-        switch snapshot.classification {
-        case .regularWindowed, .nonStandardWindowed:
-            return snapshot.targetHasVisibleWindows
-                && snapshot.hasFocusedWindow
-                && snapshot.hasMainWindow
-        case .windowlessOrAccessory, .systemUtility:
-            return true
-        }
+        snapshot.isStableActivation
     }
 
     private func nextRecoveryStage(
@@ -521,15 +643,6 @@ final class AppSwitcher: AppSwitching {
     }
 
     private func clearActivationTracking(for bundleIdentifier: String, resetPreviousTracking: Bool) {
-        if pendingActivationState?.bundleIdentifier == bundleIdentifier {
-            pendingActivationState = nil
-        }
-        if pendingDeactivationState?.bundleIdentifier == bundleIdentifier {
-            pendingDeactivationState = nil
-        }
-        if stableActivationState?.bundleIdentifier == bundleIdentifier {
-            stableActivationState = nil
-        }
         if resetPreviousTracking {
             frontmostTracker.resetPreviousAppTracking()
         }
@@ -537,19 +650,10 @@ final class AppSwitcher: AppSwitching {
     }
 
     private func completePendingDeactivation(for bundleIdentifier: String) {
-        if pendingDeactivationState?.bundleIdentifier == bundleIdentifier {
-            pendingDeactivationState = nil
-        }
-        if stableActivationState?.bundleIdentifier == bundleIdentifier {
-            stableActivationState = nil
-        }
         sessionCoordinator.completeDeactivation(for: bundleIdentifier)
     }
 
     private func cancelPendingDeactivation(for bundleIdentifier: String) {
-        if pendingDeactivationState?.bundleIdentifier == bundleIdentifier {
-            pendingDeactivationState = nil
-        }
         sessionCoordinator.cancelDeactivation(for: bundleIdentifier)
     }
 
@@ -586,6 +690,14 @@ final class AppSwitcher: AppSwitching {
         // Re-entry guard
         guard !isToggling else {
             DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: BLOCKED re-entry guard")
+            logToggleTrace(
+                family: .decision,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "blocked",
+                reason: "re_entry_guard",
+                activationPath: nil,
+                previousBundle: sessionCoordinator.previousBundle(for: shortcut.bundleIdentifier)
+            )
             return false
         }
 
@@ -594,6 +706,14 @@ final class AppSwitcher: AppSwitching {
            attemptStartedAt - lastTime < toggleCooldown {
             let elapsed = Int((attemptStartedAt - lastTime) * 1000)
             DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: BLOCKED cooldown elapsedMs=\(elapsed) limit=\(Int(toggleCooldown * 1000))ms")
+            logToggleTrace(
+                family: .decision,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "blocked",
+                reason: "cooldown",
+                activationPath: nil,
+                previousBundle: sessionCoordinator.previousBundle(for: shortcut.bundleIdentifier)
+            )
             return false
         }
 
@@ -607,10 +727,23 @@ final class AppSwitcher: AppSwitching {
             }
         }
 
-        guard let runningApp = NSRunningApplication.runningApplications(withBundleIdentifier: shortcut.bundleIdentifier).first else {
+        guard let runningApp = appLookupClient.runningApplications(shortcut.bundleIdentifier).first else {
             // App not running — launch it
-            if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: shortcut.bundleIdentifier) {
+            if let appURL = appLookupClient.applicationURL(shortcut.bundleIdentifier) {
                 frontmostTracker.noteCurrentFrontmostApp(excluding: shortcut.bundleIdentifier)
+                _ = acceptPendingLaunch(
+                    for: shortcut,
+                    previousBundleIdentifier: frontmostTracker.lastNonTargetBundleIdentifier,
+                    startedAt: attemptStartedAt
+                )
+                logToggleTrace(
+                    family: .session,
+                    bundleIdentifier: shortcut.bundleIdentifier,
+                    event: "session_started",
+                    reason: "not_running_launch_request",
+                    activationPath: .launch,
+                    previousBundle: frontmostTracker.lastNonTargetBundleIdentifier
+                )
                 logger.info("TOGGLE[\(shortcut.appName)]: NOT RUNNING → launching")
                 DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: NOT RUNNING → launching, saved previous=\(frontmostTracker.lastNonTargetBundleIdentifier ?? "nil")")
                 logToggleLifecycle(
@@ -622,10 +755,31 @@ final class AppSwitcher: AppSwitching {
                 )
                 let bundleId = shortcut.bundleIdentifier
                 let configuration = NSWorkspace.OpenConfiguration()
-                NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { @Sendable app, error in
+                fallbackActivationClient.openApplication(appURL, configuration) { [weak self] launchedApp, error in
                     if let error {
                         logger.error("Failed to launch \(bundleId): \(error.localizedDescription)")
                         DiagnosticLog.log("Failed to launch \(bundleId): \(error.localizedDescription)")
+                        Task { @MainActor [weak self] in
+                            guard let self else { return }
+                            self.logToggleTrace(
+                                family: .reset,
+                                bundleIdentifier: bundleId,
+                                event: "session_cleared",
+                                reason: "launch_failed",
+                                activationPath: .launch,
+                                previousBundle: self.sessionCoordinator.previousBundle(for: bundleId)
+                            )
+                            self.clearActivationTracking(for: bundleId, resetPreviousTracking: true)
+                        }
+                        return
+                    }
+
+                    let launchedProcessIdentifier = launchedApp?.processIdentifier
+                    Task { @MainActor [weak self] in
+                        self?.continueOwnedLaunchConfirmation(
+                            for: shortcut,
+                            launchedProcessIdentifier: launchedProcessIdentifier
+                        )
                     }
                 }
                 return true
@@ -634,6 +788,11 @@ final class AppSwitcher: AppSwitching {
             DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: NOT RUNNING, no URL found — cannot launch")
             return false
         }
+
+        _ = sessionCoordinator.updateProcessIdentifier(
+            for: shortcut.bundleIdentifier,
+            pid: runningApp.processIdentifier
+        )
 
         let preActionWindowObservation = applicationObservation.windowObservation(for: runningApp)
         let preActionSnapshot = applicationObservation.snapshot(
@@ -644,7 +803,15 @@ final class AppSwitcher: AppSwitching {
         if stableActivationState?.bundleIdentifier == shortcut.bundleIdentifier,
            pendingDeactivationState?.bundleIdentifier != shortcut.bundleIdentifier,
            !preActionSnapshot.isStableActivation {
-            stableActivationState = nil
+            logToggleTrace(
+                family: .reset,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "session_invalidated",
+                reason: "stale_state_invalidated",
+                activationPath: sessionCoordinator.session(for: shortcut.bundleIdentifier)?.activationPath,
+                previousBundle: sessionCoordinator.previousBundle(for: shortcut.bundleIdentifier)
+            )
+            sessionCoordinator.resetSession(for: shortcut.bundleIdentifier)
         }
 
         if let pendingDeactivationState, pendingDeactivationState.bundleIdentifier == shortcut.bundleIdentifier {
@@ -654,6 +821,23 @@ final class AppSwitcher: AppSwitching {
                 DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: DEACTIVATING pending=true elapsedMs=\(elapsedMilliseconds(since: pendingDeactivationState.startedAt))")
             }
             return true
+        }
+
+        if let pendingActivationState = pendingActivationState(for: shortcut.bundleIdentifier),
+           canPromoteToStable(with: preActionSnapshot) {
+            logToggleTrace(
+                family: .decision,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "pending_promoted",
+                reason: "activation_pending_now_stable",
+                activationPath: sessionCoordinator.session(for: shortcut.bundleIdentifier)?.activationPath,
+                previousBundle: pendingActivationState.previousBundleIdentifier
+            )
+            _ = promotePendingActivationIfCurrent(
+                bundleIdentifier: shortcut.bundleIdentifier,
+                generation: pendingActivationState.generation,
+                snapshot: preActionSnapshot
+            )
         }
 
         if shouldToggleOff(bundleIdentifier: shortcut.bundleIdentifier, runningAppIsActive: runningApp.isActive),
@@ -674,7 +858,8 @@ final class AppSwitcher: AppSwitching {
                 appName: shortcut.appName,
                 previousBundleIdentifier: previousApp,
                 activationPath: .hide,
-                startedAt: attemptStartedAt
+                startedAt: attemptStartedAt,
+                pid: runningApp.processIdentifier
             )
             return performHideToggle(
                 shortcut: shortcut,
@@ -692,6 +877,22 @@ final class AppSwitcher: AppSwitching {
         if runningApp.isActive, preActionSnapshot.isStableActivation,
            stableActivationState?.bundleIdentifier != shortcut.bundleIdentifier,
            pendingActivationState?.bundleIdentifier != shortcut.bundleIdentifier {
+            let deactivationState = acceptPendingDeactivation(
+                for: shortcut.bundleIdentifier,
+                appName: shortcut.appName,
+                previousBundleIdentifier: nil,
+                activationPath: .hideUntracked,
+                startedAt: attemptStartedAt,
+                pid: runningApp.processIdentifier
+            )
+            logToggleTrace(
+                family: .decision,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "hide_untracked",
+                reason: "external_untracked_hide",
+                activationPath: .hideUntracked,
+                previousBundle: nil
+            )
             logToggleLifecycle(
                 for: shortcut,
                 lifecycle: .hideUntracked,
@@ -699,13 +900,6 @@ final class AppSwitcher: AppSwitching {
                 activationPath: .hideUntracked,
                 snapshot: preActionSnapshot,
                 elapsedMilliseconds: elapsedMilliseconds(since: attemptStartedAt)
-            )
-            let deactivationState = acceptPendingDeactivation(
-                for: shortcut.bundleIdentifier,
-                appName: shortcut.appName,
-                previousBundleIdentifier: nil,
-                activationPath: .hideUntracked,
-                startedAt: attemptStartedAt
             )
             return performHideToggle(
                 shortcut: shortcut,
@@ -740,6 +934,16 @@ final class AppSwitcher: AppSwitching {
             ? pendingActivationState?.startedAt ?? attemptStartedAt
             : attemptStartedAt
         let activationPath: ActivationPath = runningApp.isHidden ? .unhideActivate : .activate
+        if continuingPendingActivation, !canPromoteToStable(with: preActionSnapshot) {
+            logToggleTrace(
+                family: .decision,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "blocked",
+                reason: "activation_pending_not_stable",
+                activationPath: activationPath,
+                previousBundle: previousApp
+            )
+        }
         if runningApp.isActive {
             // Should not normally reach here — ACTIVE_UNTRACKED should have caught it.
             // Log a warning for diagnostics if it happens (e.g. isStableActivation was false).
@@ -766,11 +970,28 @@ final class AppSwitcher: AppSwitching {
             return false
         }
 
-        let pendingState = acceptPendingActivation(
-            for: shortcut.bundleIdentifier,
-            previousBundleIdentifier: previousApp,
-            startedAt: pendingStartedAt
-        )
+        let pendingState: PendingActivationState
+        if continuingPendingActivation {
+            _ = sessionCoordinator.continueActivation(
+                for: shortcut.bundleIdentifier,
+                activationPath: activationPath,
+                pid: runningApp.processIdentifier
+            )
+            pendingState = pendingActivationState(for: shortcut.bundleIdentifier)
+                ?? PendingActivationState(
+                    bundleIdentifier: shortcut.bundleIdentifier,
+                    previousBundleIdentifier: previousApp,
+                    generation: pendingActivationState?.generation ?? -1,
+                    startedAt: pendingStartedAt
+                )
+        } else {
+            pendingState = acceptPendingActivation(
+                for: shortcut.bundleIdentifier,
+                previousBundleIdentifier: previousApp,
+                startedAt: pendingStartedAt,
+                pid: runningApp.processIdentifier
+            )
+        }
         schedulePendingConfirmation(
             state: pendingState,
             shortcut: shortcut,
@@ -872,6 +1093,121 @@ final class AppSwitcher: AppSwitching {
         return true
     }
 
+    private func continueOwnedLaunchConfirmation(
+        for shortcut: AppShortcut,
+        launchedProcessIdentifier: pid_t?
+    ) {
+        guard let pendingState = pendingActivationState(for: shortcut.bundleIdentifier) else {
+            return
+        }
+
+        let runningApp = appLookupClient.runningApplications(shortcut.bundleIdentifier)
+            .first { runningApp in
+                guard let launchedProcessIdentifier else { return true }
+                return runningApp.processIdentifier == launchedProcessIdentifier
+            }
+        guard let runningApp else {
+            logToggleTrace(
+                family: .confirmation,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "awaiting_process",
+                reason: "launch_completion_missing_process",
+                activationPath: .launch,
+                previousBundle: pendingState.previousBundleIdentifier
+            )
+            return
+        }
+
+        _ = sessionCoordinator.continueActivation(
+            for: shortcut.bundleIdentifier,
+            activationPath: .launch,
+            pid: runningApp.processIdentifier
+        )
+        logToggleTrace(
+            family: .session,
+            bundleIdentifier: shortcut.bundleIdentifier,
+            event: "launch_attached",
+            reason: "launch_completion_process_lookup",
+            activationPath: .launch,
+            previousBundle: pendingState.previousBundleIdentifier
+        )
+
+        let preActionWindowObservation = applicationObservation.windowObservation(for: runningApp)
+        let preActionSnapshot = applicationObservation.snapshot(
+            for: runningApp,
+            windowObservation: preActionWindowObservation
+        )
+
+        if promotePendingActivationIfCurrent(
+            bundleIdentifier: shortcut.bundleIdentifier,
+            generation: pendingState.generation,
+            snapshot: preActionSnapshot
+        ) {
+            logToggleTrace(
+                family: .confirmation,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "confirmed",
+                reason: "activation_stable",
+                activationPath: .launch,
+                previousBundle: pendingState.previousBundleIdentifier
+            )
+            return
+        }
+
+        if runningApp.isHidden {
+            runningApp.unhide()
+        }
+        let windows = preActionWindowObservation.windows
+        unminimizeWindows(of: runningApp, windows: windows)
+        _ = activateViaWindowServer(runningApp, windows: windows)
+
+        let continuedState = pendingActivationState(for: shortcut.bundleIdentifier) ?? pendingState
+        schedulePendingConfirmation(
+            state: continuedState,
+            shortcut: shortcut,
+            activationPath: .launch,
+            observe: { [weak self] in
+                guard let self else {
+                    return ActivationObservationSnapshot(
+                        targetBundleIdentifier: runningApp.bundleIdentifier,
+                        observedFrontmostBundleIdentifier: nil,
+                        targetIsActive: false,
+                        targetIsHidden: true,
+                        visibleWindowCount: 0,
+                        hasFocusedWindow: false,
+                        hasMainWindow: false,
+                        windowObservationSucceeded: false,
+                        windowObservationFailureReason: "appSwitcherReleased",
+                        classification: .windowlessOrAccessory,
+                        classificationReason: "app switcher released during confirmation"
+                    )
+                }
+                let confirmationWindowObservation = self.applicationObservation.windowObservation(for: runningApp)
+                return self.applicationObservation.snapshot(
+                    for: runningApp,
+                    windowObservation: confirmationWindowObservation
+                )
+            },
+            recoverIfNeeded: { [weak self] stage, completion in
+                self?.recoverActivation(
+                    runningApp,
+                    shortcut: shortcut,
+                    stage: stage,
+                    fallbackActivate: {
+                        self?.requestFallbackActivation(
+                            bundleURL: runningApp.bundleURL,
+                            bundleIdentifier: runningApp.bundleIdentifier ?? "\(runningApp.processIdentifier)",
+                            plainActivate: {
+                                runningApp.activate()
+                            }
+                        ) ?? false
+                    },
+                    completion: completion
+                )
+            }
+        )
+    }
+
     // MARK: - Activation path
 
     /// Default activation is minimal: front-process only.
@@ -928,7 +1264,7 @@ final class AppSwitcher: AppSwitching {
 
         let configuration = NSWorkspace.OpenConfiguration()
         configuration.activates = true
-        fallbackActivationClient.openApplication(bundleURL, configuration) { error in
+        fallbackActivationClient.openApplication(bundleURL, configuration) { _, error in
             if let error {
                 logger.error("Fallback activation via NSWorkspace failed for \(bundleIdentifier): \(error.localizedDescription)")
                 DiagnosticLog.log("Fallback activation via NSWorkspace failed for \(bundleIdentifier): \(error.localizedDescription)")
@@ -1022,7 +1358,7 @@ final class AppSwitcher: AppSwitching {
             }
             completion()
         case .reopen:
-            guard let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: shortcut.bundleIdentifier) else {
+            guard let appURL = appLookupClient.applicationURL(shortcut.bundleIdentifier) else {
                 logger.info("TOGGLE[\(shortcut.appName)]: sending ⌘N (no app URL)")
                 DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: sending ⌘N (no app URL)")
                 recoverActivation(
@@ -1036,7 +1372,7 @@ final class AppSwitcher: AppSwitching {
             }
 
             let config = NSWorkspace.OpenConfiguration()
-            fallbackActivationClient.openApplication(appURL, config) { @Sendable error in
+            fallbackActivationClient.openApplication(appURL, config) { @Sendable _, error in
                 if let error {
                     logger.error("TOGGLE[\(shortcut.appName)]: NSWorkspace.open failed: \(error.localizedDescription)")
                     DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: NSWorkspace.open failed: \(error.localizedDescription)")
@@ -1164,7 +1500,8 @@ final class AppSwitcher: AppSwitching {
         effectiveStable: Bool? = nil
     ) -> String {
         let state = TogglePostActionState(snapshot: snapshot)
-        return "TOGGLE[\(shortcut.appName)]: \(phase.rawValue) \(state.logDetails) \(snapshot.structuredLogFields(stableOverride: effectiveStable))"
+        let sessionFields = sessionLogFields(for: shortcut.bundleIdentifier)
+        return "TOGGLE[\(shortcut.appName)]: \(phase.rawValue) \(state.logDetails) \(snapshot.structuredLogFields(stableOverride: effectiveStable)) \(sessionFields.joined(separator: " "))"
     }
 
     func toggleLifecycleLogMessage(
@@ -1188,6 +1525,7 @@ final class AppSwitcher: AppSwitching {
         } else {
             fields.append(ActivationObservationSnapshot.quotedField("frontmost", frontmostTracker.currentFrontmostBundleIdentifier()))
         }
+        fields.append(contentsOf: sessionLogFields(for: shortcut.bundleIdentifier))
 
         return "TOGGLE[\(shortcut.appName)]: \(lifecycle.rawValue) \(fields.joined(separator: " "))"
     }
@@ -1216,6 +1554,41 @@ final class AppSwitcher: AppSwitching {
 
     private func elapsedMilliseconds(since startedAt: CFAbsoluteTime) -> Int {
         Int((confirmationClient.now() - startedAt) * 1000)
+    }
+
+    private func sessionLogFields(for bundleIdentifier: String) -> [String] {
+        guard let session = sessionCoordinator.session(for: bundleIdentifier) else {
+            return ["attemptId=nil", "pid=nil", "phase=nil"]
+        }
+        return [
+            "attemptId=\(session.attemptID.uuidString)",
+            "pid=\(session.pid.map(String.init) ?? "nil")",
+            "phase=\(session.phase.rawValue)"
+        ]
+    }
+
+    private func logToggleTrace(
+        family: ToggleDiagnosticEvent.Family,
+        bundleIdentifier: String,
+        event: String,
+        reason: String?,
+        activationPath: ActivationPath?,
+        previousBundle: String?
+    ) {
+        let session = sessionCoordinator.session(for: bundleIdentifier)
+        let message = ToggleDiagnosticEvent(
+            family: family,
+            attemptID: session?.attemptID,
+            bundleIdentifier: bundleIdentifier,
+            pid: session?.pid,
+            phase: session?.phase,
+            event: event,
+            activationPath: activationPath ?? session?.activationPath,
+            reason: reason,
+            previousBundleIdentifier: previousBundle ?? session?.previousBundle
+        ).logMessage
+        logger.info("\(message)")
+        DiagnosticLog.log(message)
     }
 
     nonisolated static let hideTransport: HideTransport = .runningApplicationHide
@@ -1248,8 +1621,8 @@ extension AppSwitcher.FallbackActivationClient {
     @MainActor
     static let live = AppSwitcher.FallbackActivationClient(
         openApplication: { url, configuration, completion in
-            NSWorkspace.shared.openApplication(at: url, configuration: configuration) { @Sendable _, error in
-                completion(error)
+            NSWorkspace.shared.openApplication(at: url, configuration: configuration) { @Sendable app, error in
+                completion(app, error)
             }
         }
     )
@@ -1260,6 +1633,18 @@ extension AppSwitcher.HideRequestClient {
     static let live = AppSwitcher.HideRequestClient(
         hideApplication: { app in
             app.hide()
+        }
+    )
+}
+
+extension AppSwitcher.AppLookupClient {
+    @MainActor
+    static let live = AppSwitcher.AppLookupClient(
+        runningApplications: { bundleIdentifier in
+            NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+        },
+        applicationURL: { bundleIdentifier in
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
         }
     )
 }

--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -183,6 +183,7 @@ final class AppSwitcher: AppSwitching {
     private let toggleCooldown: TimeInterval = 0.4
     private let cooldownCacheLimit = 20
     private let cooldownEvictionWindow: CFAbsoluteTime = 60
+    private let hiddenStateSettleRetryDelay: TimeInterval = 0.05
     private let deactivationConfirmationInitialDelay: TimeInterval = 0.05
     private let deactivationConfirmationPollInterval: TimeInterval = 0.05
     private let deactivationConfirmationTimeout: TimeInterval = 0.3
@@ -419,6 +420,7 @@ final class AppSwitcher: AppSwitching {
             activationPath: activationPath,
             delay: 0.075,
             nextRecoveryStage: .makeKeyWindow,
+            allowHiddenStateSettleRetry: true,
             observe: observe,
             recoverIfNeeded: recoverIfNeeded
         )
@@ -430,6 +432,7 @@ final class AppSwitcher: AppSwitching {
         activationPath: ActivationPath,
         delay: TimeInterval,
         nextRecoveryStage: WindowRecoveryStage?,
+        allowHiddenStateSettleRetry: Bool,
         observe: @escaping @MainActor () -> ActivationObservationSnapshot,
         recoverIfNeeded: @escaping @MainActor (WindowRecoveryStage, @escaping @MainActor () -> Void) -> Void
     ) {
@@ -465,6 +468,29 @@ final class AppSwitcher: AppSwitching {
                     reason: "activation_stable",
                     activationPath: activationPath,
                     previousBundle: pendingActivationState.previousBundleIdentifier
+                )
+                return
+            }
+
+            if allowHiddenStateSettleRetry,
+               self.shouldRetryObservationForHiddenStateLag(with: snapshot) {
+                self.logToggleTrace(
+                    family: .confirmation,
+                    bundleIdentifier: state.bundleIdentifier,
+                    event: "awaiting_hidden_state_settle",
+                    reason: "frontmost_window_complete_hidden_lag",
+                    activationPath: activationPath,
+                    previousBundle: pendingActivationState.previousBundleIdentifier
+                )
+                self.schedulePendingConfirmation(
+                    state: state,
+                    shortcut: shortcut,
+                    activationPath: activationPath,
+                    delay: self.hiddenStateSettleRetryDelay,
+                    nextRecoveryStage: nextRecoveryStage,
+                    allowHiddenStateSettleRetry: false,
+                    observe: observe,
+                    recoverIfNeeded: recoverIfNeeded
                 )
                 return
             }
@@ -507,6 +533,7 @@ final class AppSwitcher: AppSwitching {
                     activationPath: activationPath,
                     delay: nextRecoveryStage.settlingDelay,
                     nextRecoveryStage: nextRecoveryStage.nextStage,
+                    allowHiddenStateSettleRetry: false,
                     observe: observe,
                     recoverIfNeeded: recoverIfNeeded
                 )
@@ -636,6 +663,15 @@ final class AppSwitcher: AppSwitching {
             return .axRaise
         }
         return candidate
+    }
+
+    private func shouldRetryObservationForHiddenStateLag(with snapshot: ActivationObservationSnapshot) -> Bool {
+        snapshot.targetIsObservedFrontmost &&
+            snapshot.targetIsActive &&
+            snapshot.targetIsHidden &&
+            snapshot.targetHasVisibleWindows &&
+            snapshot.hasFocusedWindow &&
+            snapshot.hasMainWindow
     }
 
     private func canConfirmDeactivation(with snapshot: ActivationObservationSnapshot) -> Bool {

--- a/Sources/Quickey/Services/ApplicationObservation.swift
+++ b/Sources/Quickey/Services/ApplicationObservation.swift
@@ -20,6 +20,35 @@ struct ActivationObservationSnapshot: Sendable, Equatable {
     let windowObservationFailureReason: String?
     let classification: ApplicationClassification
     let classificationReason: String
+    let allowsWindowlessStableActivation: Bool
+
+    init(
+        targetBundleIdentifier: String?,
+        observedFrontmostBundleIdentifier: String?,
+        targetIsActive: Bool,
+        targetIsHidden: Bool,
+        visibleWindowCount: Int,
+        hasFocusedWindow: Bool,
+        hasMainWindow: Bool,
+        windowObservationSucceeded: Bool,
+        windowObservationFailureReason: String?,
+        classification: ApplicationClassification,
+        classificationReason: String,
+        allowsWindowlessStableActivation: Bool = false
+    ) {
+        self.targetBundleIdentifier = targetBundleIdentifier
+        self.observedFrontmostBundleIdentifier = observedFrontmostBundleIdentifier
+        self.targetIsActive = targetIsActive
+        self.targetIsHidden = targetIsHidden
+        self.visibleWindowCount = visibleWindowCount
+        self.hasFocusedWindow = hasFocusedWindow
+        self.hasMainWindow = hasMainWindow
+        self.windowObservationSucceeded = windowObservationSucceeded
+        self.windowObservationFailureReason = windowObservationFailureReason
+        self.classification = classification
+        self.classificationReason = classificationReason
+        self.allowsWindowlessStableActivation = allowsWindowlessStableActivation
+    }
 
     var targetHasVisibleWindows: Bool {
         visibleWindowCount > 0
@@ -35,14 +64,11 @@ struct ActivationObservationSnapshot: Sendable, Equatable {
             return false
         }
 
-        switch classification {
-        case .regularWindowed:
-            return targetHasVisibleWindows || hasFocusedWindow || hasMainWindow
-        case .nonStandardWindowed:
-            return targetHasVisibleWindows && hasFocusedWindow && hasMainWindow
-        case .windowlessOrAccessory, .systemUtility:
+        if allowsWindowlessStableActivation {
             return true
         }
+
+        return targetHasVisibleWindows || hasFocusedWindow || hasMainWindow
     }
 
     var structuredLogFields: String {
@@ -62,6 +88,7 @@ struct ActivationObservationSnapshot: Sendable, Equatable {
             Self.quotedField("windowObservationFailureReason", windowObservationFailureReason),
             Self.quotedField("classification", classification.rawValue),
             Self.quotedField("classificationReason", classificationReason),
+            "allowsWindowlessStableActivation=\(allowsWindowlessStableActivation)",
             "stable=\(stableOverride ?? isStableActivation)"
         ].joined(separator: " ")
     }
@@ -147,7 +174,8 @@ struct ApplicationObservation {
             windowObservationSucceeded: windowObservation.windowsReadSucceeded,
             windowObservationFailureReason: windowObservation.failureReason,
             classification: classification.classification,
-            classificationReason: classification.reason
+            classificationReason: classification.reason,
+            allowsWindowlessStableActivation: classification.allowsWindowlessStableActivation
         )
     }
 
@@ -155,28 +183,28 @@ struct ApplicationObservation {
         bundleIdentifier: String?,
         activationPolicy: NSApplication.ActivationPolicy,
         windowObservation: WindowObservation
-    ) -> (classification: ApplicationClassification, reason: String) {
+    ) -> (classification: ApplicationClassification, reason: String, allowsWindowlessStableActivation: Bool) {
         if activationPolicy != .regular {
-            return (.systemUtility, "activation policy is \(String(describing: activationPolicy))")
+            return (.systemUtility, "activation policy is \(String(describing: activationPolicy))", true)
         }
 
         if !windowObservation.windowsReadSucceeded {
-            return (.nonStandardWindowed, windowObservation.failureReason ?? "window observation failed")
+            return (.nonStandardWindowed, windowObservation.failureReason ?? "window observation failed", false)
         }
 
         if windowObservation.visibleWindowCount == 0 &&
             !windowObservation.hasFocusedWindow &&
             !windowObservation.hasMainWindow {
-            return (.windowlessOrAccessory, "no visible, focused, or main windows")
+            return (.nonStandardWindowed, "regular app has no visible, focused, or main window evidence", false)
         }
 
         if windowObservation.visibleWindowCount == 0 ||
             !windowObservation.hasFocusedWindow ||
             !windowObservation.hasMainWindow {
-            return (.nonStandardWindowed, "window evidence is incomplete for \(bundleIdentifier ?? "unknown bundle")")
+            return (.nonStandardWindowed, "window evidence is incomplete for \(bundleIdentifier ?? "unknown bundle")", false)
         }
 
-        return (.regularWindowed, "visible focused main window")
+        return (.regularWindowed, "visible focused main window", false)
     }
 }
 

--- a/Sources/Quickey/Services/EventTapManager.swift
+++ b/Sources/Quickey/Services/EventTapManager.swift
@@ -169,7 +169,16 @@ func handleEventTapEvent(
         if swallow {
             let seq = box.incrementAndGetSwallowSequence()
             DispatchQueue.global(qos: .utility).async {
-                DiagnosticLog.log("EVENT_TAP_SWALLOW: seq=\(seq) keyCode=\(keyCode) modifiers=\(keyPress.modifiers.rawValue) eventTimestamp=\(eventTimestamp)")
+                DiagnosticLog.log(
+                    eventTapSwallowLogMessage(
+                        seq: seq,
+                        keyCode: keyCode,
+                        modifiers: keyPress.modifiers,
+                        eventTimestamp: eventTimestamp,
+                        isAutorepeat: isAutorepeat,
+                        hyperInjected: injectHyper
+                    )
+                )
             }
             box.onKeyPress?(keyPress)
             return nil
@@ -266,6 +275,17 @@ func handleEventTapEvent(
     default:
         return Unmanaged.passUnretained(event)
     }
+}
+
+func eventTapSwallowLogMessage(
+    seq: Int,
+    keyCode: CGKeyCode,
+    modifiers: NSEvent.ModifierFlags,
+    eventTimestamp: UInt64,
+    isAutorepeat: Bool,
+    hyperInjected: Bool
+) -> String {
+    "EVENT_TAP_SWALLOW: seq=\(seq) keyCode=\(keyCode) modifiers=\(modifiers.rawValue) eventTimestamp=\(eventTimestamp) autorepeat=\(isAutorepeat) hyperInjected=\(hyperInjected)"
 }
 
 private let eventTapCallback: CGEventTapCallBack = { _, type, event, userInfo in

--- a/Sources/Quickey/Services/ShortcutManager.swift
+++ b/Sources/Quickey/Services/ShortcutManager.swift
@@ -7,18 +7,24 @@ private let logger = Logger(subsystem: DiagnosticLog.subsystem, category: "Short
 
 @MainActor
 final class ShortcutManager {
+    struct DiagnosticClient {
+        let log: @Sendable (String) -> Void
+    }
+
     private let shortcutStore: ShortcutStore
     private let persistenceService: PersistenceService
     private let appSwitcher: any AppSwitching
     private let captureCoordinator: ShortcutCaptureCoordinator
     private let permissionService: any PermissionServicing
     private let usageTracker: UsageTracker?
+    private let diagnosticClient: DiagnosticClient
     private let keyMatcher = KeyMatcher()
     private var triggerIndex: [ShortcutTrigger: AppShortcut] = [:]
     private var permissionTimer: Timer?
     private var lastAccessibilityState: Bool = false
     private var lastInputMonitoringState: Bool = false
     private var hyperKeyEnabled = false
+    private var lastCaptureBlockedMessages: Set<String> = []
 
     init(
         shortcutStore: ShortcutStore,
@@ -26,7 +32,8 @@ final class ShortcutManager {
         appSwitcher: any AppSwitching,
         captureCoordinator: ShortcutCaptureCoordinator = ShortcutCaptureCoordinator(),
         permissionService: any PermissionServicing = AccessibilityPermissionService(),
-        usageTracker: UsageTracker? = nil
+        usageTracker: UsageTracker? = nil,
+        diagnosticClient: DiagnosticClient
     ) {
         self.shortcutStore = shortcutStore
         self.persistenceService = persistenceService
@@ -34,12 +41,13 @@ final class ShortcutManager {
         self.captureCoordinator = captureCoordinator
         self.permissionService = permissionService
         self.usageTracker = usageTracker
+        self.diagnosticClient = diagnosticClient
     }
 
     func start() {
         let trusted = permissionService.requestIfNeeded(prompt: true)
         logger.info("start(): trusted=\(trusted), isTrusted=\(self.permissionService.isTrusted())")
-        DiagnosticLog.log("start(): trusted=\(trusted), isTrusted=\(permissionService.isTrusted())")
+        diagnosticClient.log("start(): trusted=\(trusted), isTrusted=\(permissionService.isTrusted())")
         startPermissionMonitoring()
         rebuildIndex()
         attemptStartIfPermitted()
@@ -100,7 +108,7 @@ final class ShortcutManager {
         logger.info(
             "checkPermission: ax=\(axGranted) im=\(imGranted) carbon=\(snapshot.carbonHotKeysRegistered) eventTap=\(snapshot.eventTapActive)"
         )
-        DiagnosticLog.log(
+        diagnosticClient.log(
             "checkPermission: ax=\(axGranted) im=\(imGranted) carbon=\(snapshot.carbonHotKeysRegistered) eventTap=\(snapshot.eventTapActive)"
         )
 
@@ -108,10 +116,10 @@ final class ShortcutManager {
         if accessibilityChanged {
             if axGranted {
                 logger.notice("Accessibility permission: granted")
-                DiagnosticLog.log("Accessibility permission: granted")
+                diagnosticClient.log("Accessibility permission: granted")
             } else {
                 logger.error("Accessibility permission: REVOKED")
-                DiagnosticLog.log("Accessibility permission: REVOKED")
+                diagnosticClient.log("Accessibility permission: REVOKED")
                 sendPermissionNotification(permission: "Accessibility")
             }
             lastAccessibilityState = axGranted
@@ -120,10 +128,10 @@ final class ShortcutManager {
         if inputMonitoringChanged {
             if imGranted {
                 logger.notice("Input Monitoring permission: granted")
-                DiagnosticLog.log("Input Monitoring permission: granted")
+                diagnosticClient.log("Input Monitoring permission: granted")
             } else {
                 logger.error("Input Monitoring permission: REVOKED")
-                DiagnosticLog.log("Input Monitoring permission: REVOKED")
+                diagnosticClient.log("Input Monitoring permission: REVOKED")
                 sendPermissionNotification(permission: "Input Monitoring")
             }
             lastInputMonitoringState = imGranted
@@ -132,7 +140,7 @@ final class ShortcutManager {
         guard axGranted else {
             if snapshot.carbonHotKeysRegistered || snapshot.eventTapActive {
                 logger.error("Accessibility lost — stopping shortcut capture")
-                DiagnosticLog.log("Accessibility lost — stopping shortcut capture")
+                diagnosticClient.log("Accessibility lost — stopping shortcut capture")
                 captureCoordinator.stop()
             }
             return
@@ -149,7 +157,7 @@ final class ShortcutManager {
 
         captureCoordinator.refreshInputMonitoring(granted: imGranted)
         logger.notice("Accessibility ready — syncing shortcut capture")
-        DiagnosticLog.log("Accessibility ready — syncing shortcut capture")
+        diagnosticClient.log("Accessibility ready — syncing shortcut capture")
         attemptStartIfPermitted()
     }
 
@@ -187,9 +195,10 @@ final class ShortcutManager {
         logger.info(
             "attemptStart: shortcuts=\(self.shortcutStore.shortcuts.count) triggerIndex=\(self.triggerIndex.count) carbon=\(snapshot.carbonHotKeysRegistered) eventTap=\(snapshot.eventTapActive)"
         )
-        DiagnosticLog.log(
+        diagnosticClient.log(
             "attemptStart: shortcuts=\(shortcutStore.shortcuts.count) triggerIndex=\(triggerIndex.count) carbon=\(snapshot.carbonHotKeysRegistered) eventTap=\(snapshot.eventTapActive)"
         )
+        emitCaptureBlockedDiagnostics(snapshot: snapshot)
     }
 
     // MARK: - Key handling
@@ -211,8 +220,69 @@ final class ShortcutManager {
             return false
         }
         logger.info("MATCHED: \(match.appName) - \(match.bundleIdentifier)")
-        DiagnosticLog.log("MATCHED: \(match.appName) - \(match.bundleIdentifier)")
+        diagnosticClient.log("MATCHED: \(match.appName) - \(match.bundleIdentifier)")
+        diagnosticClient.log(matchedShortcutTraceMessage(for: match))
         _ = trigger(match)
         return true
     }
+
+    private func emitCaptureBlockedDiagnostics(snapshot: ShortcutCaptureSnapshot) {
+        var blockedMessages = Set<String>()
+
+        if snapshot.standardShortcutCount > 0 && !snapshot.carbonHotKeysRegistered {
+            blockedMessages.insert(captureBlockedMessage(
+                reason: "missing_registration_or_system_conflict",
+                route: .standard,
+                snapshot: snapshot
+            ))
+        }
+
+        if snapshot.hyperShortcutCount > 0 && !permissionService.isInputMonitoringTrusted() {
+            blockedMessages.insert(captureBlockedMessage(
+                reason: "input_monitoring_missing",
+                route: .hyper,
+                snapshot: snapshot
+            ))
+        } else if snapshot.hyperShortcutCount > 0 && !snapshot.eventTapActive {
+            blockedMessages.insert(captureBlockedMessage(
+                reason: "event_tap_inactive",
+                route: .hyper,
+                snapshot: snapshot
+            ))
+        }
+
+        guard blockedMessages != lastCaptureBlockedMessages else {
+            return
+        }
+
+        lastCaptureBlockedMessages = blockedMessages
+        for message in blockedMessages.sorted() {
+            diagnosticClient.log(message)
+        }
+    }
+
+    func matchedShortcutTraceMessage(for shortcut: AppShortcut) -> String {
+        let route = ShortcutCaptureRoute.route(for: shortcut, hyperKeyEnabled: hyperKeyEnabled)
+        return "SHORTCUT_TRACE_DECISION event=matched bundle=\(shortcut.bundleIdentifier) route=\(route == .hyper ? "hyper" : "standard")"
+    }
+
+    func captureBlockedMessage(
+        reason: String,
+        route: ShortcutCaptureRoute,
+        snapshot: ShortcutCaptureSnapshot
+    ) -> String {
+        "SHORTCUT_TRACE_BLOCKED reason=\(quoted(reason)) route=\(route == .hyper ? "hyper" : "standard") carbonRegistered=\(snapshot.carbonHotKeysRegistered) eventTapActive=\(snapshot.eventTapActive) standardShortcutCount=\(snapshot.standardShortcutCount) hyperShortcutCount=\(snapshot.hyperShortcutCount)"
+    }
+
+    private func quoted(_ value: String) -> String {
+        "\"\(value.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\""))\""
+    }
+}
+
+extension ShortcutManager.DiagnosticClient {
+    static let live = ShortcutManager.DiagnosticClient(
+        log: { message in
+            DiagnosticLog.log(message)
+        }
+    )
 }

--- a/Sources/Quickey/Services/ToggleDiagnosticEvent.swift
+++ b/Sources/Quickey/Services/ToggleDiagnosticEvent.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+struct ToggleDiagnosticEvent: Sendable {
+    enum Family: String, Sendable {
+        case decision = "TOGGLE_TRACE_DECISION"
+        case session = "TOGGLE_TRACE_SESSION"
+        case reset = "TOGGLE_TRACE_RESET"
+        case confirmation = "TOGGLE_TRACE_CONFIRMATION"
+    }
+
+    let family: Family
+    let attemptID: UUID?
+    let bundleIdentifier: String
+    let pid: pid_t?
+    let phase: ToggleSessionCoordinator.Session.Phase?
+    let event: String
+    let activationPath: AppSwitcher.ActivationPath?
+    let reason: String?
+    let previousBundleIdentifier: String?
+
+    var logMessage: String {
+        [
+            family.rawValue,
+            Self.stringField("attemptId", attemptID?.uuidString ?? "nil"),
+            Self.stringField("bundle", bundleIdentifier),
+            "pid=\(pid.map(String.init) ?? "nil")",
+            Self.stringField("phase", phase?.rawValue ?? "nil"),
+            Self.stringField("event", event),
+            Self.stringField("activationPath", activationPath?.rawValue ?? "nil"),
+            Self.quotedField("reason", reason),
+            Self.quotedField("previousBundle", previousBundleIdentifier)
+        ].joined(separator: " ")
+    }
+
+    private static func stringField(_ key: String, _ value: String) -> String {
+        "\(key)=\(value)"
+    }
+
+    private static func quotedField(_ key: String, _ value: String?) -> String {
+        "\(key)=\(encode(value ?? "nil"))"
+    }
+
+    private static func encode(_ value: String) -> String {
+        var escaped = "\""
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "\"":
+                escaped.append("\\\"")
+            case "\\":
+                escaped.append("\\\\")
+            case "\n":
+                escaped.append("\\n")
+            case "\r":
+                escaped.append("\\r")
+            case "\t":
+                escaped.append("\\t")
+            default:
+                escaped.unicodeScalars.append(scalar)
+            }
+        }
+        escaped.append("\"")
+        return escaped
+    }
+}

--- a/Sources/Quickey/Services/ToggleSessionCoordinator.swift
+++ b/Sources/Quickey/Services/ToggleSessionCoordinator.swift
@@ -14,11 +14,17 @@ final class ToggleSessionCoordinator {
         var sessionCap: Int = 50
     }
 
-    struct Session: Equatable {
+    struct ToggleSession: Equatable {
         let bundleIdentifier: String
+        let attemptID: UUID
+        var generation: Int
+        var pid: pid_t?
+        var appName: String?
         var phase: Phase
+        var activationPath: AppSwitcher.ActivationPath
         var previousBundle: String?
         var activationStartedAt: CFAbsoluteTime
+        var phaseStartedAt: CFAbsoluteTime
         var lastActivityAt: CFAbsoluteTime
         var confirmedAt: CFAbsoluteTime?
         var retryCount: Int
@@ -26,12 +32,15 @@ final class ToggleSessionCoordinator {
 
         enum Phase: String, Equatable, Sendable {
             case idle
+            case launching
             case activating
             case activeStable
             case deactivating
             case degraded
         }
     }
+
+    typealias Session = ToggleSession
 
     enum ReconfirmResult: Equatable {
         case accepted
@@ -42,6 +51,7 @@ final class ToggleSessionCoordinator {
 
     let configuration: Configuration
     private let now: @MainActor () -> CFAbsoluteTime
+    private var nextGeneration = 0
     private(set) var sessions: [String: Session] = [:]
 
     init(
@@ -70,30 +80,127 @@ final class ToggleSessionCoordinator {
         session(for: bundleIdentifier)?.previousBundle
     }
 
+    func pendingActivationSession(for bundleIdentifier: String? = nil) -> Session? {
+        session(for: bundleIdentifier, matching: [.launching, .activating, .degraded])
+    }
+
+    func pendingDeactivationSession(for bundleIdentifier: String? = nil) -> Session? {
+        session(for: bundleIdentifier, matching: [.deactivating])
+    }
+
+    func stableSession(for bundleIdentifier: String? = nil) -> Session? {
+        session(for: bundleIdentifier, matching: [.activeStable, .deactivating])
+    }
+
+    func trackedActivationBundle(excluding bundleIdentifier: String) -> String? {
+        guard let session = mostRecentSession(matching: [.launching, .activating, .activeStable, .deactivating, .degraded]),
+              session.bundleIdentifier != bundleIdentifier else {
+            return nil
+        }
+        return session.bundleIdentifier
+    }
+
     // MARK: - Mutations
 
     @discardableResult
-    func beginActivation(for bundleIdentifier: String, previousBundle: String?) -> Session {
-        evictIfNeeded(excluding: bundleIdentifier)
-        let currentTime = now()
-        let session = Session(
+    func beginLaunch(
+        for bundleIdentifier: String,
+        appName: String? = nil,
+        previousBundle: String?,
+        startedAt: CFAbsoluteTime? = nil
+    ) -> Session {
+        makeSession(
             bundleIdentifier: bundleIdentifier,
-            phase: .activating,
+            appName: appName,
+            phase: .launching,
+            activationPath: .launch,
             previousBundle: previousBundle,
-            activationStartedAt: currentTime,
-            lastActivityAt: currentTime,
-            confirmedAt: nil,
-            retryCount: 0,
-            degradedReason: nil
+            pid: nil,
+            startedAt: startedAt
         )
+    }
+
+    @discardableResult
+    func beginActivation(
+        for bundleIdentifier: String,
+        previousBundle: String?,
+        appName: String? = nil,
+        activationPath: AppSwitcher.ActivationPath = .activate,
+        pid: pid_t? = nil,
+        startedAt: CFAbsoluteTime? = nil
+    ) -> Session {
+        makeSession(
+            bundleIdentifier: bundleIdentifier,
+            appName: appName,
+            phase: .activating,
+            activationPath: activationPath,
+            previousBundle: previousBundle,
+            pid: pid,
+            startedAt: startedAt
+        )
+    }
+
+    @discardableResult
+    func updateProcessIdentifier(for bundleIdentifier: String, pid: pid_t?) -> Session? {
+        guard var session = sessions[bundleIdentifier] else { return nil }
+        if let existingPID = session.pid,
+           let pid,
+           existingPID != pid {
+            let rolloverMessage = ToggleDiagnosticEvent(
+                family: .reset,
+                attemptID: session.attemptID,
+                bundleIdentifier: bundleIdentifier,
+                pid: existingPID,
+                phase: session.phase,
+                event: "session_cleared",
+                activationPath: session.activationPath,
+                reason: "pid_rollover",
+                previousBundleIdentifier: session.previousBundle
+            ).logMessage
+            DiagnosticLog.log(rolloverMessage)
+
+            let replacement = makeSession(
+                bundleIdentifier: bundleIdentifier,
+                appName: session.appName,
+                phase: .activating,
+                activationPath: session.activationPath,
+                previousBundle: session.previousBundle,
+                pid: pid,
+                startedAt: now()
+            )
+            return replacement
+        }
+        session.pid = pid
+        session.lastActivityAt = now()
         sessions[bundleIdentifier] = session
         return session
     }
 
     @discardableResult
-    func markStable(for bundleIdentifier: String) -> Session? {
+    func continueActivation(
+        for bundleIdentifier: String,
+        activationPath: AppSwitcher.ActivationPath,
+        pid: pid_t? = nil
+    ) -> Session? {
         guard var session = sessions[bundleIdentifier],
-              session.phase == .activating || session.phase == .degraded else {
+              session.phase == .launching || session.phase == .activating || session.phase == .degraded else {
+            return nil
+        }
+        session.phase = .activating
+        session.activationPath = activationPath
+        if let pid {
+            session.pid = pid
+        }
+        session.lastActivityAt = now()
+        sessions[bundleIdentifier] = session
+        return session
+    }
+
+    @discardableResult
+    func markStable(for bundleIdentifier: String, generation: Int? = nil) -> Session? {
+        guard var session = sessions[bundleIdentifier],
+              session.phase == .launching || session.phase == .activating || session.phase == .degraded,
+              generation.map({ $0 == session.generation }) ?? true else {
             return nil
         }
         let currentTime = now()
@@ -105,13 +212,15 @@ final class ToggleSessionCoordinator {
     }
 
     @discardableResult
-    func markDegraded(for bundleIdentifier: String, reason: String) -> Session? {
+    func markDegraded(for bundleIdentifier: String, reason: String, generation: Int? = nil) -> Session? {
         guard var session = sessions[bundleIdentifier],
-              session.phase == .activating || session.phase == .degraded else {
+              session.phase == .launching || session.phase == .activating || session.phase == .degraded,
+              generation.map({ $0 == session.generation }) ?? true else {
             return nil
         }
         session.phase = .degraded
         session.degradedReason = reason
+        session.lastActivityAt = now()
         sessions[bundleIdentifier] = session
         return session
     }
@@ -146,13 +255,43 @@ final class ToggleSessionCoordinator {
     }
 
     @discardableResult
-    func beginDeactivation(for bundleIdentifier: String) -> Session? {
+    func beginDeactivation(
+        for bundleIdentifier: String,
+        appName: String? = nil,
+        previousBundle: String? = nil,
+        activationPath: AppSwitcher.ActivationPath = .hide,
+        pid: pid_t? = nil,
+        startedAt: CFAbsoluteTime? = nil
+    ) -> Session? {
+        if activationPath == .hideUntracked {
+            return makeSession(
+                bundleIdentifier: bundleIdentifier,
+                appName: appName,
+                phase: .deactivating,
+                activationPath: activationPath,
+                previousBundle: previousBundle,
+                pid: pid,
+                startedAt: startedAt
+            )
+        }
+
         guard var session = sessions[bundleIdentifier],
               session.phase == .activeStable else {
             return nil
         }
         let currentTime = now()
+        if let appName {
+            session.appName = appName
+        }
+        if let previousBundle {
+            session.previousBundle = previousBundle
+        }
+        if let pid {
+            session.pid = pid
+        }
+        session.activationPath = activationPath
         session.phase = .deactivating
+        session.phaseStartedAt = startedAt ?? currentTime
         session.lastActivityAt = currentTime
         sessions[bundleIdentifier] = session
         return session
@@ -201,7 +340,7 @@ final class ToggleSessionCoordinator {
         let currentTime = now()
         for (bundleId, var session) in sessions {
             if bundleId != newFrontmostBundle
-                && (session.phase == .activeStable || session.phase == .deactivating) {
+                && session.phase == .activeStable {
                 session.phase = .idle
                 session.lastActivityAt = currentTime
                 sessions[bundleId] = session
@@ -209,7 +348,22 @@ final class ToggleSessionCoordinator {
         }
     }
 
-    func handleTermination(bundleIdentifier: String) {
+    func handleTermination(bundleIdentifier: String, pid: pid_t? = nil) {
+        guard let session = sessions[bundleIdentifier] else { return }
+        guard pid == nil || session.pid == nil || session.pid == pid else { return }
+        DiagnosticLog.log(
+            ToggleDiagnosticEvent(
+                family: .reset,
+                attemptID: session.attemptID,
+                bundleIdentifier: bundleIdentifier,
+                pid: session.pid,
+                phase: session.phase,
+                event: "session_cleared",
+                activationPath: session.activationPath,
+                reason: "termination",
+                previousBundleIdentifier: session.previousBundle
+            ).logMessage
+        )
         sessions.removeValue(forKey: bundleIdentifier)
     }
 
@@ -235,10 +389,12 @@ final class ToggleSessionCoordinator {
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            let bundle = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?.bundleIdentifier
+            let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+            let bundle = app?.bundleIdentifier
+            let pid = app?.processIdentifier
             if let bundle {
                 Task { @MainActor [weak self] in
-                    self?.handleTermination(bundleIdentifier: bundle)
+                    self?.handleTermination(bundleIdentifier: bundle, pid: pid)
                 }
             }
         }
@@ -270,7 +426,7 @@ final class ToggleSessionCoordinator {
                 return true
             }
             return false
-        case .activating:
+        case .launching, .activating:
             if currentTime - session.lastActivityAt > configuration.activatingIdleExpiry
                 || currentTime - session.activationStartedAt > configuration.absoluteActivationCeiling {
                 session.phase = .idle
@@ -293,6 +449,33 @@ final class ToggleSessionCoordinator {
                 return true
             }
             return false
+        }
+    }
+
+    private func session(for bundleIdentifier: String?, matching phases: Set<Session.Phase>) -> Session? {
+        if let bundleIdentifier {
+            guard let session = session(for: bundleIdentifier), phases.contains(session.phase) else {
+                return nil
+            }
+            return session
+        }
+
+        return mostRecentSession(matching: phases)
+    }
+
+    private func mostRecentSession(matching phases: Set<Session.Phase>) -> Session? {
+        var candidates: [Session] = []
+        for bundleIdentifier in sessions.keys {
+            guard let session = session(for: bundleIdentifier), phases.contains(session.phase) else {
+                continue
+            }
+            candidates.append(session)
+        }
+        return candidates.max { lhs, rhs in
+            if lhs.lastActivityAt == rhs.lastActivityAt {
+                return lhs.generation < rhs.generation
+            }
+            return lhs.lastActivityAt < rhs.lastActivityAt
         }
     }
 
@@ -328,5 +511,39 @@ final class ToggleSessionCoordinator {
             .min(by: { $0.value.lastActivityAt < $1.value.lastActivityAt }) {
             sessions.removeValue(forKey: stalest.key)
         }
+    }
+
+    @discardableResult
+    private func makeSession(
+        bundleIdentifier: String,
+        appName: String?,
+        phase: Session.Phase,
+        activationPath: AppSwitcher.ActivationPath,
+        previousBundle: String?,
+        pid: pid_t?,
+        startedAt: CFAbsoluteTime?
+    ) -> Session {
+        evictIfNeeded(excluding: bundleIdentifier)
+        nextGeneration += 1
+        let currentTime = now()
+        let startedAt = startedAt ?? currentTime
+        let session = Session(
+            bundleIdentifier: bundleIdentifier,
+            attemptID: UUID(),
+            generation: nextGeneration,
+            pid: pid,
+            appName: appName,
+            phase: phase,
+            activationPath: activationPath,
+            previousBundle: previousBundle,
+            activationStartedAt: startedAt,
+            phaseStartedAt: startedAt,
+            lastActivityAt: currentTime,
+            confirmedAt: nil,
+            retryCount: 0,
+            degradedReason: nil
+        )
+        sessions[bundleIdentifier] = session
+        return session
     }
 }

--- a/Tests/QuickeyTests/AppControllerTests.swift
+++ b/Tests/QuickeyTests/AppControllerTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import Quickey
+
+@Test @MainActor
+func startupSequenceAppliesPersistedHyperStateBeforeStartingShortcutManager() {
+    var events: [String] = []
+
+    AppController.runStartupSequence(
+        loadShortcuts: {
+            events.append("load")
+            return []
+        },
+        replaceShortcuts: { _ in
+            events.append("replace")
+        },
+        reapplyHyperIfNeeded: {
+            events.append("reapplyHyper")
+        },
+        isHyperEnabled: {
+            events.append("readHyperEnabled")
+            return true
+        },
+        setHyperKeyEnabled: { enabled in
+            events.append("setHyper:\(enabled)")
+        },
+        startShortcutManager: {
+            events.append("startShortcutManager")
+        },
+        installMenuBar: {
+            events.append("installMenuBar")
+        }
+    )
+
+    #expect(events == [
+        "load",
+        "replace",
+        "reapplyHyper",
+        "readHyperEnabled",
+        "setHyper:true",
+        "startShortcutManager",
+        "installMenuBar"
+    ])
+}

--- a/Tests/QuickeyTests/AppPreferencesTests.swift
+++ b/Tests/QuickeyTests/AppPreferencesTests.swift
@@ -223,7 +223,8 @@ private func makeShortcutManager(
         persistenceService: PersistenceService(),
         appSwitcher: FakeAppSwitcher(),
         captureCoordinator: captureCoordinator,
-        permissionService: permissionService
+        permissionService: permissionService,
+        diagnosticClient: .live
     )
 }
 

--- a/Tests/QuickeyTests/AppSwitcherTests.swift
+++ b/Tests/QuickeyTests/AppSwitcherTests.swift
@@ -85,7 +85,7 @@ func requestFallbackActivationReopensApplicationViaWorkspaceWhenBundleURLExists(
         fallbackActivationClient: .init(openApplication: { url, configuration, completion in
             recorder.openedURLs.append(url)
             recorder.activatesFlags.append(configuration.activates)
-            completion(nil)
+            completion(nil, nil)
         })
     )
     var plainActivateCalls = 0
@@ -112,7 +112,7 @@ func requestFallbackActivationUsesPlainActivationWhenBundleURLIsMissing() {
         fallbackActivationClient: .init(openApplication: { url, configuration, completion in
             recorder.openedURLs.append(url)
             recorder.activatesFlags.append(configuration.activates)
-            completion(nil)
+            completion(nil, nil)
         })
     )
     var plainActivateCalls = 0
@@ -223,6 +223,33 @@ func hideRequestLogUsesRequestNaming() {
 }
 
 @Test
+func toggleTraceLogMessageIncludesAttemptIdentityAndReason() {
+    let event = ToggleDiagnosticEvent(
+        family: .decision,
+        attemptID: UUID(uuidString: "12345678-1234-1234-1234-1234567890AB"),
+        bundleIdentifier: "com.apple.Safari",
+        pid: 42,
+        phase: .activating,
+        event: "blocked",
+        activationPath: .launch,
+        reason: "activation_pending_not_stable",
+        previousBundleIdentifier: "com.apple.Terminal"
+    )
+
+    let message = event.logMessage
+
+    #expect(message.contains("TOGGLE_TRACE_DECISION"))
+    #expect(message.contains("attemptId=12345678-1234-1234-1234-1234567890AB"))
+    #expect(message.contains("bundle=com.apple.Safari"))
+    #expect(message.contains("pid=42"))
+    #expect(message.contains("phase=activating"))
+    #expect(message.contains("event=blocked"))
+    #expect(message.contains("activationPath=launch"))
+    #expect(message.contains("reason=\"activation_pending_not_stable\""))
+    #expect(message.contains("previousBundle=\"com.apple.Terminal\""))
+}
+
+@Test
 func activationDefaultsToFrontProcessOnly() {
     #expect(AppSwitcher.windowServerActivationMode == .frontProcessOnly)
 }
@@ -273,20 +300,27 @@ func toggleLifecycleLogMessageIncludesStructuredObservationFields() {
 
 @Test @MainActor
 func secondTriggerDuringPendingActivationDoesNotToggleOff() {
-    let switcher = AppSwitcher(frontmostTracker: makeTrackerForAppSwitcherTests())
+    let clock = MutableClock(time: 10)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        confirmationClient: .init(now: { clock.time }, schedule: { _, _ in }),
+        sessionCoordinator: coordinator
+    )
 
     let first = switcher.acceptPendingActivation(
         for: "com.apple.Safari",
         previousBundleIdentifier: "com.openai.codex",
-        startedAt: 10
+        startedAt: clock.time
     )
 
     #expect(switcher.shouldToggleOff(bundleIdentifier: "com.apple.Safari", runningAppIsActive: true) == false)
 
+    clock.time = 11
     let second = switcher.acceptPendingActivation(
         for: "com.apple.Safari",
         previousBundleIdentifier: "com.openai.codex",
-        startedAt: 11
+        startedAt: clock.time
     )
 
     #expect(first.generation == 1)
@@ -297,16 +331,23 @@ func secondTriggerDuringPendingActivationDoesNotToggleOff() {
 
 @Test @MainActor
 func staleConfirmationGenerationCannotPromoteState() {
-    let switcher = AppSwitcher(frontmostTracker: makeTrackerForAppSwitcherTests())
+    let clock = MutableClock(time: 20)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        confirmationClient: .init(now: { clock.time }, schedule: { _, _ in }),
+        sessionCoordinator: coordinator
+    )
     let first = switcher.acceptPendingActivation(
         for: "com.apple.Safari",
         previousBundleIdentifier: "com.openai.codex",
-        startedAt: 20
+        startedAt: clock.time
     )
+    clock.time = 21
     let second = switcher.acceptPendingActivation(
         for: "com.apple.Safari",
         previousBundleIdentifier: "com.openai.codex",
-        startedAt: 21
+        startedAt: clock.time
     )
     let stableSnapshot = ActivationObservationSnapshot(
         targetBundleIdentifier: "com.apple.Safari",
@@ -335,11 +376,17 @@ func staleConfirmationGenerationCannotPromoteState() {
 
 @Test @MainActor
 func confirmationWithoutVisibleWindowEvidenceDoesNotPromoteStable() {
-    let switcher = AppSwitcher(frontmostTracker: makeTrackerForAppSwitcherTests())
+    let clock = MutableClock(time: 25)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        confirmationClient: .init(now: { clock.time }, schedule: { _, _ in }),
+        sessionCoordinator: coordinator
+    )
     let pending = switcher.acceptPendingActivation(
         for: "com.apple.Home",
         previousBundleIdentifier: "com.openai.codex",
-        startedAt: 25
+        startedAt: clock.time
     )
     let windowlessSnapshot = ActivationObservationSnapshot(
         targetBundleIdentifier: "com.apple.Home",
@@ -368,12 +415,18 @@ func confirmationWithoutVisibleWindowEvidenceDoesNotPromoteStable() {
 
 @Test @MainActor
 func acceptedTriggerStillReturnsTrueWhileConfirmationIsPending() {
-    let switcher = AppSwitcher(frontmostTracker: makeTrackerForAppSwitcherTests())
+    let clock = MutableClock(time: 30)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        confirmationClient: .init(now: { clock.time }, schedule: { _, _ in }),
+        sessionCoordinator: coordinator
+    )
 
     let accepted = switcher.recordAcceptedTrigger(
         bundleIdentifier: "com.apple.Safari",
         previousBundleIdentifier: "com.openai.codex",
-        startedAt: 30
+        startedAt: clock.time
     )
 
     #expect(accepted == true)
@@ -457,7 +510,7 @@ func recoverWindowlessAppStageCompletionHappensBeforeNextConfirmation() {
 }
 
 @Test @MainActor
-func visibleWindowActivationEscalatesMakeKeyWindowBeforeAXRaise() {
+func visibleWindowEvidencePromotesStableWithoutRecoveryEscalation() {
     let scheduler = ManualConfirmationScheduler()
     let switcher = AppSwitcher(
         frontmostTracker: makeTrackerForAppSwitcherTests(),
@@ -492,32 +545,6 @@ func visibleWindowActivationEscalatesMakeKeyWindowBeforeAXRaise() {
             windowObservationFailureReason: nil,
             classification: .regularWindowed,
             classificationReason: "frontmost but key window not settled"
-        ),
-        ActivationObservationSnapshot(
-            targetBundleIdentifier: "com.apple.Safari",
-            observedFrontmostBundleIdentifier: "com.apple.Safari",
-            targetIsActive: true,
-            targetIsHidden: false,
-            visibleWindowCount: 1,
-            hasFocusedWindow: false,
-            hasMainWindow: true,
-            windowObservationSucceeded: true,
-            windowObservationFailureReason: nil,
-            classification: .regularWindowed,
-            classificationReason: "still not focused after makeKeyWindow"
-        ),
-        ActivationObservationSnapshot(
-            targetBundleIdentifier: "com.apple.Safari",
-            observedFrontmostBundleIdentifier: "com.apple.Safari",
-            targetIsActive: true,
-            targetIsHidden: false,
-            visibleWindowCount: 1,
-            hasFocusedWindow: true,
-            hasMainWindow: true,
-            windowObservationSucceeded: true,
-            windowObservationFailureReason: nil,
-            classification: .regularWindowed,
-            classificationReason: "focused after escalation"
         )
     ]
     var events: [String] = []
@@ -538,10 +565,8 @@ func visibleWindowActivationEscalatesMakeKeyWindowBeforeAXRaise() {
     )
 
     scheduler.runNext()
-    scheduler.runNext()
-    scheduler.runNext()
 
-    #expect(events == ["confirm:false", "recover:makeKeyWindow", "confirm:false", "recover:axRaise", "confirm:true"])
+    #expect(events == ["confirm:false"])
     #expect(switcher.stableActivationState?.bundleIdentifier == "com.apple.Safari")
 }
 
@@ -945,6 +970,64 @@ func workspaceHideNotificationCompletesPendingDeactivationWithHideConfirmedLog()
     #expect(switcher.pendingDeactivationState == nil)
     #expect(switcher.stableActivationState == nil)
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
+}
+
+@Test @MainActor
+func externalUntrackedHideDispatchesHideRequestThroughCoordinatorOwnedSession() {
+    guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
+          let bundleIdentifier = frontmostApp.bundleIdentifier else {
+        Issue.record("Expected a frontmost application with a bundle identifier for external hide test")
+        return
+    }
+
+    let scheduler = ManualConfirmationScheduler()
+    var hideCalls = 0
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        applicationObservation: ApplicationObservation(client: .init(
+            currentFrontmostBundleIdentifier: { bundleIdentifier },
+            windowObservation: { _ in
+                .init(
+                    windows: nil,
+                    visibleWindowCount: 1,
+                    hasFocusedWindow: true,
+                    hasMainWindow: true,
+                    windowsReadSucceeded: true,
+                    failureReason: nil
+                )
+            },
+            activationPolicy: { _ in .regular }
+        )),
+        hideRequestClient: .init(hideApplication: { _ in
+            hideCalls += 1
+            return true
+        }),
+        appLookupClient: .init(
+            runningApplications: { _ in [frontmostApp] },
+            applicationURL: { _ in nil }
+        ),
+        confirmationClient: .init(
+            now: { 100 },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        )
+    )
+    let shortcut = AppShortcut(
+        appName: frontmostApp.localizedName ?? "Frontmost",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "u",
+        modifierFlags: ["command"]
+    )
+
+    let accepted = switcher.toggleApplication(for: shortcut)
+
+    #expect(accepted == true)
+    #expect(switcher.pendingDeactivationState?.activationPath == .hideUntracked)
+
+    scheduler.runNext()
+
+    #expect(hideCalls == 1)
 }
 
 @Test @MainActor

--- a/Tests/QuickeyTests/AppSwitcherTests.swift
+++ b/Tests/QuickeyTests/AppSwitcherTests.swift
@@ -570,6 +570,175 @@ func visibleWindowEvidencePromotesStableWithoutRecoveryEscalation() {
     #expect(switcher.stableActivationState?.bundleIdentifier == "com.apple.Safari")
 }
 
+@Test @MainActor
+func hiddenLagWithCompleteWindowEvidenceRetriesObservationBeforeWindowRecovery() {
+    let scheduler = ManualConfirmationScheduler()
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        confirmationClient: .init(
+            now: { 75 },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        )
+    )
+    let state = switcher.acceptPendingActivation(
+        for: "dev.zed.Zed",
+        previousBundleIdentifier: "com.mitchellh.ghostty",
+        startedAt: 75
+    )
+    let shortcut = AppShortcut(
+        appName: "Zed",
+        bundleIdentifier: "dev.zed.Zed",
+        keyEquivalent: "z",
+        modifierFlags: ["control", "option", "shift", "command"]
+    )
+    var snapshots = [
+        ActivationObservationSnapshot(
+            targetBundleIdentifier: "dev.zed.Zed",
+            observedFrontmostBundleIdentifier: "dev.zed.Zed",
+            targetIsActive: true,
+            targetIsHidden: true,
+            visibleWindowCount: 1,
+            hasFocusedWindow: true,
+            hasMainWindow: true,
+            windowObservationSucceeded: true,
+            windowObservationFailureReason: nil,
+            classification: .regularWindowed,
+            classificationReason: "visible focused main window with stale hidden state"
+        ),
+        ActivationObservationSnapshot(
+            targetBundleIdentifier: "dev.zed.Zed",
+            observedFrontmostBundleIdentifier: "dev.zed.Zed",
+            targetIsActive: true,
+            targetIsHidden: false,
+            visibleWindowCount: 1,
+            hasFocusedWindow: true,
+            hasMainWindow: true,
+            windowObservationSucceeded: true,
+            windowObservationFailureReason: nil,
+            classification: .regularWindowed,
+            classificationReason: "visible focused main window"
+        )
+    ]
+    var events: [String] = []
+
+    switcher.schedulePendingConfirmation(
+        state: state,
+        shortcut: shortcut,
+        activationPath: .unhideActivate,
+        observe: {
+            let snapshot = snapshots.removeFirst()
+            events.append("confirm:hidden=\(snapshot.targetIsHidden)")
+            return snapshot
+        },
+        recoverIfNeeded: { stage, completion in
+            events.append("recover:\(stage.rawValue)")
+            completion()
+        }
+    )
+
+    scheduler.runNext()
+    scheduler.runNext()
+
+    #expect(events == ["confirm:hidden=true", "confirm:hidden=false"])
+    #expect(switcher.stableActivationState?.bundleIdentifier == "dev.zed.Zed")
+}
+
+@Test @MainActor
+func hiddenLagOnlyRetriesObservationOnceBeforeRecoveryEscalation() {
+    let scheduler = ManualConfirmationScheduler()
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        confirmationClient: .init(
+            now: { 80 },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        )
+    )
+    let state = switcher.acceptPendingActivation(
+        for: "dev.zed.Zed",
+        previousBundleIdentifier: "com.mitchellh.ghostty",
+        startedAt: 80
+    )
+    let shortcut = AppShortcut(
+        appName: "Zed",
+        bundleIdentifier: "dev.zed.Zed",
+        keyEquivalent: "z",
+        modifierFlags: ["control", "option", "shift", "command"]
+    )
+    var snapshots = [
+        ActivationObservationSnapshot(
+            targetBundleIdentifier: "dev.zed.Zed",
+            observedFrontmostBundleIdentifier: "dev.zed.Zed",
+            targetIsActive: true,
+            targetIsHidden: true,
+            visibleWindowCount: 1,
+            hasFocusedWindow: true,
+            hasMainWindow: true,
+            windowObservationSucceeded: true,
+            windowObservationFailureReason: nil,
+            classification: .regularWindowed,
+            classificationReason: "visible focused main window with stale hidden state"
+        ),
+        ActivationObservationSnapshot(
+            targetBundleIdentifier: "dev.zed.Zed",
+            observedFrontmostBundleIdentifier: "dev.zed.Zed",
+            targetIsActive: true,
+            targetIsHidden: true,
+            visibleWindowCount: 1,
+            hasFocusedWindow: true,
+            hasMainWindow: true,
+            windowObservationSucceeded: true,
+            windowObservationFailureReason: nil,
+            classification: .regularWindowed,
+            classificationReason: "hidden state still lagging"
+        ),
+        ActivationObservationSnapshot(
+            targetBundleIdentifier: "dev.zed.Zed",
+            observedFrontmostBundleIdentifier: "dev.zed.Zed",
+            targetIsActive: true,
+            targetIsHidden: false,
+            visibleWindowCount: 1,
+            hasFocusedWindow: true,
+            hasMainWindow: true,
+            windowObservationSucceeded: true,
+            windowObservationFailureReason: nil,
+            classification: .regularWindowed,
+            classificationReason: "visible focused main window"
+        )
+    ]
+    var events: [String] = []
+
+    switcher.schedulePendingConfirmation(
+        state: state,
+        shortcut: shortcut,
+        activationPath: .unhideActivate,
+        observe: {
+            let snapshot = snapshots.removeFirst()
+            events.append("confirm:hidden=\(snapshot.targetIsHidden)")
+            return snapshot
+        },
+        recoverIfNeeded: { stage, completion in
+            events.append("recover:\(stage.rawValue)")
+            completion()
+        }
+    )
+
+    scheduler.runNext()
+    scheduler.runNext()
+    scheduler.runNext()
+
+    #expect(events == [
+        "confirm:hidden=true",
+        "confirm:hidden=true",
+        "recover:makeKeyWindow",
+        "confirm:hidden=false"
+    ])
+    #expect(switcher.stableActivationState?.bundleIdentifier == "dev.zed.Zed")
+}
+
 // MARK: - Coordinator integration tests
 
 @Test @MainActor

--- a/Tests/QuickeyTests/ApplicationObservationTests.swift
+++ b/Tests/QuickeyTests/ApplicationObservationTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Testing
 @testable import Quickey
 
@@ -32,8 +33,8 @@ func observationReevaluatesClassificationPerAttempt() {
         hasMainWindow: false,
         windowObservationSucceeded: true,
         windowObservationFailureReason: nil,
-        classification: .windowlessOrAccessory,
-        classificationReason: "no visible windows"
+        classification: .nonStandardWindowed,
+        classificationReason: "regular app has no visible, focused, or main window evidence"
     )
     let secondAttempt = ActivationObservationSnapshot(
         targetBundleIdentifier: "com.apple.Home",
@@ -45,36 +46,36 @@ func observationReevaluatesClassificationPerAttempt() {
         hasMainWindow: true,
         windowObservationSucceeded: true,
         windowObservationFailureReason: nil,
-        classification: .nonStandardWindowed,
+        classification: .regularWindowed,
         classificationReason: "window appeared during confirmation"
     )
 
-    #expect(firstAttempt.classification == .windowlessOrAccessory)
-    #expect(secondAttempt.classification == .nonStandardWindowed)
+    #expect(firstAttempt.classification == .nonStandardWindowed)
+    #expect(secondAttempt.classification == .regularWindowed)
     #expect(firstAttempt.classification != secondAttempt.classification)
 }
 
 @Test
-func nonStandardFrontmostWindowWithoutFocusIsNotStable() {
+func regularAppWithoutUsableWindowEvidenceIsNotStable() {
     let snapshot = ActivationObservationSnapshot(
         targetBundleIdentifier: "dev.zed.Zed",
         observedFrontmostBundleIdentifier: "dev.zed.Zed",
         targetIsActive: true,
         targetIsHidden: false,
-        visibleWindowCount: 1,
+        visibleWindowCount: 0,
         hasFocusedWindow: false,
         hasMainWindow: false,
         windowObservationSucceeded: true,
         windowObservationFailureReason: nil,
         classification: .nonStandardWindowed,
-        classificationReason: "window evidence is incomplete for dev.zed.Zed"
+        classificationReason: "regular app has no visible, focused, or main window evidence"
     )
 
     #expect(snapshot.isStableActivation == false)
 }
 
 @Test
-func nonStandardFrontmostWindowWithFocusAndMainWindowCanBeStable() {
+func regularAppWithAnyUsableWindowEvidenceCanBeStable() {
     let snapshot = ActivationObservationSnapshot(
         targetBundleIdentifier: "dev.zed.Zed",
         observedFrontmostBundleIdentifier: "dev.zed.Zed",
@@ -137,6 +138,7 @@ func structuredLogFieldsQuoteStringValues() {
     #expect(snapshot.structuredLogFields.contains("target=\"com.apple.Safari\""))
     #expect(snapshot.structuredLogFields.contains("classification=\"regularWindowed\""))
     #expect(snapshot.structuredLogFields.contains("classificationReason=\"visible focused \\\"main\\\" window\""))
+    #expect(snapshot.structuredLogFields.contains("allowsWindowlessStableActivation=false"))
 }
 
 @Test
@@ -158,4 +160,60 @@ func structuredLogFieldsIncludeWindowObservationFailureSignal() {
     #expect(snapshot.structuredLogFields.contains("windowObservationSucceeded=false"))
     #expect(snapshot.structuredLogFields.contains("windowObservationFailureReason=\"axWindowsReadFailed=-25204\""))
     #expect(snapshot.structuredLogFields.contains("classification=\"nonStandardWindowed\""))
+}
+
+@Test @MainActor
+func regularAppWithoutWindowEvidenceDoesNotClassifyAsWindowlessAccessory() {
+    let currentApp = NSRunningApplication.current
+    let observation = ApplicationObservation(client: .init(
+        currentFrontmostBundleIdentifier: {
+            currentApp.bundleIdentifier
+        },
+        windowObservation: { _ in
+            .init(
+                windows: nil,
+                visibleWindowCount: 0,
+                hasFocusedWindow: false,
+                hasMainWindow: false,
+                windowsReadSucceeded: true,
+                failureReason: nil
+            )
+        },
+        activationPolicy: { _ in
+            .regular
+        }
+    ))
+
+    let snapshot = observation.snapshot(for: currentApp)
+
+    #expect(snapshot.classification == .nonStandardWindowed)
+    #expect(snapshot.allowsWindowlessStableActivation == false)
+}
+
+@Test @MainActor
+func nonRegularAppWithoutWindowEvidenceCanRemainStable() {
+    let currentApp = NSRunningApplication.current
+    let observation = ApplicationObservation(client: .init(
+        currentFrontmostBundleIdentifier: {
+            currentApp.bundleIdentifier
+        },
+        windowObservation: { _ in
+            .init(
+                windows: nil,
+                visibleWindowCount: 0,
+                hasFocusedWindow: false,
+                hasMainWindow: false,
+                windowsReadSucceeded: true,
+                failureReason: nil
+            )
+        },
+        activationPolicy: { _ in
+            .accessory
+        }
+    ))
+
+    let snapshot = observation.snapshot(for: currentApp)
+
+    #expect(snapshot.classification == .systemUtility)
+    #expect(snapshot.allowsWindowlessStableActivation == true)
 }

--- a/Tests/QuickeyTests/QuickeyTests.swift
+++ b/Tests/QuickeyTests/QuickeyTests.swift
@@ -384,6 +384,24 @@ struct EventTapManagerDeliveryTests {
         #expect(delivered == keyPress)
     }
 
+    @Test
+    func eventTapSwallowLogMessageIncludesAutorepeatAndHyperInjectionContext() {
+        let message = eventTapSwallowLogMessage(
+            seq: 42,
+            keyCode: CGKeyCode(kVK_ANSI_Z),
+            modifiers: [.command, .option, .control, .shift],
+            eventTimestamp: 123_456,
+            isAutorepeat: false,
+            hyperInjected: true
+        )
+
+        #expect(message.contains("EVENT_TAP_SWALLOW"))
+        #expect(message.contains("seq=42"))
+        #expect(message.contains("keyCode=6"))
+        #expect(message.contains("autorepeat=false"))
+        #expect(message.contains("hyperInjected=true"))
+    }
+
     private func makeKeyEvent(
         _ keyCode: CGKeyCode,
         modifiers: NSEvent.ModifierFlags,

--- a/Tests/QuickeyTests/SettingsViewTests.swift
+++ b/Tests/QuickeyTests/SettingsViewTests.swift
@@ -98,7 +98,8 @@ private func makeShortcutManager(
         persistenceService: PersistenceService(),
         appSwitcher: FakeAppSwitcher(),
         captureCoordinator: captureCoordinator,
-        permissionService: permissionService
+        permissionService: permissionService,
+        diagnosticClient: .live
     )
 }
 

--- a/Tests/QuickeyTests/ShortcutManagerStatusTests.swift
+++ b/Tests/QuickeyTests/ShortcutManagerStatusTests.swift
@@ -1,3 +1,4 @@
+import Carbon.HIToolbox
 import Foundation
 import Testing
 @testable import Quickey
@@ -54,18 +55,22 @@ private final class MutablePermissionService: @unchecked Sendable, PermissionSer
 @MainActor
 private final class FakeCaptureProvider: ShortcutCaptureProvider {
     var isRunning = false
+    var startSucceeds = true
     private(set) var startCallCount = 0
     private(set) var stopCallCount = 0
     private(set) var registeredShortcuts: Set<KeyPress> = []
+    private var onKeyPress: (@MainActor @Sendable (KeyPress) -> Void)?
 
     func start(onKeyPress: @escaping @MainActor @Sendable (KeyPress) -> Void) {
         startCallCount += 1
-        isRunning = !registeredShortcuts.isEmpty
+        self.onKeyPress = onKeyPress
+        isRunning = startSucceeds && !registeredShortcuts.isEmpty
     }
 
     func stop() {
         stopCallCount += 1
         isRunning = false
+        onKeyPress = nil
     }
 
     func updateRegisteredShortcuts(_ keyPresses: Set<KeyPress>) {
@@ -74,24 +79,32 @@ private final class FakeCaptureProvider: ShortcutCaptureProvider {
             isRunning = false
         }
     }
+
+    func emit(_ keyPress: KeyPress) {
+        onKeyPress?(keyPress)
+    }
 }
 
 @MainActor
 private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
     var isRunning = false
+    var startSucceeds = true
     private(set) var startCallCount = 0
     private(set) var stopCallCount = 0
     private(set) var registeredShortcuts: Set<KeyPress> = []
     private(set) var hyperKeyEnabled = false
+    private var onKeyPress: (@MainActor @Sendable (KeyPress) -> Void)?
 
     func start(onKeyPress: @escaping @MainActor @Sendable (KeyPress) -> Void) {
         startCallCount += 1
-        isRunning = !registeredShortcuts.isEmpty
+        self.onKeyPress = onKeyPress
+        isRunning = startSucceeds && !registeredShortcuts.isEmpty
     }
 
     func stop() {
         stopCallCount += 1
         isRunning = false
+        onKeyPress = nil
     }
 
     func updateRegisteredShortcuts(_ keyPresses: Set<KeyPress>) {
@@ -103,6 +116,10 @@ private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
 
     func setHyperKeyEnabled(_ enabled: Bool) {
         hyperKeyEnabled = enabled
+    }
+
+    func emit(_ keyPress: KeyPress) {
+        onKeyPress?(keyPress)
     }
 }
 
@@ -118,7 +135,8 @@ private struct FakeAppSwitcher: AppSwitching {
 private func makeShortcutManager(
     permissionService: some PermissionServicing,
     standardProvider: FakeCaptureProvider = FakeCaptureProvider(),
-    hyperProvider: FakeHyperCaptureProvider = FakeHyperCaptureProvider()
+    hyperProvider: FakeHyperCaptureProvider = FakeHyperCaptureProvider(),
+    diagnosticSink: @escaping @Sendable (String) -> Void = { _ in }
 ) -> (ShortcutManager, FakeCaptureProvider, FakeHyperCaptureProvider) {
     let coordinator = ShortcutCaptureCoordinator(
         standardProvider: standardProvider,
@@ -129,7 +147,8 @@ private func makeShortcutManager(
         persistenceService: PersistenceService(),
         appSwitcher: FakeAppSwitcher(),
         captureCoordinator: coordinator,
-        permissionService: permissionService
+        permissionService: permissionService,
+        diagnosticClient: .init(log: diagnosticSink)
     )
     return (manager, standardProvider, hyperProvider)
 }
@@ -233,7 +252,8 @@ func accessibilityLossStopsAllShortcutCapture() {
         persistenceService: PersistenceService(),
         appSwitcher: FakeAppSwitcher(),
         captureCoordinator: coordinator,
-        permissionService: permissionService
+        permissionService: permissionService,
+        diagnosticClient: .live
     )
 
     manager.checkPermissionChange()
@@ -260,4 +280,80 @@ func unchangedPermissionsDoNotResyncCaptureRepeatedly() {
 
     #expect(standardProvider.startCallCount == standardStartsAfterLaunch)
     #expect(hyperProvider.startCallCount == hyperStartsAfterLaunch)
+}
+
+@Test @MainActor
+func matchedShortcutEmitsTraceOnlyForMatchedKeys() {
+    let diagnostics = DiagnosticCapture()
+    let standardProvider = FakeCaptureProvider()
+    let (manager, _, _) = makeShortcutManager(
+        permissionService: FakePermissionService(ax: true, input: false),
+        standardProvider: standardProvider,
+        diagnosticSink: diagnostics.record
+    )
+    manager.save(shortcuts: [standardShortcut()])
+    manager.start()
+
+    standardProvider.emit(KeyPress(
+        keyCode: UInt16(kVK_ANSI_S),
+        modifiers: [.command, .shift]
+    ))
+
+    let logCountAfterMatch = diagnostics.messages.count
+    standardProvider.emit(KeyPress(
+        keyCode: UInt16(kVK_ANSI_A),
+        modifiers: [.command]
+    ))
+
+    #expect(diagnostics.messages.contains { $0.contains("MATCHED: Safari - com.apple.Safari") })
+    #expect(diagnostics.messages.contains { $0.contains("SHORTCUT_TRACE_DECISION event=matched bundle=com.apple.Safari") })
+    #expect(diagnostics.messages.count == logCountAfterMatch)
+}
+
+@Test @MainActor
+func missingStandardRegistrationEmitsCaptureBlockedDiagnostic() {
+    let diagnostics = DiagnosticCapture()
+    let standardProvider = FakeCaptureProvider()
+    standardProvider.startSucceeds = false
+    let (manager, _, _) = makeShortcutManager(
+        permissionService: FakePermissionService(ax: true, input: false),
+        standardProvider: standardProvider,
+        diagnosticSink: diagnostics.record
+    )
+    manager.save(shortcuts: [standardShortcut()])
+
+    manager.start()
+
+    #expect(diagnostics.messages.contains {
+        $0.contains("SHORTCUT_TRACE_BLOCKED")
+            && $0.contains("reason=\"missing_registration_or_system_conflict\"")
+            && $0.contains("route=standard")
+    })
+}
+
+@Test @MainActor
+func missingInputMonitoringEmitsHyperCaptureBlockedDiagnostic() {
+    let diagnostics = DiagnosticCapture()
+    let (manager, _, _) = makeShortcutManager(
+        permissionService: FakePermissionService(ax: true, input: false),
+        diagnosticSink: diagnostics.record
+    )
+    manager.save(shortcuts: [hyperShortcut()])
+    manager.setHyperKeyEnabled(true)
+
+    manager.start()
+
+    #expect(diagnostics.messages.contains {
+        $0.contains("SHORTCUT_TRACE_BLOCKED")
+            && $0.contains("reason=\"input_monitoring_missing\"")
+            && $0.contains("route=hyper")
+    })
+}
+
+private final class DiagnosticCapture: @unchecked Sendable {
+    private(set) var messages: [String] = []
+
+    func record(_ message: String) {
+        messages.append(message)
+    }
 }

--- a/Tests/QuickeyTests/ToggleLaunchLifecycleTests.swift
+++ b/Tests/QuickeyTests/ToggleLaunchLifecycleTests.swift
@@ -1,0 +1,296 @@
+import AppKit
+import Testing
+@testable import Quickey
+
+@Test @MainActor
+func launchPathCreatesOwnedPendingStateForNotRunningTarget() {
+    let clock = ToggleLaunchLifecycleClock(time: 100)
+    let appURL = URL(fileURLWithPath: "/Applications/TestTarget.app")
+    var openedURLs: [URL] = []
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForToggleLaunchLifecycleTests(currentFrontmost: "com.apple.Terminal"),
+        fallbackActivationClient: .init(openApplication: { url, _, completion in
+            openedURLs.append(url)
+            completion(nil, nil)
+        }),
+        appLookupClient: .init(
+            runningApplications: { _ in [] },
+            applicationURL: { _ in appURL }
+        ),
+        confirmationClient: .init(
+            now: { clock.time },
+            schedule: { _, _ in }
+        ),
+        sessionCoordinator: coordinator
+    )
+    let shortcut = AppShortcut(
+        appName: "TestTarget",
+        bundleIdentifier: "com.test.Target",
+        keyEquivalent: "t",
+        modifierFlags: ["command"]
+    )
+
+    let accepted = switcher.toggleApplication(for: shortcut)
+
+    #expect(accepted == true)
+    #expect(openedURLs == [appURL])
+    #expect(switcher.pendingActivationState?.bundleIdentifier == shortcut.bundleIdentifier)
+    #expect(switcher.pendingActivationState?.previousBundleIdentifier == "com.apple.Terminal")
+    #expect(coordinator.session(for: shortcut.bundleIdentifier)?.phase == .launching)
+}
+
+@Test @MainActor
+func launchCompletionAttachesOwnedSessionToConfirmationPipeline() async {
+    guard let launchedApp = NSWorkspace.shared.frontmostApplication,
+          let bundleIdentifier = launchedApp.bundleIdentifier else {
+        Issue.record("Expected a frontmost application with a bundle identifier for launch lifecycle test")
+        return
+    }
+
+    let clock = ToggleLaunchLifecycleClock(time: 150)
+    let scheduler = ToggleLaunchLifecycleScheduler()
+    let appURL = URL(fileURLWithPath: "/Applications/TestTarget.app")
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    var isRunning = false
+    var windowObservations = [
+        ApplicationObservation.WindowObservation(
+            windows: nil,
+            visibleWindowCount: 0,
+            hasFocusedWindow: false,
+            hasMainWindow: false,
+            windowsReadSucceeded: true,
+            failureReason: nil
+        ),
+        ApplicationObservation.WindowObservation(
+            windows: nil,
+            visibleWindowCount: 1,
+            hasFocusedWindow: true,
+            hasMainWindow: true,
+            windowsReadSucceeded: true,
+            failureReason: nil
+        )
+    ]
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForToggleLaunchLifecycleTests(currentFrontmost: "com.apple.Terminal"),
+        applicationObservation: ApplicationObservation(client: .init(
+            currentFrontmostBundleIdentifier: { bundleIdentifier },
+            windowObservation: { _ in
+                if windowObservations.count > 1 {
+                    return windowObservations.removeFirst()
+                }
+                return windowObservations[0]
+            },
+            activationPolicy: { _ in .regular }
+        )),
+        fallbackActivationClient: .init(openApplication: { _, _, completion in
+            isRunning = true
+            completion(launchedApp, nil)
+        }),
+        appLookupClient: .init(
+            runningApplications: { _ in
+                isRunning ? [launchedApp] : []
+            },
+            applicationURL: { _ in appURL }
+        ),
+        confirmationClient: .init(
+            now: { clock.time },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        ),
+        sessionCoordinator: coordinator
+    )
+    let shortcut = AppShortcut(
+        appName: "TestTarget",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "t",
+        modifierFlags: ["command"]
+    )
+
+    let accepted = switcher.toggleApplication(for: shortcut)
+    await Task.yield()
+
+    #expect(accepted == true)
+    #expect(coordinator.session(for: bundleIdentifier)?.phase == .activating)
+
+    scheduler.runNext()
+
+    #expect(switcher.stableActivationState?.bundleIdentifier == bundleIdentifier)
+    #expect(coordinator.session(for: bundleIdentifier)?.phase == .activeStable)
+}
+
+@Test @MainActor
+func terminationImmediatelyClearsStableActivationState() {
+    let clock = ToggleLaunchLifecycleClock(time: 200)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForToggleLaunchLifecycleTests(),
+        confirmationClient: .init(
+            now: { clock.time },
+            schedule: { _, _ in }
+        ),
+        sessionCoordinator: coordinator
+    )
+
+    let pending = switcher.acceptPendingActivation(
+        for: "com.apple.Safari",
+        previousBundleIdentifier: "com.apple.Terminal",
+        startedAt: clock.time
+    )
+    clock.time = 201
+    let stableSnapshot = ActivationObservationSnapshot(
+        targetBundleIdentifier: "com.apple.Safari",
+        observedFrontmostBundleIdentifier: "com.apple.Safari",
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 1,
+        hasFocusedWindow: true,
+        hasMainWindow: true,
+        windowObservationSucceeded: true,
+        windowObservationFailureReason: nil,
+        classification: .regularWindowed,
+        classificationReason: "visible focused main window"
+    )
+    let promoted = switcher.promotePendingActivationIfCurrent(
+        bundleIdentifier: "com.apple.Safari",
+        generation: pending.generation,
+        snapshot: stableSnapshot
+    )
+
+    #expect(promoted == true)
+    #expect(switcher.stableActivationState?.bundleIdentifier == "com.apple.Safari")
+
+    coordinator.handleTermination(bundleIdentifier: "com.apple.Safari")
+
+    #expect(coordinator.session(for: "com.apple.Safari") == nil)
+    #expect(switcher.stableActivationState == nil)
+}
+
+@Test @MainActor
+func secondPressAfterOwnedLaunchUsesTrackedHideInsteadOfHideUntracked() async {
+    guard let launchedApp = NSWorkspace.shared.frontmostApplication,
+          let bundleIdentifier = launchedApp.bundleIdentifier else {
+        Issue.record("Expected a frontmost application with a bundle identifier for second-press launch lifecycle test")
+        return
+    }
+
+    let clock = ToggleLaunchLifecycleClock(time: 300)
+    let scheduler = ToggleLaunchLifecycleScheduler()
+    let appURL = URL(fileURLWithPath: "/Applications/TestTarget.app")
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    var isRunning = false
+    var hideCalls = 0
+    var windowObservations = [
+        ApplicationObservation.WindowObservation(
+            windows: nil,
+            visibleWindowCount: 0,
+            hasFocusedWindow: false,
+            hasMainWindow: false,
+            windowsReadSucceeded: true,
+            failureReason: nil
+        ),
+        ApplicationObservation.WindowObservation(
+            windows: nil,
+            visibleWindowCount: 1,
+            hasFocusedWindow: true,
+            hasMainWindow: true,
+            windowsReadSucceeded: true,
+            failureReason: nil
+        ),
+        ApplicationObservation.WindowObservation(
+            windows: nil,
+            visibleWindowCount: 1,
+            hasFocusedWindow: true,
+            hasMainWindow: true,
+            windowsReadSucceeded: true,
+            failureReason: nil
+        )
+    ]
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForToggleLaunchLifecycleTests(currentFrontmost: "com.apple.Terminal"),
+        applicationObservation: ApplicationObservation(client: .init(
+            currentFrontmostBundleIdentifier: { bundleIdentifier },
+            windowObservation: { _ in
+                if windowObservations.count > 1 {
+                    return windowObservations.removeFirst()
+                }
+                return windowObservations[0]
+            },
+            activationPolicy: { _ in .regular }
+        )),
+        fallbackActivationClient: .init(openApplication: { _, _, completion in
+            isRunning = true
+            completion(launchedApp, nil)
+        }),
+        hideRequestClient: .init(hideApplication: { _ in
+            hideCalls += 1
+            return true
+        }),
+        appLookupClient: .init(
+            runningApplications: { _ in
+                isRunning ? [launchedApp] : []
+            },
+            applicationURL: { _ in appURL }
+        ),
+        confirmationClient: .init(
+            now: { clock.time },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        ),
+        sessionCoordinator: coordinator
+    )
+    let shortcut = AppShortcut(
+        appName: "TestTarget",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "t",
+        modifierFlags: ["command"]
+    )
+
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    await Task.yield()
+    scheduler.runNext()
+    #expect(switcher.stableActivationState?.bundleIdentifier == bundleIdentifier)
+
+    clock.time += 0.5
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+
+    #expect(switcher.pendingDeactivationState?.activationPath == .hide)
+    scheduler.runNext()
+    #expect(hideCalls == 1)
+}
+
+@MainActor
+private func makeTrackerForToggleLaunchLifecycleTests(currentFrontmost: String? = nil) -> FrontmostApplicationTracker {
+    FrontmostApplicationTracker(client: .init(
+        currentFrontmostBundleIdentifier: { currentFrontmost }
+    ))
+}
+
+@MainActor
+private final class ToggleLaunchLifecycleClock {
+    var time: CFAbsoluteTime
+
+    init(time: CFAbsoluteTime) {
+        self.time = time
+    }
+}
+
+@MainActor
+private final class ToggleLaunchLifecycleScheduler {
+    private var operations: [@MainActor () -> Void] = []
+
+    func schedule(after _: TimeInterval, _ operation: @escaping @MainActor () -> Void) {
+        operations.append(operation)
+    }
+
+    func runNext() {
+        guard !operations.isEmpty else {
+            Issue.record("Expected a scheduled launch confirmation operation")
+            return
+        }
+        let operation = operations.removeFirst()
+        operation()
+    }
+}

--- a/Tests/QuickeyTests/ToggleSessionCoordinatorTests.swift
+++ b/Tests/QuickeyTests/ToggleSessionCoordinatorTests.swift
@@ -6,11 +6,11 @@ import Testing
 
 @Test @MainActor
 func activeStableExpiresWhenAnotherAppBecomesFrontmost() {
-    var currentTime: CFAbsoluteTime = 100
-    let coordinator = ToggleSessionCoordinator(now: { currentTime })
+    let clock = CoordinatorTestClock(time: 100)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
 
     coordinator.beginActivation(for: "com.apple.Safari", previousBundle: "com.apple.Terminal")
-    currentTime = 101
+    clock.time = 101
     coordinator.markStable(for: "com.apple.Safari")
 
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .activeStable)
@@ -22,29 +22,29 @@ func activeStableExpiresWhenAnotherAppBecomesFrontmost() {
 
 @Test @MainActor
 func degradedSessionReturnsToIdleAfterRetryCap() {
-    var currentTime: CFAbsoluteTime = 100
+    let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
         configuration: .init(degradedRetryCap: 2),
-        now: { currentTime }
+        now: { clock.time }
     )
 
     coordinator.beginActivation(for: "com.apple.Home", previousBundle: "com.apple.Terminal")
     coordinator.markDegraded(for: "com.apple.Home", reason: "no visible windows")
 
     // First reconfirm — accepted
-    currentTime = 101
+    clock.time = 101
     let result1 = coordinator.reconfirmDegraded(for: "com.apple.Home")
     #expect(result1 == .accepted)
     coordinator.markDegraded(for: "com.apple.Home", reason: "still no visible windows")
 
     // Second reconfirm — accepted
-    currentTime = 102
+    clock.time = 102
     let result2 = coordinator.reconfirmDegraded(for: "com.apple.Home")
     #expect(result2 == .accepted)
     coordinator.markDegraded(for: "com.apple.Home", reason: "still no visible windows")
 
     // Third reconfirm — capped (retry cap is 2)
-    currentTime = 103
+    clock.time = 103
     let result3 = coordinator.reconfirmDegraded(for: "com.apple.Home")
     #expect(result3 == .retryCapped)
     #expect(coordinator.session(for: "com.apple.Home")?.phase == .idle)
@@ -64,27 +64,27 @@ func terminatedTargetClearsPendingSession() {
 
 @Test @MainActor
 func sessionStoreEvictsStalestIdleOrExpiredSessionAtConfiguredCap() {
-    var currentTime: CFAbsoluteTime = 100
+    let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
         configuration: .init(sessionCap: 3),
-        now: { currentTime }
+        now: { clock.time }
     )
 
     // Create 3 sessions that become idle
     coordinator.beginActivation(for: "com.app.A", previousBundle: nil)
-    currentTime = 101
+    clock.time = 101
     coordinator.resetSession(for: "com.app.A")
 
-    currentTime = 200
+    clock.time = 200
     coordinator.beginActivation(for: "com.app.B", previousBundle: nil)
-    currentTime = 201
+    clock.time = 201
     coordinator.resetSession(for: "com.app.B")
 
-    currentTime = 300
+    clock.time = 300
     coordinator.beginActivation(for: "com.app.C", previousBundle: nil)
 
     // Cap is 3, we have 3 sessions. Adding one more should evict stalest idle.
-    currentTime = 400
+    clock.time = 400
     coordinator.beginActivation(for: "com.app.D", previousBundle: nil)
 
     // A was stalest idle → evicted
@@ -99,59 +99,59 @@ func sessionStoreEvictsStalestIdleOrExpiredSessionAtConfiguredCap() {
 
 @Test @MainActor
 func degradedReconfirmResetsIdleExpiryTimer() {
-    var currentTime: CFAbsoluteTime = 100
+    let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
         configuration: .init(degradedIdleExpiry: 2.0, absoluteActivationCeiling: 10.0),
-        now: { currentTime }
+        now: { clock.time }
     )
 
     coordinator.beginActivation(for: "com.apple.Home", previousBundle: "com.apple.Terminal")
     coordinator.markDegraded(for: "com.apple.Home", reason: "no windows")
 
     // Advance 1.5s (under 2s idle expiry)
-    currentTime = 101.5
+    clock.time = 101.5
     let result = coordinator.reconfirmDegraded(for: "com.apple.Home")
     #expect(result == .accepted)
     coordinator.markDegraded(for: "com.apple.Home", reason: "still no windows")
 
     // Advance 1.5s more (3.0 total, but only 1.5s since reconfirm) — still valid
-    currentTime = 103.0
+    clock.time = 103.0
     #expect(coordinator.session(for: "com.apple.Home")?.phase == .degraded)
 
     // Advance past idle expiry from last activity (101.5 + 2.0 = 103.5)
-    currentTime = 104.0
+    clock.time = 104.0
     #expect(coordinator.session(for: "com.apple.Home")?.phase == .idle)
 }
 
 @Test @MainActor
 func degradedReconfirmDoesNotResetAbsoluteActivationCeiling() {
-    var currentTime: CFAbsoluteTime = 100
+    let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
         configuration: .init(
             degradedIdleExpiry: 2.0,
             absoluteActivationCeiling: 5.0,
             degradedRetryCap: 10
         ),
-        now: { currentTime }
+        now: { clock.time }
     )
 
     coordinator.beginActivation(for: "com.apple.Home", previousBundle: "com.apple.Terminal")
     coordinator.markDegraded(for: "com.apple.Home", reason: "no windows")
 
     // Reconfirm at 1.5s
-    currentTime = 101.5
+    clock.time = 101.5
     let result1 = coordinator.reconfirmDegraded(for: "com.apple.Home")
     #expect(result1 == .accepted)
     coordinator.markDegraded(for: "com.apple.Home", reason: "still no windows")
 
     // Reconfirm at 3.0s — still under ceiling
-    currentTime = 103.0
+    clock.time = 103.0
     let result2 = coordinator.reconfirmDegraded(for: "com.apple.Home")
     #expect(result2 == .accepted)
     coordinator.markDegraded(for: "com.apple.Home", reason: "still no windows")
 
     // Reconfirm at 5.5s — past absolute ceiling (100 + 5.0 = 105.0)
-    currentTime = 105.5
+    clock.time = 105.5
     let result3 = coordinator.reconfirmDegraded(for: "com.apple.Home")
     #expect(result3 == .absoluteCeilingReached)
     #expect(coordinator.session(for: "com.apple.Home")?.phase == .idle)
@@ -159,29 +159,29 @@ func degradedReconfirmDoesNotResetAbsoluteActivationCeiling() {
 
 @Test @MainActor
 func sameSessionRetriesCountAgainstSameRetryCap() {
-    var currentTime: CFAbsoluteTime = 100
+    let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
         configuration: .init(absoluteActivationCeiling: 20.0, degradedRetryCap: 2),
-        now: { currentTime }
+        now: { clock.time }
     )
 
     coordinator.beginActivation(for: "com.apple.Home", previousBundle: nil)
     coordinator.markDegraded(for: "com.apple.Home", reason: "no windows")
 
     // Reconfirm 1
-    currentTime = 101
+    clock.time = 101
     _ = coordinator.reconfirmDegraded(for: "com.apple.Home")
     #expect(coordinator.session(for: "com.apple.Home")?.retryCount == 1)
     coordinator.markDegraded(for: "com.apple.Home", reason: "still no windows")
 
     // Reconfirm 2
-    currentTime = 102
+    clock.time = 102
     _ = coordinator.reconfirmDegraded(for: "com.apple.Home")
     #expect(coordinator.session(for: "com.apple.Home")?.retryCount == 2)
     coordinator.markDegraded(for: "com.apple.Home", reason: "still no windows")
 
     // Reconfirm 3 — capped
-    currentTime = 103
+    clock.time = 103
     let result = coordinator.reconfirmDegraded(for: "com.apple.Home")
     #expect(result == .retryCapped)
 }
@@ -199,43 +199,43 @@ func beginActivationStoresPreviousBundleInSession() {
 
 @Test @MainActor
 func activatingSessionExpiresAfterIdleTimeout() {
-    var currentTime: CFAbsoluteTime = 100
+    let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
         configuration: .init(activatingIdleExpiry: 2.0),
-        now: { currentTime }
+        now: { clock.time }
     )
 
     coordinator.beginActivation(for: "com.apple.Safari", previousBundle: nil)
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .activating)
 
-    currentTime = 102.5
+    clock.time = 102.5
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
 }
 
 @Test @MainActor
 func activatingSessionExpiresAfterAbsoluteCeiling() {
-    var currentTime: CFAbsoluteTime = 100
+    let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
         configuration: .init(activatingIdleExpiry: 10.0, absoluteActivationCeiling: 5.0),
-        now: { currentTime }
+        now: { clock.time }
     )
 
     coordinator.beginActivation(for: "com.apple.Safari", previousBundle: nil)
 
     // Simulate activity within idle expiry but past absolute ceiling
-    currentTime = 103
+    clock.time = 103
     coordinator.touchSession(for: "com.apple.Safari")
-    currentTime = 105.5
+    clock.time = 105.5
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
 }
 
 @Test @MainActor
 func handleFrontmostChangeDoesNotExpireCurrentFrontmostApp() {
-    var currentTime: CFAbsoluteTime = 100
-    let coordinator = ToggleSessionCoordinator(now: { currentTime })
+    let clock = CoordinatorTestClock(time: 100)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
 
     coordinator.beginActivation(for: "com.apple.Safari", previousBundle: "com.apple.Terminal")
-    currentTime = 101
+    clock.time = 101
     coordinator.markStable(for: "com.apple.Safari")
 
     // Safari is still frontmost
@@ -246,22 +246,22 @@ func handleFrontmostChangeDoesNotExpireCurrentFrontmostApp() {
 
 @Test @MainActor
 func evictionPrefersIdleOverExpiredNonIdle() {
-    var currentTime: CFAbsoluteTime = 100
+    let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
         configuration: .init(activatingIdleExpiry: 2.0, sessionCap: 2),
-        now: { currentTime }
+        now: { clock.time }
     )
 
     // A: activating (will become expired non-idle)
     coordinator.beginActivation(for: "com.app.A", previousBundle: nil)
 
     // B: idle
-    currentTime = 200
+    clock.time = 200
     coordinator.beginActivation(for: "com.app.B", previousBundle: nil)
     coordinator.resetSession(for: "com.app.B")
 
     // C: triggers eviction — B (idle) should be evicted before A (expired non-idle)
-    currentTime = 300
+    clock.time = 300
     coordinator.beginActivation(for: "com.app.C", previousBundle: nil)
 
     #expect(coordinator.session(for: "com.app.B") == nil)
@@ -271,19 +271,19 @@ func evictionPrefersIdleOverExpiredNonIdle() {
 
 @Test @MainActor
 func evictionDoesNotEvictCurrentlyMutatingSession() {
-    var currentTime: CFAbsoluteTime = 100
+    let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
         configuration: .init(sessionCap: 2),
-        now: { currentTime }
+        now: { clock.time }
     )
 
     coordinator.beginActivation(for: "com.app.A", previousBundle: nil)
-    currentTime = 200
+    clock.time = 200
     coordinator.beginActivation(for: "com.app.B", previousBundle: nil)
 
     // Both sessions are activating (non-idle). Adding C should evict stalest non-idle,
     // but NOT the currently mutating session (C itself).
-    currentTime = 300
+    clock.time = 300
     coordinator.beginActivation(for: "com.app.C", previousBundle: nil)
 
     // A is stalest, should be evicted
@@ -306,11 +306,11 @@ func terminatedTargetClearsDegradedSession() {
 
 @Test @MainActor
 func deactivationResetsSessionToIdle() {
-    var currentTime: CFAbsoluteTime = 100
-    let coordinator = ToggleSessionCoordinator(now: { currentTime })
+    let clock = CoordinatorTestClock(time: 100)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
 
     coordinator.beginActivation(for: "com.apple.Safari", previousBundle: "com.apple.Terminal")
-    currentTime = 101
+    clock.time = 101
     coordinator.markStable(for: "com.apple.Safari")
     coordinator.beginDeactivation(for: "com.apple.Safari")
 
@@ -323,53 +323,61 @@ func deactivationResetsSessionToIdle() {
 
 @Test @MainActor
 func activeStableIdleExpiryAppliesLazily() {
-    var currentTime: CFAbsoluteTime = 100
+    let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
         configuration: .init(activeStableIdleExpiry: 300),
-        now: { currentTime }
+        now: { clock.time }
     )
 
     coordinator.beginActivation(for: "com.apple.Safari", previousBundle: nil)
-    currentTime = 101
+    clock.time = 101
     coordinator.markStable(for: "com.apple.Safari")
 
-    currentTime = 200
+    clock.time = 200
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .activeStable)
 
-    currentTime = 402  // 301s since confirmedAt
+    clock.time = 402  // 301s since confirmedAt
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
 }
 
 @Test @MainActor
 func deactivatingSessionExpiresAfterIdleTimeout() {
-    var currentTime: CFAbsoluteTime = 100
+    let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
         configuration: .init(activatingIdleExpiry: 2.0),
-        now: { currentTime }
+        now: { clock.time }
     )
 
     coordinator.beginActivation(for: "com.apple.Safari", previousBundle: nil)
-    currentTime = 101
+    clock.time = 101
     coordinator.markStable(for: "com.apple.Safari")
     coordinator.beginDeactivation(for: "com.apple.Safari")
 
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .deactivating)
 
-    currentTime = 104  // 3s since deactivation started, past 2s expiry
+    clock.time = 104  // 3s since deactivation started, past 2s expiry
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
 }
 
 @Test @MainActor
-func handleFrontmostChangeResetsDeactivatingSession() {
-    var currentTime: CFAbsoluteTime = 100
-    let coordinator = ToggleSessionCoordinator(now: { currentTime })
+func handleFrontmostChangeKeepsDeactivatingSessionAliveUntilHideConfirmation() {
+    let clock = CoordinatorTestClock(time: 100)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
 
     coordinator.beginActivation(for: "com.apple.Safari", previousBundle: nil)
-    currentTime = 101
+    clock.time = 101
     coordinator.markStable(for: "com.apple.Safari")
     coordinator.beginDeactivation(for: "com.apple.Safari")
 
     coordinator.handleFrontmostChange(newFrontmostBundle: "com.apple.Terminal")
 
-    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .deactivating)
+}
+
+private final class CoordinatorTestClock: @unchecked Sendable {
+    var time: CFAbsoluteTime
+
+    init(time: CFAbsoluteTime) {
+        self.time = time
+    }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,8 @@ This directory maps the maintainer-facing docs for Quickey.
 
 ## Maintainer Notes
 - [`../AGENTS.md`](../AGENTS.md)
-- [`handoff-notes.md`](./handoff-notes.md)
-- [`lessons-learned.md`](./lessons-learned.md)
+- [`handoff-notes.md`](./handoff-notes.md) — current runtime validation status, packaged-app caveats, latest toggle trace signatures, and the exact 2026-04-09 Safari launch/relaunch validation evidence
+- [`lessons-learned.md`](./lessons-learned.md) — operational pitfalls, including session ownership across relaunches and the no-window success policy for regular apps
 
 ## Automation
 - [`loop-prompt.md`](./loop-prompt.md) — reference and migration note; active automation is the `/babysit-prs` skill

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,12 +161,18 @@ Responsibilities:
 - fall back to `NSWorkspace` reopen requests before plain AppKit activation requests when SkyLight activation cannot complete
 - build `ActivationObservationSnapshot` values from frontmost-app, active/hidden, visible-window, focused-window, main-window, and app-classification evidence
 - re-evaluate app classification per toggle attempt instead of caching it globally
-- keep per-target toggle sessions on the main actor and let `ToggleSessionCoordinator` own the durable `previousBundle` for `activating`, `activeStable`, `degraded`, and `deactivating` phases
+- keep per-target toggle sessions on the main actor and let `ToggleSessionCoordinator` own the full pid-aware lifecycle for `launching`, `activating`, `activeStable`, `degraded`, `deactivating`, and `idle`
+- treat `ToggleSessionCoordinator` as the canonical lifecycle owner; `AppSwitcher` only exposes derived pending/stable views instead of keeping a second mutable toggle owner
+- keep durable `previousBundle`, `attemptID`, `pid`, and activation path on the coordinator session so relaunches and pid rollover stay traceable
+- attach the `NSRunningApplication` returned by `NSWorkspace.openApplication` back onto the existing `launching` session so launch and activate share the same confirmation pipeline
 - invalidate or clear sessions from `NSWorkspace.didActivateApplicationNotification` and `NSWorkspace.didTerminateApplicationNotification` instead of polling
 - only allow toggle-off from a confirmed stable state; repeat triggers during pending or degraded activation re-confirm the session instead of restoring away
 - use `FrontmostApplicationTracker` for current-frontmost capture and restore attempts, while session-owned `previousBundle` remains the source of truth during confirmation and deactivation
+- only allow windowless stable success for non-regular targets; regular apps must show visible/focused/main-window evidence before toggle-on can become `activeStable`
 - keep the hot activation path to front-process activation only, then escalate to `makeKeyWindow`, `AXRaise`, and window recovery only when observation shows activation is not yet settled
 - toggle off by requesting `NSRunningApplication.hide()`, then confirm deactivation asynchronously from `NSWorkspace.didHideApplicationNotification` plus a short observation window before clearing session state
+- when an app is externally frontmost and unowned, still create a coordinator-owned `deactivating` session before dispatching `hide()` so `hide_untracked` remains an explicit, traceable toggle lane instead of an ad-hoc branch
+- emit `TOGGLE_TRACE_*` lifecycle diagnostics from accepted-toggle transitions and `SHORTCUT_TRACE_*` diagnostics only from matched or explicitly blocked shortcut boundaries
 - reveal selected application in Finder when needed
 
 ### Usage tracking
@@ -227,10 +233,12 @@ Global keyDown event
   -> CarbonHotKeyProvider or EventTapManager emits KeyPress
   -> ShortcutManager.handleKeyPress()
   -> KeyMatcher finds matching AppShortcut
+  -> ShortcutManager emits `SHORTCUT_TRACE_DECISION` or `SHORTCUT_TRACE_BLOCKED` only on the accepted-trigger boundary
   -> AppSwitcher.toggleApplication()
-  -> ToggleSessionCoordinator records bundle-keyed session + previousBundle
+  -> ToggleSessionCoordinator creates/updates pid-aware attempt session + previousBundle
   -> ApplicationObservation captures frontmost/window evidence
   -> activate / confirm / recover stage-by-stage
+  -> `TOGGLE_TRACE_*` lines record branch reason, reset reason, and confirmation outcome for that attempt
   -> direct hide request only from activeStable, then async hide confirmation
 ```
 
@@ -252,7 +260,11 @@ CGEvent callback receives tapDisabledByTimeout / tapDisabledByUserInput
 - **Capability-aware shortcut readiness**: `ShortcutCaptureStatus` separates Accessibility, Input Monitoring, Carbon registration, Hyper event-tap activity, standard-shortcut readiness, and Hyper readiness
 - **O(1) trigger index**: `ShortcutSignature` dictionary replaces linear scans in the hot path
 - **Observation-first toggle truth**: `ApplicationObservation` snapshots gate stable-state promotion from frontmost/window evidence instead of trusting `isActive` alone
+- **Single-source toggle ownership**: `ToggleSessionCoordinator` is the only mutable lifecycle owner; `AppSwitcher` derives pending/stable views from coordinator state instead of dual-writing local activation state
 - **Session-owned previous-app memory**: `ToggleSessionCoordinator` holds the durable `previousBundle` once a toggle session is accepted; `FrontmostApplicationTracker` remains the restore executor
+- **Pid-aware attempt sessions**: launch / relaunch / termination recovery use attempt-scoped sessions that track `attemptID`, `pid`, `activationPath`, and current phase so process-lifetime boundaries cannot silently desynchronize ownership
+- **No-window success policy**: regular apps require usable window evidence before `activeStable`; only `activationPolicy != .regular` targets may succeed while windowless
+- **Attempt-scoped diagnostics**: `TOGGLE_TRACE_*` and `SHORTCUT_TRACE_*` explain branch choice and failure boundaries without adding detailed logs to unrelated key events
 - **Notification-driven invalidation**: `NSWorkspace` activation and termination notifications clear or expire stable/deactivating sessions without polling
 - **Hardened EventTap lifecycle**: explicit ownership, callback-safe timeout snapshots, threshold-based escalation, and same-thread run-loop recreation
 - **Split capture transports**: standard shortcuts use Carbon hotkeys; Hyper-only shortcuts use the active event tap. Passive `.listenOnly` mode is not used in the interception path because it cannot consume shortcut events

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,72 +3,66 @@
 ## High-level overview
 Quickey is a menu bar macOS utility that stores app-shortcut bindings, captures global key events, matches them to stored shortcuts, and toggles target apps.
 
-```text
-+--------------------+
-|   Menu Bar App     |
-|  AppDelegate/Main  |
-+---------+----------+
-          |
-          v
-+--------------------+
-|   AppController    |
-| bootstraps modules |
-+----+----+----+-----+
-     |    |    |
-     |    |    +-----------------------------+
-     |    |                                  |
-     v    v                                  v
-+---------+--------+              +----------------------+
-| ShortcutManager  |<------------>|    ShortcutStore     |
-| event + trigger  |              | in-memory shortcuts  |
-+----+--------+----+              +----------+-----------+
-     |        |                              |
-     |        v                              v
-     |   +------------------+        +-------------------+
-     |   | Persistence      |        | Settings UI       |
-     |   | JSON save/load   |        | SwiftUI + AppKit  |
-     |   +------------------+        +-------------------+
-     |
-     v
-+--------------------+
-+ ShortcutCapture    +
-| Coordinator        |
-+---------+----------+
-     +----+----+
-     |         |
-     v         v
-+--------------------+   +--------------------+
-| CarbonHotKeyProvider|   | EventTapManager   |
-| standard shortcuts  |   | Hyper-only input  |
-+---------+----------+   +---------+----------+
-          |                        |
-          +-----------+------------+
-                      |
-                      v
-+--------------------+
-|    KeyMatcher      |
-| key/modifier match |
-+---------+----------+
-          |
-          v
-+--------------------+
-|    AppSwitcher     |
-| activate/toggle    |
-+----+---------+-----------+
-     |         |
-     |         +-----------------------+
-     |                                 |
-     v                                 v
-+---------------------------+   +------------------------+
-| ToggleSessionCoordinator  |   | ApplicationObservation |
-| per-target runtime state  |   | frontmost/window truth |
-+------------+--------------+   +------------------------+
-             |
-             v
-+---------------------------+
-| FrontmostApplicationTracker |
-| previous app restore state |
-+---------------------------+
+```mermaid
+flowchart LR
+  subgraph B["启动 / 配置"]
+    A["A(AppController)\n启动编排"]
+    H["H(HyperKeyService)\n恢复持久化 Hyper"]
+    P["P(PersistenceService)\nshortcuts.json"]
+    S["S(ShortcutStore)\n内存快捷键"]
+    U["U(Settings UI / AppPreferences)\n编辑快捷键与通用设置"]
+    R["R(LaunchAtLoginService)\n登录项状态"]
+    X["X(UsageTracker)\n使用统计"]
+  end
+
+  subgraph C["捕获 / 匹配"]
+    M["M(ShortcutManager)\n匹配、分发、SHORTCUT_TRACE_*"]
+    Q["Q(ShortcutCaptureCoordinator)\ntransport-aware readiness"]
+    C1["C(CarbonHotKeyProvider)\n标准快捷键"]
+    E["E(EventTapCaptureProvider / EventTapManager)\nHyper 快捷键"]
+    K["K(KeyMatcher)\nO(1) Trigger Index"]
+  end
+
+  subgraph T["Toggle 运行时"]
+    W["W(AppSwitcher)\n激活 / 隐藏编排"]
+    T1["T(ToggleSessionCoordinator)\ncanonical owner\nlaunching → activating → activeStable → deactivating → degraded / idle"]
+    O["O(ApplicationObservation)\nfrontmost + window 证据"]
+    F["F(FrontmostApplicationTracker)\nprevious app snapshot"]
+    L["L(AppBundleLocator)\n目标 app 定位"]
+    G["G(ToggleDiagnosticEvent)\nTOGGLE_TRACE_* 格式化"]
+  end
+
+  U --> P
+  U --> S
+  U --> H
+  U --> R
+  U --> X
+
+  A --> P
+  A --> S
+  A --> H
+  A --> M
+  A --> R
+
+  P --> S
+  S --> M
+  S --> K
+  M --> K
+
+  M <--> Q
+  Q --> C1
+  Q --> E
+  C1 --> M
+  E --> M
+
+  M --> W
+  W <--> T1
+  W --> O
+  W --> F
+  W --> L
+
+  M --> G
+  W --> G
 ```
 
 ## Main modules

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -2,10 +2,28 @@
 
 ## Current State
 Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. On 2026-04-08, the shortcut-capture and toggle runtime were further refactored: standard shortcuts now use Carbon hotkeys, Hyper-dependent shortcuts remain on the active event tap, activation now defaults to front-process-only before escalating observation-driven window recovery, and toggle-off now uses `NSRunningApplication.hide()` with asynchronous confirmation. On 2026-04-08, targeted macOS re-validation was completed for the redesigned Safari/Hyper paths: Safari toggle-on/toggle-off now works again, Hyper-routed shortcuts survive fresh relaunches, and the post-fix runtime window shows `TOGGLE_HIDE_CONFIRMED` without new `TOGGLE_DEGRADED`, `hide_untracked`, event-tap-disable, or shortcut-capture resync-storm signatures. Broader app-matrix validation is still pending. A signed and notarized distributable is still unresolved.
+On 2026-04-09, toggle reliability recovery moved lifecycle ownership fully into `ToggleSessionCoordinator`: launch / activate / stable / deactivation state is now pid-aware, attempt-scoped, and no longer split between coordinator and `AppSwitcher`. Regular apps now require usable window evidence (`visibleWindowCount > 0` or focused/main-window evidence) before toggle-on can be recorded as stable success; only non-regular apps may succeed windowlessly. The same recovery also added attempt-linked `TOGGLE_TRACE_*` and accepted-trigger `SHORTCUT_TRACE_*` diagnostics so one log window can explain branch choice, reset reason, and confirmation outcome end-to-end.
 On 2026-04-08, launch-at-login presentation was hardened so `SMAppService.Status.notFound` is no longer always treated as a packaging failure: when Quickey is running outside `/Applications` or `~/Applications`, the General tab now shows install-location guidance instead of the red bundle-misconfiguration warning.
 On 2026-04-08, local DMG packaging and a tag-driven GitHub release workflow were added. The repo can now build `build/Quickey-<version>.dmg` locally and defines the credential-backed notarization/publish path. On 2026-04-08, the release workflow was further hardened to preflight required signing/notarization secrets and skip cleanly with a summary when Developer ID credentials are absent, and a separate internal-package workflow was added to upload unsigned DMG artifacts for trusted testers. The internal workflow now also maintains a stable `internal-downloads` tag-backed prerelease page with tester-facing install notes and the latest internal DMG asset, instead of deleting and recreating the release each run.
+On 2026-04-09, packaged-app runtime validation moved past the original TCC blocker after `build/Quickey.app` was re-added to Accessibility and Input Monitoring. Manual Safari validation on the packaged app now shows the owned launch / relaunch path attaching the launched process back to the same attempt (`TOGGLE_TRACE_SESSION ... event=launch_attached reason="launch_completion_process_lookup"`), frontmost-without-window states staying in visibility recovery (`TOGGLE_TRACE_CONFIRMATION ... event=awaiting_window_evidence`) until usable window evidence appears, and second press hiding cleanly via `TOGGLE_HIDE_CONFIRMED` instead of falling through to `hide_untracked`. A follow-up investigation also closed the apparent `carbon=false eventTap=true` mystery after restart: the persisted Safari shortcut in `~/Library/Application Support/Quickey/shortcuts.json` was Hyper-routed (`command` + `option` + `control` + `shift` + `s`) and `defaults read com.quickey.app hyperKeyEnabled` was `1`, so the packaged app was correctly running through the event-tap path. The earlier assumption that Carbon readiness had drifted was incorrect, and `AppController` now reapplies the persisted Hyper state before `ShortcutManager.start()` so the very first readiness snapshot matches the real active transport.
 
-## Automated Verification (2026-04-08)
+## Automated Verification
+
+### 2026-04-09
+- `swift test` passed; the suite reported 187 tests passed
+- `swift test --filter AppSwitcherTests` passed
+- `swift test --filter AppControllerTests` passed
+- `swift test --filter ShortcutManagerStatusTests` passed
+- `swift test --filter ToggleSessionCoordinatorTests` passed
+- `swift test --filter ToggleLaunchLifecycleTests` passed
+- `bats scripts/e2e-lib.bats` passed
+- `bash scripts/package-app.sh` passed, rebuilt `build/Quickey.app`, and re-signed it with the local `Quickey` identity
+- `codesign --verify --deep --strict --verbose=2 build/Quickey.app` passed
+- `bash scripts/e2e-full-test.sh` failed at packaged-app runtime preflight because TCC was not granted for `build/Quickey.app` in this environment (`trusted=false`, `ax=false`, `im=false`, event tap never started)
+- a follow-up packaged-app spot-check validated standard external activation against the current `command + shift + s` Safari shortcut: `MATCHED`, `TOGGLE_TRACE_DECISION event=hide_untracked`, `TOGGLE_HIDE_UNTRACKED`, `HIDE_REQUEST`, and `TOGGLE_HIDE_CONFIRMED` all appeared with the same non-nil `attemptId` / `pid` / `phase`
+- after the E2E harness was updated to use transport-aware readiness plus config-aware module skips, `bash scripts/e2e-full-test.sh` passed on the current local shortcut fixture with 1 warning (`Hyper Key (CGEvent hold)` skipped because the IINA Hyper shortcut is not configured)
+
+### 2026-04-08
 - `swift test` passed after the DMG packaging and release workflow changes; the suite reported 173 tests passed
 - `swift build` passed after the refactor
 - `./scripts/package-app.sh` passed after the refactor, rebuilt `build/Quickey.app`, and re-signed it with the local `Quickey` identity
@@ -22,6 +40,17 @@ On 2026-04-08, local DMG packaging and a tag-driven GitHub release workflow were
 - On 2026-04-08, Hyper-routed shortcuts were re-validated after a fresh relaunch; the startup-state replay fix restored live `HYPER_INJECT` / `EVENT_TAP_SWALLOW` behavior
 - The post-fix runtime window showed repeated `HIDE_REQUEST` -> `TOGGLE_HIDE_CONFIRMED` pairs without fresh `TOGGLE_DEGRADED`, `TOGGLE_HIDE_DEGRADED`, `hide_untracked`, event-tap-disable diagnostics, or repeated "syncing shortcut capture" churn
 - Broader 2026-04-08 app-matrix validation for system/window-weird apps remains pending
+- On 2026-04-09, packaged `build/Quickey.app` was manually revalidated for Safari fresh-launch and relaunch after TCC was granted:
+  - fresh launch produced `event=session_started activationPath=launch`, `event=launch_attached reason="launch_completion_process_lookup"`, `event=awaiting_window_evidence`, then `event=confirmed reason="activation_stable"`
+  - the next press produced `TOGGLE_HIDE_ATTEMPT`, `HIDE_REQUEST`, and `TOGGLE_HIDE_CONFIRMED` with Finder frontmost afterward
+  - relaunch after termination produced `TOGGLE_TRACE_RESET ... reason="termination"`, then a new owned `launch` attempt with a new pid, followed by the same stable-confirmed -> hide-confirmed sequence
+- On 2026-04-09, packaged `build/Quickey.app` was also manually revalidated for Safari external activation under the current Hyper configuration:
+  - externally fronting Safari, then triggering the persisted Hyper shortcut, produced `TOGGLE_TRACE_DECISION event=hide_untracked reason="external_untracked_hide"`, followed by a real `HIDE_REQUEST` and `TOGGLE_HIDE_CONFIRMED`
+  - the current packaged-app configuration is Hyper-routed, so `checkPermission: ax=true im=true carbon=false eventTap=true` is expected in that state, not a Carbon regression
+- On 2026-04-09, packaged `build/Quickey.app` was then manually revalidated again for Safari external activation after switching the persisted shortcut back to the standard `command + shift + s` route:
+  - externally fronting Safari, then triggering the standard shortcut, produced `MATCHED`, `TOGGLE_TRACE_DECISION event=hide_untracked`, `TOGGLE_HIDE_UNTRACKED`, `HIDE_REQUEST`, and `TOGGLE_HIDE_CONFIRMED`
+  - the very first `hide_untracked` trace and lifecycle lines now carried the same non-nil `attemptId`, `pid`, and `phase=deactivating` as the later hide request / confirmation lines, confirming that the coordinator-owned deactivation session is allocated before logging that branch
+- On 2026-04-09, the frontmost/no-window policy was also observed live on Safari: Quickey logged `awaiting_window_evidence` and recovery stages while Safari was frontmost without usable window evidence, and only promoted to stable once visible/focused/main-window evidence appeared
 
 ## Toggle Loop Fix and Cross-App Restore (2026-03-25, Issue #80)
 - **Toggle loop root cause**: physical key repeat events spaced > 200ms bypassed debounce, causing activate/hide/activate cycles
@@ -46,8 +75,52 @@ On 2026-04-08, local DMG packaging and a tag-driven GitHub release workflow were
 - Stable toggle-off now enters an explicit `deactivating` phase, requests `hide()` on the target app, and clears runtime session state only after hide confirmation succeeds
 - Event tap recovery now either recreates the tap successfully on the existing background RunLoop thread or leaves an explicit degraded readiness state after repeated recreation failures
 - Standard shortcuts and Hyper shortcuts now report readiness independently, so missing Input Monitoring only degrades Hyper capture instead of the whole app
+- `ToggleSessionCoordinator` is now the canonical toggle owner: launch / activate / stable / deactivating state, pid rollover handling, and durable `previousBundle` memory no longer depend on split local `AppSwitcher` state
+- Relaunches now allocate an owned `launching` session before `NSWorkspace` open returns, so the next press cannot fall through to `hide_untracked` merely because the process was between lifetimes
+- `NSWorkspace.openApplication` completion is now used as a process-identity seam: the returned `NSRunningApplication` feeds pid attachment and the same confirmation pipeline used by activate/unhide, instead of leaving launch as fire-and-forget
+- Regular apps cannot silently succeed toggle-on without usable window evidence; only targets with `activationPolicy != .regular` may remain stable without visible/focused/main-window proof
+- `hide_untracked` now creates an explicit coordinator-owned `deactivating` session before dispatching `hide()`, so external activation still gets a real `HIDE_REQUEST` / confirmation pair instead of only logging the branch
+
+## Toggle Reliability Recovery (2026-04-09)
+- `ToggleSessionCoordinator` now owns pid-aware attempt sessions with explicit `launching`, `activating`, `activeStable`, `deactivating`, `degraded`, and `idle` phases.
+- `AppSwitcher` derives pending/stable views from the coordinator instead of keeping its own mutable lifecycle owner.
+- `ToggleDiagnosticEvent` centralizes `TOGGLE_TRACE_*` formatting so attempt-linked branch logs stay cheap and consistent.
+- `ShortcutManager` emits `SHORTCUT_TRACE_*` only for matched shortcuts or explicit blocked-capture states, not for unrelated key events.
+
+### Trace signatures to treat as success
+- Toggle-on settled: `TOGGLE_TRACE_CONFIRMATION attemptId=... event=confirmed reason="activation_stable"`
+- Toggle-off settled: `TOGGLE_TRACE_CONFIRMATION attemptId=... event=confirmed reason="hide_confirmed"`
+- Owned launch path started correctly: `TOGGLE_TRACE_SESSION attemptId=... event=session_started activationPath=launch reason="not_running_launch_request"`
+- Owned launch attached to the real process: `TOGGLE_TRACE_SESSION attemptId=... event=launch_attached activationPath=launch reason="launch_completion_process_lookup"`
+- Hyper-routed Safari in the current local config: `SHORTCUT_TRACE_DECISION event=matched bundle=com.apple.Safari route=hyper`
+
+### Trace signatures to treat as failure or follow-up
+- Regular app frontmost but still unusable: `TOGGLE_TRACE_CONFIRMATION attemptId=... event=awaiting_window_evidence reason="frontmost_without_window_evidence"`
+- Hide request degraded instead of settling: `TOGGLE_TRACE_CONFIRMATION attemptId=... event=degraded reason="partial_hide_degraded"`
+- Session reset: `TOGGLE_TRACE_RESET attemptId=... event=session_cleared reason="termination" | "pid_rollover" | "launch_failed" | "activation_recovery_exhausted"`
+- Stale tracking corrected: `TOGGLE_TRACE_RESET attemptId=... event=session_invalidated reason="stale_state_invalidated"`
+- Capture path blocked before toggle dispatch: `SHORTCUT_TRACE_BLOCKED reason="missing_registration_or_system_conflict" | "input_monitoring_missing" | "event_tap_inactive"`
+
+### Trace signatures that are only valid in specific ownership cases
+- `TOGGLE_TRACE_DECISION event=hide_untracked reason="external_untracked_hide"` is acceptable only for genuinely external activation. It is a regression if it appears immediately after an owned launch or relaunch.
+- When `hide_untracked` is valid, it must still be followed by a real hide lane (`HIDE_REQUEST` and `TOGGLE_HIDE_CONFIRMED` or explicit degraded confirmation). A lone `hide_untracked` log without a deactivation session is a bug.
+- `TOGGLE_TRACE_DECISION event=blocked reason="activation_pending_not_stable"` is the correct second-press behavior while an owned launch/activation is still settling.
+- `checkPermission: ax=true im=true carbon=false eventTap=true` is only suspicious if the current enabled shortcut set is supposed to be standard-only. If the persisted shortcut is Hyper-routed and `hyperKeyEnabled` is on, that snapshot is expected.
+- `scripts/e2e-full-test.sh` and `scripts/e2e-lib.sh` now preflight packaged-app startup with transport-aware readiness: standard-only configs accept `carbon=true eventTap=false`, Hyper-only configs require an active event tap, and mixed fixtures require both transports to be ready before modules start.
+- E2E modules should treat missing fixture shortcuts as configuration skips, not runtime failures. On the current local setup, Safari standard coverage is valid while the IINA Hyper module should report `WARN` unless a Hyper-routed IINA shortcut is actually present in `shortcuts.json`.
 
 ## Follow-up Requiring macOS Validation
+- If you want to validate the standard transport specifically, first switch the persisted shortcut back to a standard combo; otherwise continue validating the current Hyper-routed config with F19 / Hyper input and rerun `bash scripts/e2e-full-test.sh`
+- Fresh-launch path
+  Validate: target not running -> shortcut launches it -> second press hides it without `hide_untracked` or `phase=no_session`
+- Relaunch path
+  Validate: target stabilizes -> target quits -> shortcut relaunches it -> second press still hides cleanly
+- External activation path
+  Validate: user fronts the target outside Quickey -> Quickey only uses `hide_untracked` when the session is truly unowned, and that branch still emits a real `HIDE_REQUEST` / `TOGGLE_HIDE_CONFIRMED` pair
+- Frontmost/no-window path
+  Validate: target becomes frontmost without visible/focused/main-window evidence -> Quickey stays in visibility recovery or degraded state instead of recording stable success
+- Hotkey-latency regression
+  Validate: repeated matched shortcuts do not show perceptible latency after the new attempt/session diagnostics
 - Normal apps beyond Safari: Finder, Terminal
   Validate stable activation, second-press toggle-off via `hide()`, and coherent `TOGGLE_STABLE` / `TOGGLE_HIDE_CONFIRMED` diagnostics
 - System or window-weird apps: Home, Clock, System Settings
@@ -82,13 +155,15 @@ On 2026-04-08, local DMG packaging and a tag-driven GitHub release workflow were
 
 ## Residual Risks
 - The new capture split and toggle guarantees are covered by code-level tests and by the automated suite, but they still need the targeted macOS matrix above before we can claim runtime correctness for Safari-only toggle-off, standard-vs-Hyper parity, Home, Clock, System Settings, or timeout-stress behavior
+- The new 2026-04-09 attempt/session diagnostics, launch attachment, and untracked-hide session ownership are implemented and test-covered, and Safari fresh-launch / relaunch / external-activation were manually validated on packaged `build/Quickey.app`; broader app-matrix and standard-vs-Hyper parity work still remain
 - Event tap recovery semantics are implemented with thresholded escalation and degraded reporting, but a reproducible on-device timeout-stress run is still needed to confirm the live logs are operationally sufficient
 - Signed/notarized release validation is still blocked on Developer ID availability; until those credentials exist, only the internal-package DMG artifact path can be verified end-to-end
 
 ## Immediate Next Actions
-1. Expand the targeted macOS validation matrix from the now-confirmed Safari/Hyper relaunch paths to Finder, Terminal, Home, Clock, System Settings, hidden/minimized paths, and event-tap timeout stress
-2. Verify standard-shortcut vs Hyper parity on the same target apps beyond the already revalidated Safari/Hyper cases, and capture any remaining app-specific exceptions in this file
-3. Use the internal-package workflow for tester-facing DMG artifacts until Developer ID credentials are available
-4. Run the DMG release workflow with real Developer ID and notary credentials on a `v*` tag once those credentials exist
-5. Validate the published DMG on a clean macOS machine and confirm drag-install to `/Applications`
-6. Fold any new validation findings back into this note, not into the feature overview docs
+1. Rerun `bash scripts/e2e-full-test.sh` with the intended shortcut transport explicitly set first: either keep the current Hyper-routed Safari config and drive F19 / Hyper input, or switch Safari back to a standard combo before interpreting Carbon readiness logs
+2. Expand the targeted macOS validation matrix from the now-confirmed Safari fresh-launch / relaunch / external-activation paths to Finder, Terminal, Home, Clock, System Settings, hidden/minimized paths, and event-tap timeout stress
+3. Verify standard-shortcut vs Hyper parity on the same target apps beyond the already revalidated Safari cases, and capture any remaining app-specific exceptions in this file
+4. Use the internal-package workflow for tester-facing DMG artifacts until Developer ID credentials are available
+5. Run the DMG release workflow with real Developer ID and notary credentials on a `v*` tag once those credentials exist
+6. Validate the published DMG on a clean macOS machine and confirm drag-install to `/Applications`
+7. Fold any new validation findings back into this note, not into the feature overview docs

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -5,7 +5,7 @@ Quickey was broadly validated on macOS 15.3.1 on 2026-03-20. On 2026-04-08, the 
 On 2026-04-09, toggle reliability recovery moved lifecycle ownership fully into `ToggleSessionCoordinator`: launch / activate / stable / deactivation state is now pid-aware, attempt-scoped, and no longer split between coordinator and `AppSwitcher`. Regular apps now require usable window evidence (`visibleWindowCount > 0` or focused/main-window evidence) before toggle-on can be recorded as stable success; only non-regular apps may succeed windowlessly. The same recovery also added attempt-linked `TOGGLE_TRACE_*` and accepted-trigger `SHORTCUT_TRACE_*` diagnostics so one log window can explain branch choice, reset reason, and confirmation outcome end-to-end.
 On 2026-04-08, launch-at-login presentation was hardened so `SMAppService.Status.notFound` is no longer always treated as a packaging failure: when Quickey is running outside `/Applications` or `~/Applications`, the General tab now shows install-location guidance instead of the red bundle-misconfiguration warning.
 On 2026-04-08, local DMG packaging and a tag-driven GitHub release workflow were added. The repo can now build `build/Quickey-<version>.dmg` locally and defines the credential-backed notarization/publish path. On 2026-04-08, the release workflow was further hardened to preflight required signing/notarization secrets and skip cleanly with a summary when Developer ID credentials are absent, and a separate internal-package workflow was added to upload unsigned DMG artifacts for trusted testers. The internal workflow now also maintains a stable `internal-downloads` tag-backed prerelease page with tester-facing install notes and the latest internal DMG asset, instead of deleting and recreating the release each run.
-On 2026-04-09, packaged-app runtime validation moved past the original TCC blocker after `build/Quickey.app` was re-added to Accessibility and Input Monitoring. Manual Safari validation on the packaged app now shows the owned launch / relaunch path attaching the launched process back to the same attempt (`TOGGLE_TRACE_SESSION ... event=launch_attached reason="launch_completion_process_lookup"`), frontmost-without-window states staying in visibility recovery (`TOGGLE_TRACE_CONFIRMATION ... event=awaiting_window_evidence`) until usable window evidence appears, and second press hiding cleanly via `TOGGLE_HIDE_CONFIRMED` instead of falling through to `hide_untracked`. A follow-up investigation also closed the apparent `carbon=false eventTap=true` mystery after restart: the persisted Safari shortcut in `~/Library/Application Support/Quickey/shortcuts.json` was Hyper-routed (`command` + `option` + `control` + `shift` + `s`) and `defaults read com.quickey.app hyperKeyEnabled` was `1`, so the packaged app was correctly running through the event-tap path. The earlier assumption that Carbon readiness had drifted was incorrect, and `AppController` now reapplies the persisted Hyper state before `ShortcutManager.start()` so the very first readiness snapshot matches the real active transport.
+On 2026-04-09, packaged-app runtime validation moved past the original TCC blocker after `build/Quickey.app` was re-added to Accessibility and Input Monitoring. Manual Safari validation on the packaged app now shows the owned launch / relaunch path attaching the launched process back to the same attempt (`TOGGLE_TRACE_SESSION ... event=launch_attached reason="launch_completion_process_lookup"`), frontmost-without-window states staying in visibility recovery (`TOGGLE_TRACE_CONFIRMATION ... event=awaiting_window_evidence`) until usable window evidence appears, and second press hiding cleanly via `TOGGLE_HIDE_CONFIRMED` instead of falling through to `hide_untracked`. A follow-up investigation also closed the earlier `carbon=false eventTap=true` mystery after restart: at that point Safari itself was Hyper-routed, so the event-tap path was the correct transport. The current local fixture has since moved to a mixed transport setup (`command + shift + s` for Safari plus a Hyper-routed IINA shortcut), and the latest packaged-app verification now shows `checkPermission: ax=true im=true carbon=true eventTap=true` together with clean `TOGGLE_STABLE` / `TOGGLE_HIDE_CONFIRMED` chains and no fresh degraded/session-reset signatures in the recent log window.
 
 ## Automated Verification
 
@@ -21,7 +21,8 @@ On 2026-04-09, packaged-app runtime validation moved past the original TCC block
 - `codesign --verify --deep --strict --verbose=2 build/Quickey.app` passed
 - `bash scripts/e2e-full-test.sh` failed at packaged-app runtime preflight because TCC was not granted for `build/Quickey.app` in this environment (`trusted=false`, `ax=false`, `im=false`, event tap never started)
 - a follow-up packaged-app spot-check validated standard external activation against the current `command + shift + s` Safari shortcut: `MATCHED`, `TOGGLE_TRACE_DECISION event=hide_untracked`, `TOGGLE_HIDE_UNTRACKED`, `HIDE_REQUEST`, and `TOGGLE_HIDE_CONFIRMED` all appeared with the same non-nil `attemptId` / `pid` / `phase`
-- after the E2E harness was updated to use transport-aware readiness plus config-aware module skips, `bash scripts/e2e-full-test.sh` passed on the current local shortcut fixture with 1 warning (`Hyper Key (CGEvent hold)` skipped because the IINA Hyper shortcut is not configured)
+- after the E2E harness was updated to use transport-aware readiness plus config-aware module skips, `bash scripts/e2e-full-test.sh` passed on the local fixture
+- with the current mixed saved fixture (`Safari` standard + `IINA` Hyper), `bash scripts/e2e-full-test.sh` passed with `6/6 PASS` and `0 warnings`
 
 ### 2026-04-08
 - `swift test` passed after the DMG packaging and release workflow changes; the suite reported 173 tests passed
@@ -51,6 +52,9 @@ On 2026-04-09, packaged-app runtime validation moved past the original TCC block
   - externally fronting Safari, then triggering the standard shortcut, produced `MATCHED`, `TOGGLE_TRACE_DECISION event=hide_untracked`, `TOGGLE_HIDE_UNTRACKED`, `HIDE_REQUEST`, and `TOGGLE_HIDE_CONFIRMED`
   - the very first `hide_untracked` trace and lifecycle lines now carried the same non-nil `attemptId`, `pid`, and `phase=deactivating` as the later hide request / confirmation lines, confirming that the coordinator-owned deactivation session is allocated before logging that branch
 - On 2026-04-09, the frontmost/no-window policy was also observed live on Safari: Quickey logged `awaiting_window_evidence` and recovery stages while Safari was frontmost without usable window evidence, and only promoted to stable once visible/focused/main-window evidence appeared
+- On 2026-04-09, a later mixed-transport validation pass also exercised Safari standard toggles and IINA Hyper toggles in the same packaged session:
+  - the saved shortcut fixture contained both Safari standard and IINA Hyper bindings, so `checkPermission: ax=true im=true carbon=true eventTap=true` was the expected steady-state readiness snapshot
+  - the recent runtime log window showed repeated `TOGGLE_STABLE` -> `TOGGLE_HIDE_CONFIRMED` pairs for both apps, plus expected cooldown blocks under rapid repeat input, but no fresh `TOGGLE_DEGRADED`, `TOGGLE_HIDE_DEGRADED`, `phase=no_session`, `hide_untracked`, or capture-blocked signatures
 
 ## Toggle Loop Fix and Cross-App Restore (2026-03-25, Issue #80)
 - **Toggle loop root cause**: physical key repeat events spaced > 200ms bypassed debounce, causing activate/hide/activate cycles
@@ -92,7 +96,7 @@ On 2026-04-09, packaged-app runtime validation moved past the original TCC block
 - Toggle-off settled: `TOGGLE_TRACE_CONFIRMATION attemptId=... event=confirmed reason="hide_confirmed"`
 - Owned launch path started correctly: `TOGGLE_TRACE_SESSION attemptId=... event=session_started activationPath=launch reason="not_running_launch_request"`
 - Owned launch attached to the real process: `TOGGLE_TRACE_SESSION attemptId=... event=launch_attached activationPath=launch reason="launch_completion_process_lookup"`
-- Hyper-routed Safari in the current local config: `SHORTCUT_TRACE_DECISION event=matched bundle=com.apple.Safari route=hyper`
+- Hyper-routed IINA in the current local config: `SHORTCUT_TRACE_DECISION event=matched bundle=com.colliderli.iina route=hyper`
 
 ### Trace signatures to treat as failure or follow-up
 - Regular app frontmost but still unusable: `TOGGLE_TRACE_CONFIRMATION attemptId=... event=awaiting_window_evidence reason="frontmost_without_window_evidence"`
@@ -106,11 +110,12 @@ On 2026-04-09, packaged-app runtime validation moved past the original TCC block
 - When `hide_untracked` is valid, it must still be followed by a real hide lane (`HIDE_REQUEST` and `TOGGLE_HIDE_CONFIRMED` or explicit degraded confirmation). A lone `hide_untracked` log without a deactivation session is a bug.
 - `TOGGLE_TRACE_DECISION event=blocked reason="activation_pending_not_stable"` is the correct second-press behavior while an owned launch/activation is still settling.
 - `checkPermission: ax=true im=true carbon=false eventTap=true` is only suspicious if the current enabled shortcut set is supposed to be standard-only. If the persisted shortcut is Hyper-routed and `hyperKeyEnabled` is on, that snapshot is expected.
+- `checkPermission: ax=true im=true carbon=true eventTap=true` is the expected steady-state snapshot when the saved fixture mixes standard and Hyper shortcuts.
 - `scripts/e2e-full-test.sh` and `scripts/e2e-lib.sh` now preflight packaged-app startup with transport-aware readiness: standard-only configs accept `carbon=true eventTap=false`, Hyper-only configs require an active event tap, and mixed fixtures require both transports to be ready before modules start.
-- E2E modules should treat missing fixture shortcuts as configuration skips, not runtime failures. On the current local setup, Safari standard coverage is valid while the IINA Hyper module should report `WARN` unless a Hyper-routed IINA shortcut is actually present in `shortcuts.json`.
+- E2E modules should treat missing fixture shortcuts as configuration skips, not runtime failures. When both Safari standard and IINA Hyper are present in `shortcuts.json`, the current local full suite should run without warnings.
 
 ## Follow-up Requiring macOS Validation
-- If you want to validate the standard transport specifically, first switch the persisted shortcut back to a standard combo; otherwise continue validating the current Hyper-routed config with F19 / Hyper input and rerun `bash scripts/e2e-full-test.sh`
+- If you want to validate one transport in isolation, trim the saved fixture to that transport first. The current local fixture is mixed, so combined validation should expect both Carbon and event-tap readiness.
 - Fresh-launch path
   Validate: target not running -> shortcut launches it -> second press hides it without `hide_untracked` or `phase=no_session`
 - Relaunch path
@@ -160,7 +165,7 @@ On 2026-04-09, packaged-app runtime validation moved past the original TCC block
 - Signed/notarized release validation is still blocked on Developer ID availability; until those credentials exist, only the internal-package DMG artifact path can be verified end-to-end
 
 ## Immediate Next Actions
-1. Rerun `bash scripts/e2e-full-test.sh` with the intended shortcut transport explicitly set first: either keep the current Hyper-routed Safari config and drive F19 / Hyper input, or switch Safari back to a standard combo before interpreting Carbon readiness logs
+1. Keep the intended shortcut fixture explicit before interpreting readiness logs. The current local fixture is mixed (Safari standard + IINA Hyper), so `carbon=true eventTap=true` and a warning-free `bash scripts/e2e-full-test.sh` run are now the expected baseline.
 2. Expand the targeted macOS validation matrix from the now-confirmed Safari fresh-launch / relaunch / external-activation paths to Finder, Terminal, Home, Clock, System Settings, hidden/minimized paths, and event-tap timeout stress
 3. Verify standard-shortcut vs Hyper parity on the same target apps beyond the already revalidated Safari cases, and capture any remaining app-specific exceptions in this file
 4. Use the internal-package workflow for tester-facing DMG artifacts until Developer ID credentials are available

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -139,6 +139,41 @@ Even after removing restore-first toggle-off, the same `previousBundle` still ne
 **Practical guidance**
 Let the toggle session own the durable `previousBundle` once a trigger is accepted. Use `FrontmostApplicationTracker` to capture current frontmost context, but keep the authoritative previous-app value on the coordinator session until the session is reset. Treat it as session context and observability metadata, not as a reason to reintroduce restore-first toggle-off.
 
+## Bundle-Only Tracking Fails Across Process Lifetimes
+
+**Issue**
+Launch -> quit -> relaunch flows can leave Quickey believing a target is both "stable" and "missing" at the same time.
+
+**Cause**
+When bundle-keyed session tracking is duplicated across multiple owners, termination or pid rollover can clear one owner while the other still holds stale stable/pending state. That is how relaunch paths degrade into `phase=no_session`, `hide_untracked`, or other ownership confusion right after an otherwise valid launch.
+
+**Practical guidance**
+Make `ToggleSessionCoordinator` the only lifecycle owner. Keep pid, attempt id, phase, and durable `previousBundle` on that single session object, and reset or replace the session on termination and pid rollover. `AppSwitcher` may expose derived read-only views, but it must not become a second mutable lifecycle owner.
+
+Do not throw away the `NSRunningApplication` returned by `NSWorkspace.openApplication`. The launch completion is the cleanest process-identity seam Quickey gets for a just-launched target. Attach that pid back onto the existing `launching` session immediately and run the same confirmation pipeline used by activate/unhide, or the next press can still fall through to `hide_untracked` despite an otherwise successful launch.
+
+## Frontmost Without Window Evidence Is Not Success For Regular Apps
+
+**Issue**
+A regular app can become frontmost and active without restoring a usable window, making toggle-on look "successful" even though the user still sees no target window to work with.
+
+**Cause**
+Treating all frontmost non-hidden apps as stable collapses accessory utilities and normal windowed apps into the same success path. That hides exactly the failure mode users care about: the app is technically foregrounded, but still not actually usable.
+
+**Practical guidance**
+Only allow windowless stable success for targets whose `activationPolicy != .regular`. For `.regular` apps, require at least one of `visibleWindowCount > 0`, `hasFocusedWindow == true`, or `hasMainWindow == true` before promoting to `activeStable`. If that evidence never arrives, stay in pending/visibility-recovery or degrade explicitly; do not silently coerce the state into success.
+
+## Attempt-Scoped Trace Logs Beat Outcome-Only Logging
+
+**Issue**
+Outcome logs such as `TOGGLE_STABLE` or `TOGGLE_HIDE_DEGRADED` are not enough to explain which branch Quickey took when launch, relaunch, deactivation, and ownership invalidation happen close together.
+
+**Cause**
+Without an attempt-level identifier, log readers have to infer which launch, confirmation, and reset lines belong together. That breaks down quickly around relaunches, pid changes, or repeated key presses.
+
+**Practical guidance**
+Emit trace logs with `attemptId`, `bundle`, `pid`, `phase`, `event`, `activationPath`, `reason`, and `previousBundle`. Keep them at the matched-shortcut and lifecycle-transition boundaries, not on every raw key event. The goal is that one failed attempt window in `~/.config/Quickey/debug.log` is enough to reconstruct the branch choice end-to-end.
+
 ## Notification-Driven Toggle Invalidation
 
 **Issue**
@@ -171,6 +206,52 @@ Apps can become frontmost through paths Quickey does not own: Dock click, Cmd-Ta
 
 **Practical guidance**
 When the target app is already active and frontmost but has no tracking state, treat it as an untracked toggle-off: hide the app and let macOS bring the next app forward. Guard against self-referencing `previousApp` (target == previous) by explicitly clearing it. Log the `ACTIVE_UNTRACKED` path with coordinator phase and tracker state for post-hoc analysis.
+
+The hide-untracked branch still needs a real owned deactivation session. Logging `hide_untracked` alone is not enough: if the branch does not allocate a coordinator-owned `deactivating` session first, later `HIDE_REQUEST` / hide-confirmation guards can no-op and the target will remain frontmost even though Quickey chose the correct branch in logs.
+
+## Verify The Persisted Shortcut Route Before Debugging Capture Readiness
+
+**Issue**
+`checkPermission: ax=true im=true carbon=false eventTap=true` can look like Carbon registration drift even when the capture stack is actually behaving correctly.
+
+**Cause**
+Quickey's active transport depends on the current saved shortcut set plus `hyperKeyEnabled`. If the persisted shortcut is a Hyper combo, then `carbon=false eventTap=true` is the expected readiness snapshot. In the 2026-04-09 Safari investigation, the real culprit was not permission loss or Carbon failure: `shortcuts.json` had already been switched to `command` + `option` + `control` + `shift` + `s`, and `hyperKeyEnabled` was still enabled.
+
+**Practical guidance**
+Before debugging transport readiness, inspect the actual persisted shortcut config and Hyper toggle state. Do not assume the active shortcut is still standard because an older session used `Shift+Cmd+S`. Interpret `carbon` / `eventTap` logs against the current saved shortcut route, not against stale expectations.
+
+## Restore Hyper State Before Starting Capture
+
+**Issue**
+Startup diagnostics can report a transport that is already obsolete by the time the app is actually accepting shortcuts.
+
+**Cause**
+If `ShortcutManager.start()` runs before the persisted Hyper state is replayed, the first readiness log reflects the pre-restore transport instead of the real steady-state routing. That is how a valid Hyper configuration can briefly print `attemptStart: ... carbon=true eventTap=false` and look like transport drift.
+
+**Practical guidance**
+Replay the persisted Hyper enablement before starting shortcut capture. The first `attemptStart` / readiness snapshot should describe the transport Quickey will actually use after launch, not a transient bootstrapping state that disappears one call later.
+
+## Validation Readiness Must Be Transport-Specific
+
+**Issue**
+An E2E harness can falsely report startup failure even while the configured shortcut transport is healthy.
+
+**Cause**
+Standard shortcuts and Hyper shortcuts have different readiness predicates. Waiting unconditionally for `Event tap started` treats event-tap availability as a universal startup requirement, but a standard-only shortcut set is valid with `carbon=true eventTap=false`.
+
+**Practical guidance**
+Drive validation off the active transport, not a one-size-fits-all startup marker. For standard shortcuts, require Accessibility plus successful Carbon registration. For Hyper shortcuts, require Input Monitoring plus an active event tap. Keep the validation rule aligned with the same transport-specific readiness semantics used in production code.
+
+## E2E Fixtures Must Match The Saved Shortcut Set
+
+**Issue**
+An end-to-end module can fail even when the product is healthy if the machine's saved shortcuts do not contain the fixture shortcut the module is trying to exercise.
+
+**Cause**
+The E2E shell modules historically assumed a fixed local fixture, such as Safari on `Shift+Cmd+S` and IINA on a Hyper combo. When `shortcuts.json` drifts away from that fixture, the module reports a product failure even though Quickey is simply following the saved config.
+
+**Practical guidance**
+Teach each E2E module to inspect the current saved shortcuts before asserting on runtime behavior. If the required shortcut is absent for the expected route, report `SKIP`/`WARN` instead of `FAIL`. Reserve hard failures for mismatches between the configured shortcut and the observed runtime behavior.
 
 ## Previous App Self-Reference in Tracker
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -241,6 +241,7 @@ Standard shortcuts and Hyper shortcuts have different readiness predicates. Wait
 
 **Practical guidance**
 Drive validation off the active transport, not a one-size-fits-all startup marker. For standard shortcuts, require Accessibility plus successful Carbon registration. For Hyper shortcuts, require Input Monitoring plus an active event tap. Keep the validation rule aligned with the same transport-specific readiness semantics used in production code.
+For mixed fixtures, expect both transports to be ready at once (`carbon=true` and `eventTap=true`) and make the harness wait for both before declaring startup healthy.
 
 ## E2E Fixtures Must Match The Saved Shortcut Set
 

--- a/docs/superpowers/plans/2026-04-09-toggle-reliability-recovery-plan.md
+++ b/docs/superpowers/plans/2026-04-09-toggle-reliability-recovery-plan.md
@@ -1,0 +1,399 @@
+# Toggle Reliability Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate Quickey's first-launch / relaunch toggle failures and frontmost-without-window false positives by replacing the current split-brain activation tracking with a pid-aware toggle session model, and make future failures diagnosable from one pass of logs.
+
+**Architecture:** Keep shortcut matching, window observation, and platform activation separate, but move toggle lifecycle ownership into a single canonical session model owned by `ToggleSessionCoordinator`, with `AppSwitcher` acting as the façade that drives transitions. Borrow Zed's "pending input is first-class state" and "debug the current matching context directly" ideas, but do not copy its editor-specific keybinding system into Quickey's global shortcut path.
+
+**Tech Stack:** Swift 6, AppKit, Accessibility APIs, Carbon hotkeys, NSWorkspace, file-backed diagnostic logging, Swift Testing.
+
+---
+
+## Research Summary
+
+### What the current Quickey evidence proves
+
+- `~/.config/Quickey/debug.log` shows a concrete relaunch failure window at `2026-04-09T01:23:34Z` to `2026-04-09T01:23:35Z`: `NOT RUNNING → launching` is followed by `stableState invalidated by coordinator, phase=no_session`, then `TOGGLE_HIDE_UNTRACKED`, then `TOGGLE_HIDE_DEGRADED` even though Safari is frontmost and window-complete. See [`debug.log:17216`](/Users/yvan/.config/Quickey/debug.log:17216) through [`debug.log:17223`](/Users/yvan/.config/Quickey/debug.log:17223).
+- `~/.config/Quickey/debug.log` also shows a different failure class on the "toggle on" side. At `2026-04-09T01:47:27Z`, the shortcut definitely matches and the activation request definitely runs, but Quickey records success while Safari still has `visibleWindowCount=0`, `hasFocusedWindow=false`, and `hasMainWindow=false`. See [`debug.log:18008`](/Users/yvan/.config/Quickey/debug.log:18008) through [`debug.log:18013`](/Users/yvan/.config/Quickey/debug.log:18013). This means at least one current "toggle on doesn't work" symptom is not a capture failure; it is a false-positive success classification.
+- The current stability rule in [ApplicationObservation.swift](/Users/yvan/developer/Quickey/Sources/Quickey/Services/ApplicationObservation.swift#L33) makes that false positive possible: `.windowlessOrAccessory` is always considered stable once the app is frontmost, active, and not hidden. For user-facing regular apps, that collapses "frontmost with no restored window" into "successful toggle on". See [ApplicationObservation.swift](/Users/yvan/developer/Quickey/Sources/Quickey/Services/ApplicationObservation.swift#L38) through [ApplicationObservation.swift](/Users/yvan/developer/Quickey/Sources/Quickey/Services/ApplicationObservation.swift#L45).
+- The logs also prove Quickey can distinguish a real window-stabilization sequence when the app does have a visible window. At `2026-04-09T01:30:38Z`, Safari transitions through `TOGGLE_DEGRADED` while `hasFocusedWindow=false`, then only becomes stable after the focused window arrives. See [`debug.log:17618`](/Users/yvan/.config/Quickey/debug.log:17618) through [`debug.log:17626`](/Users/yvan/.config/Quickey/debug.log:17626). That is valuable because it shows the log format already has enough raw signals; the state machine is what is collapsing incompatible cases.
+- Current launch handling in [AppSwitcher.swift](/Users/yvan/developer/Quickey/Sources/Quickey/Services/AppSwitcher.swift#L642) only opens the app and returns. It does not create a tracked pending activation, does not attach a pid, and does not schedule confirmation for the launched process.
+- Current session state is split across two owners:
+  - [AppSwitcher.swift](/Users/yvan/developer/Quickey/Sources/Quickey/Services/AppSwitcher.swift) keeps `pendingActivationState`, `pendingDeactivationState`, and `stableActivationState`.
+  - [ToggleSessionCoordinator.swift](/Users/yvan/developer/Quickey/Sources/Quickey/Services/ToggleSessionCoordinator.swift#L213) keeps a separate bundle-keyed session store and independently reacts to workspace notifications.
+- That split lets local AppSwitcher state and coordinator state diverge at process lifetime boundaries. The `phase=no_session` log line is the direct proof that one side still believed the bundle was stable while the other side had already dropped the session.
+
+### What Zed is worth copying, and what is not
+
+- Zed treats pending keyboard input as explicit state in [key_dispatch.rs](/tmp/zed/crates/gpui/src/key_dispatch.rs#L476). A keystroke dispatch returns `bindings`, `pending`, and `to_replay`, rather than hiding the in-flight state inside ad hoc branches. That is the main architectural lesson for Quickey: in-flight toggle state should be explicit and queryable.
+- Zed provides a dedicated key-debug surface in [key_context_view.rs](/tmp/zed/crates/language_tools/src/key_context_view.rs#L24), which records pending keys, context stack, candidate bindings, and match outcome. The lesson for Quickey is not "build the same UI", but "make the current state machine and branch decisions directly observable."
+- Zed keeps macOS platform primitives thin in [platform.rs](/tmp/zed/crates/gpui_macos/src/platform.rs#L555): `activate` and `hide` are wrappers, while higher-level semantics live elsewhere. Quickey should move in the same direction: platform calls stay dumb; toggle lifecycle logic stays in one state owner.
+- Zed's user-facing keybinding docs explicitly document precedence, pending sequences, and a debugging command in [key-bindings.md](/tmp/zed/docs/src/key-bindings.md#L39). Quickey should adopt the same level of explicitness for shortcut/toggle diagnostics, but Quickey is not an editor and does not need Zed's context-tree binding system.
+
+### What Raycast is worth copying, and what is not
+
+- Raycast's official manual treats hotkeys as first-class global triggers for applications, commands, quicklinks, and window-management actions, not just as a way to open the launcher. See [Hotkey](https://manual.raycast.com/hotkey) and [Command Aliases and Hotkeys](https://manual.raycast.com/command-aliases-and-hotkeys). The lesson for Quickey is that the shortcut should directly own the command semantics; users should not have to mentally translate one hotkey into several hidden phases.
+- Raycast's recorder explicitly surfaces conflicts and lets the user choose layout-independent versus key-equivalent recording, as well as single-tap and double-tap modifier triggers. See [Shortcuts](https://manual.raycast.com/windows/shortcuts). Quickey does not need to copy the full settings UI right now, but it should preserve enough structured shortcut metadata that conflict diagnosis and keyboard-layout issues remain explainable.
+- Raycast's changelog explicitly calls out a hotkey bugfix: "Global hotkey now unhides app if windows are minimized." See [Raycast v1.80.0](https://www.raycast.com/changelog/macos/1-80-0). That is a valuable product cue for Quickey: minimized/hidden/unhidden is not an incidental edge case, it is a first-class branch of launcher semantics.
+- Raycast also separates "switch windows" from generic app launching and exposes window/app actions directly. See [Raycast v1.19.0](https://www.raycast.com/changelog/1-19-0) and the fix note in [Raycast v1.77.0](https://www.raycast.com/changelog/1-77-0), which explicitly mentions fixing tracking for windows of apps launched after the initial command use. Quickey should not grow into a full window switcher in this cycle, but it should stop collapsing "app exists but is minimized", "app exists with visible windows", and "app is not running" into one under-specified toggle lane.
+
+### What Keyboard Maestro is worth copying, and what is not
+
+- Keyboard Maestro treats switching and launching as specialized products, not as a byproduct of generic hotkeys. Its documentation explicitly separates `Application Launcher`, `Application Switcher`, and `Window Switcher`, and describes the switchers as dedicated actions that can launch, switch, hide, quit, show, and minimize. See [Keyboard Maestro documentation](https://www.keyboardmaestro.com/documentation-keyboardmaestro/6/keyboardmaestro.pdf). The lesson for Quickey is that "bring app forward", "toggle app visibility", and "switch windows" are close cousins, but they are not the same state machine.
+- Keyboard Maestro also treats activation scope as first-class configuration. `Macro Groups` can be global, app-specific, excluded from specific apps, or manually activated/deactivated as a mode. See [Macro Groups](https://wiki.keyboardmaestro.com/manual/Macro_Groups). Quickey should copy the mental model, not the full feature set: shortcut availability and toggle semantics need explicit context, not implied side effects.
+- Keyboard Maestro's docs repeatedly expose user-visible failure boundaries such as "Window Switcher can only see windows in the current Space" and that the engine performs switcher behavior even when the editor is not open. See [Keyboard Maestro documentation](https://www.keyboardmaestro.com/documentation-keyboardmaestro/6/keyboardmaestro.pdf). Quickey should be equally explicit about what part of the system owns hotkey capture, what part owns toggle lifecycle, and which platform limits still apply.
+
+### What BetterTouchTool is worth copying, and what is not
+
+- BetterTouchTool separates trigger definition from action execution. Its official docs distinguish global triggers, app-specific triggers, and named triggers that can be reused from multiple physical triggers or called from scripts. See [Global and App-Specific Triggers](https://docs.folivora.ai/docs/2_2_preferences_global_vs_app_specific.html) and [Reusable Named Triggers](https://docs.folivora.ai/docs/other-triggers/named-triggers/). Quickey should borrow that separation: one shortcut should map to one explicit toggle command object, while launch/unhide/focus/hide remain downstream execution branches.
+- BetterTouchTool also exposes a scripting and CLI surface for triggering the same actions programmatically. See [CLI](https://docs.folivora.ai/docs/scripting/cli/) and [URL Scheme](https://docs.folivora.ai/docs/scripting/url-scheme/). Quickey does not need to grow a scripting API in this cycle, but the design implication is useful: action semantics should be stable enough that they can be invoked and debugged independently of the physical hotkey source.
+
+### What Thor is worth copying, and what is not
+
+- The local Thor checkout confirms the product is intentionally minimal. In [ShortcutMonitor.swift](/Users/yvan/developer/Thor/Thor/ShortcutMonitor.swift#L15), Thor registers one MASShortcut action per selected app; if the target bundle is already frontmost it calls `hide()`, otherwise it opens the app with `NSWorkspace.OpenConfiguration.activates = true`. There is no intermediate lifecycle state, no pid attachment, and no window-evidence gate. The lesson for Quickey is product clarity: the user should be able to explain the shortcut in one sentence.
+- Thor's persistence model is equally flat. [AppsManager.swift](/Users/yvan/developer/Thor/Thor/AppsManager.swift#L56) simply unregisters all shortcuts, updates the selected-app list, writes JSON, and re-registers. [AppModel.swift](/Users/yvan/developer/Thor/Thor/AppModel.swift#L20) stores bundle URL, display name, and MASShortcut string only; there is no separate application/window/session layer. That confirms Thor is solving "shortcut to app" rather than "reliable lifecycle-aware visibility toggle."
+- Thor also exposes one interesting product idea that Quickey should consider keeping conceptually separate from hidden safety throttles: a user-visible temporary shortcut disable flow. [AppDelegate.swift](/Users/yvan/developer/Thor/Thor/AppDelegate.swift#L90) listens for a chosen modifier key and temporarily unregisters all app shortcuts before re-enabling them on a timer. Quickey should not copy the exact UX by default, but the principle is useful: user-facing escape hatches are clearer than opaque internal suppression when shortcuts are getting in the way.
+- Thor is therefore both inspiration and caution. Its semantics are excellent as a product contract, but its implementation is intentionally too small for Quickey's current reliability target because it does not model pid rollover, minimized windows, partially settled focus state, or diagnostic branch reasons. Quickey should copy Thor's semantic clarity, not its lack of lifecycle tracking.
+
+### What skhd is worth copying, and what is not
+
+- `skhd` is not an app switcher, but it is a mature macOS hotkey daemon with very explicit operational boundaries. Its README emphasizes responsiveness, live config reload, app-specific hotkeys, blacklist support, and clear daemon/log file behavior. See [skhd README](https://github.com/koekeishiya/skhd). Quickey should adopt the same clarity around capture ownership: one place to observe what keys are being seen, one place to understand whether capture is active, and one place to see why a binding did not fire.
+- `skhd` also offers `--observe`, `--verbose`, and pid-file based service management. See [skhd README](https://github.com/koekeishiya/skhd). Quickey does not need a daemon CLI, but it should have the same philosophy: debugging shortcut capture must be easier than debugging downstream app activation.
+
+### What Alfred is worth copying, and what is not
+
+- Alfred's official Hotkey Trigger docs make hotkeys contextual by focused app, with explicit precedence rules for "only active when app has focus", "active when app does not have focus", and "global". See [Hotkey Trigger](https://www.alfredapp.com/help/workflows/triggers/hotkey/). Quickey should adopt the same mindset: when a shortcut has context-sensitive behavior, that behavior must be explicit and inspectable rather than hidden in incidental runtime state.
+- Alfred's hotkey docs also call out speed tuning for modifier pass-through. See [Hotkey Trigger](https://www.alfredapp.com/help/workflows/triggers/hotkey/). Quickey does not need the same UI today, but this is a reminder that perceived shortcut reliability includes trigger latency, not just eventual correctness.
+- Most importantly, Alfred's `Launch Apps & Files` action has an explicit `Toggle visibility for apps` option. See [Launch Apps & Files Action](https://www.alfredapp.com/help/workflows/actions/launch-apps-files/). That confirms Quickey's core semantics should be modeled as a dedicated visibility command, not treated as a side effect of generic launch/focus code.
+
+### What Hammerspoon is worth copying, and what is not
+
+- Hammerspoon exposes hotkey conflict and availability as first-class queries through `hs.hotkey.assignable`, `hs.hotkey.systemAssigned`, `hs.hotkey.getHotkeys`, and active/shadowed semantics. See [hs.hotkey](https://www.hammerspoon.org/docs/hs.hotkey.html). Quickey should not make users guess whether a shortcut is truly available or shadowed by the system.
+- Hammerspoon's application API explicitly separates `launchOrFocus`, `hide`, `unhide`, `allWindows`, `visibleWindows`, `focusedWindow`, `mainWindow`, and `applicationForPID`. See [hs.application](https://www.hammerspoon.org/docs/hs.application.html). That is directly relevant to Quickey: process identity, application visibility, and window visibility are separate axes and should remain separate in our model.
+
+### What AltTab is worth copying, and what is not
+
+- AltTab keeps `Application` and `Window` as separate domain objects in [Application.swift](/tmp/alt-tab-macos/src/logic/Application.swift), including pid, hidden state, focused window, AX observer, and explicit `hideOrShow()` semantics. This is much closer to Quickey's problem space than Zed's editor model.
+- AltTab subscribes to AX notifications for activated, main window changed, focused window changed, window created, hidden, and shown states. See [AccessibilityEvents.swift](/tmp/alt-tab-macos/src/logic/events/AccessibilityEvents.swift). Quickey currently samples state on demand; AltTab demonstrates the value of event-driven lifecycle updates for reducing ambiguity.
+- AltTab also uses a dedicated AX scheduler with throttling, retry, unresponsive-pid tracking, and per-key serialized work in [AXCallScheduler.swift](/tmp/alt-tab-macos/src/logic/AXCallScheduler.swift). Quickey does not necessarily need all of that machinery, but it is a strong signal that mature macOS window-switching tools isolate Accessibility IPC timing from main business logic.
+
+### Alternatives considered
+
+1. Keep applying local patches to `hide_untracked`, `stableActivationState`, and launch edge cases.
+   Reject. This is what we have effectively been doing, and the failure keeps moving because the underlying lifecycle ownership is still split.
+2. Rewrite the whole toggle stack from scratch in one pass.
+   Reject. Too risky while we still need stable Carbon / event-tap capture and existing tests to keep working.
+3. Do a focused re-architecture of the toggle lifecycle while preserving the existing capture pipeline.
+   Recommend this. It attacks the real fault line, keeps the platform-specific shortcut path intact, and is small enough to verify incrementally.
+4. Keep the old state model alive behind compatibility fallbacks while layering a new session model on top.
+   Reject. That would preserve the very split-brain ownership that caused the bug, add permanent mental overhead, and leave future failures harder to diagnose.
+
+## Target Design
+
+### Design Section 1: Single Source of Truth for Toggle Lifecycle
+
+Quickey should have exactly one owner for per-target toggle lifecycle state. Replace the current "AppSwitcher local state + coordinator bundle session" split with a single pid-aware session record owned by `ToggleSessionCoordinator`, while `AppSwitcher` becomes the main-actor façade that observes state and invokes transitions. The recommended model is:
+
+```swift
+enum TogglePhase: String, Sendable {
+    case launching
+    case activating
+    case activeStable
+    case deactivating
+    case degraded
+    case idle
+}
+
+struct ToggleSession: Equatable, Sendable {
+    let bundleIdentifier: String
+    let attemptID: UUID
+    var pid: pid_t?
+    var phase: TogglePhase
+    var activationPath: AppSwitcher.ActivationPath
+    var previousBundleIdentifier: String?
+    var startedAt: CFAbsoluteTime
+    var confirmedAt: CFAbsoluteTime?
+    var degradedReason: String?
+}
+```
+
+The key design choice is that `launching` is a real phase, not a fire-and-forget branch. If Quickey launched the app, the next press must see that same in-flight session instead of falling through to `hide_untracked`.
+
+This also aligns with Alfred's explicit `Toggle visibility for apps` option and AltTab's separate application/window objects: Quickey should model "visibility toggle" as a first-class command over an owned session, not as an accidental consequence of launch/focus branches.
+
+### Design Section 2: Launch, Relaunch, and Termination Must Be Process-Aware
+
+Bundle identifier is not enough. The logs already show Safari relaunching from one pid to another while the bundle-level memory lingers. Every activation path should attach pid as soon as it exists, and every termination should clear the matching session immediately.
+
+Rules:
+
+- `NOT RUNNING → launching` creates a `launching` session before calling `NSWorkspace.openApplication`.
+- The `openApplication` completion or the next successful process lookup attaches the launched pid to the same session.
+- `NSWorkspace.didTerminateApplicationNotification` clears any session for that bundle and pid, and emits a structured reset log.
+- If the same bundle reappears under a different pid, Quickey treats it as a new process generation even if the bundle is unchanged.
+- Hidden and minimized windows are explicit sub-states of an owned process, not incidental observation details. The session must record whether Quickey is trying to launch, unhide, or merely re-focus an existing visible process.
+
+### Design Section 3: Repeated Shortcut Presses Need Explicit Pending Semantics
+
+During `launching` or `activating`, a second shortcut press must not silently route into `hide_untracked` or generic `activate`. Quickey should branch explicitly:
+
+- If the session is still pending and the current observation is not yet stable, log `BLOCKED activation_pending_not_stable` and keep confirming.
+- If the session is pending and the current observation is already stable, promote to `activeStable` first, then evaluate toggle-off in the same turn.
+- Only use `hide_untracked` for truly external activation: active, stable, no owned session, no pending session, no recently launched owned attempt.
+- If the owned target is minimized or hidden, the session should prefer `unhide` / visibility restoration over pretending the target is already in the same state as a visible foreground app. This mirrors the kind of distinction Raycast publicly calls out in its hotkey behavior.
+- If the target is frontmost but has no restored visible/focused/main window evidence, Quickey must not record "toggle on succeeded" for a regular user-facing app. That observation is either a `launching visibility recovery` case or a `degraded no visible window` case, not `activeStable`. This is the concrete protection against the Safari false-positive windowless success seen in [`debug.log:18008`](/Users/yvan/.config/Quickey/debug.log:18008) through [`debug.log:18013`](/Users/yvan/.config/Quickey/debug.log:18013).
+
+### Design Section 3A: Explicit No-Window Success Policy
+
+The current plan must not leave "true windowless utility" as an implementation-time judgment call.
+
+Rules:
+
+- Only non-regular targets may succeed without window evidence. Concretely: if `activationPolicy != .regular`, the target may be considered stable once it is frontmost, active, and not hidden.
+- Any `.regular` app must present usable window evidence before becoming `activeStable`. Usable evidence means:
+  - `visibleWindowCount > 0`, or
+  - `hasFocusedWindow == true`, or
+  - `hasMainWindow == true`
+- A `.regular` app with zero visible/focused/main window evidence is never a silent success. It must remain `activating`, move into an explicit visibility-recovery path, or become `degraded`.
+- Accessibility read failure for a `.regular` app is not permission to succeed without evidence. It should be represented as `degraded` or `pending`, with the failure reason preserved in diagnostics.
+- Do not add heuristic allowlists, bundle-specific exceptions, or "seems accessory-like" guesses in this cycle. If a real app needs a special rule later, it must come from new logs and a dedicated design update.
+
+### Design Section 4: Diagnostics Must Explain the Branch, Not Just the Outcome
+
+Current logs are structured, but they do not reliably connect one toggle attempt across launch, confirmation, invalidation, and hide. Add a new structured trace family that includes:
+
+- `attemptId`
+- `bundle`
+- `pid`
+- `phase`
+- `event`
+- `activationPath`
+- `reason`
+- `previousBundle`
+
+Recommended event families:
+
+- `TOGGLE_TRACE_DECISION`
+- `TOGGLE_TRACE_SESSION`
+- `TOGGLE_TRACE_RESET`
+- `TOGGLE_TRACE_CONFIRMATION`
+
+This is the Quickey equivalent of Zed's "Key Context View" principle: when a shortcut misbehaves, we should be able to answer "what branch did Quickey take, and why?" from one trace window.
+
+The practical target should be closer to Hammerspoon's explicit hotkey visibility and Alfred's contextual hotkey clarity: a user or maintainer should be able to tell whether a failure was caused by shortcut capture, system conflict, owned pending session state, external activation, or window visibility state.
+
+### Design Section 5: Reliability Constraints To Avoid New Debt
+
+This work should explicitly optimize for correctness and maintainability over short-term compatibility shims.
+
+Rules:
+
+- Do not keep two independent lifecycle owners once the new model lands. `ToggleSessionCoordinator` is the canonical owner; AppSwitcher-local lifecycle state must be deleted or reduced to derived read-only views. No permanent dual-write bridge.
+- Do not add catch-all fallback branches such as "if activation looks weird, mark stable anyway" for regular user-facing apps. Unknown or incomplete state should stay visible as `pending` or `degraded` until it is explained, not be silently coerced into success.
+- Keep `ACTIVE_UNTRACKED` only because it is a proven external-ownership case already documented in [AGENTS.md](/Users/yvan/developer/Quickey/AGENTS.md#L62). Do not invent additional fallback lanes unless logs demonstrate a distinct ownership model that cannot be represented by the primary state machine.
+- Every newly introduced branch must have one corresponding test and one corresponding diagnostic reason string. If a branch cannot be named, logged, and tested, it should not exist.
+- When the new path supersedes an old branch, delete the old branch in the same implementation cycle instead of leaving a dormant compatibility path behind.
+
+### Design Section 6: Performance And Best-Practice Guardrails
+
+This redesign must preserve Quickey's existing hot-path discipline and only spend more work after a shortcut has already been matched.
+
+Rules:
+
+- Do not add new work to the raw key-capture hot path beyond what is already necessary for matching and dispatch. `ShortcutManager` should still do O(1) trigger lookup before any activation/window logic begins.
+- Do not move Accessibility window observation into the general key-event path. AX calls should remain scoped to the matched target app and the confirmation/degradation pipeline for that one target.
+- Do not add new global polling loops or background retry timers for lifecycle recovery. Use bounded, per-session confirmation with explicit retry caps and expiry, consistent with existing coordinator discipline.
+- Keep all new retry behavior bounded by existing concepts such as absolute ceilings, idle expiry, and retry caps. No unbounded reconfirm loops, no "keep trying until it works" behavior.
+- Keep platform-specific state reads on the main actor only where the Apple API semantics require it. Do not spread `@MainActor` to unrelated runtime logic just to make the implementation easier.
+- Diagnostics must stay cheap enough that they do not materially change hotkey responsiveness. Detailed trace logs should be emitted only for matched shortcuts, accepted lifecycle transitions, and explicit blocking/failure reasons, not for every unrelated key event.
+- Prefer event-driven state transitions over additional sampling when a trustworthy system notification already exists. If observation still needs sampling, keep the sampling window narrow and tied to a live owned session.
+- Any new abstraction introduced for clarity must also reduce or at least not increase runtime coupling. Do not add a new indirection layer that leaves the number of state transitions or AX round-trips unchanged while making the code harder to reason about.
+
+## File Map
+
+**Create:**
+
+- `Tests/QuickeyTests/ToggleLaunchLifecycleTests.swift`
+  Purpose: isolated regression tests for launch → relaunch → second-press behavior.
+
+**Modify:**
+
+- `Sources/Quickey/Services/AppSwitcher.swift`
+  Purpose: remove split local lifecycle state, route launch/activate/hide through coordinator-owned session transitions, add structured branch logs, and delete superseded fallback branches in the same pass.
+- `Sources/Quickey/Services/ToggleSessionCoordinator.swift`
+  Purpose: become the single session owner with pid-aware phases and transition helpers, while preserving bounded retry/expiry semantics and durable `previousBundle` ownership.
+- `Sources/Quickey/Services/ApplicationObservation.swift`
+  Purpose: keep observation purely observational and expose enough data for session transitions, not ownership, while stopping regular user-facing apps from treating `frontmost + no restored window` as a successful toggle-on state.
+- `Sources/Quickey/Services/ShortcutManager.swift`
+  Purpose: if diagnostics are added here, keep them on the accepted-trigger boundary rather than regressing the raw capture/match hot path.
+- `Tests/QuickeyTests/AppSwitcherTests.swift`
+  Purpose: preserve existing lifecycle assertions while moving them to the new session semantics.
+- `Tests/QuickeyTests/ApplicationObservationTests.swift`
+  Purpose: lock the no-window success policy so `.regular` apps cannot silently pass while non-regular utilities still can.
+- `Tests/QuickeyTests/ToggleSessionCoordinatorTests.swift`
+  Purpose: preserve coordinator invariants while session ownership becomes single-source and pid-aware.
+- `Tests/QuickeyTests/ShortcutManagerStatusTests.swift`
+  Purpose: protect shortcut-capture readiness and accepted-trigger semantics while diagnostics and lifecycle ownership change around them.
+- `docs/architecture.md`
+  Purpose: update the runtime ownership model so docs match the coordinator-owned single-source toggle lifecycle design.
+- `docs/README.md`
+  Purpose: keep maintainer navigation aligned with any renamed lifecycle concepts or validation flow.
+- `docs/handoff-notes.md`
+  Purpose: record the exact failure signatures and the new validation checklist.
+- `docs/lessons-learned.md`
+  Purpose: document the anti-pattern we hit: bundle-only tracking across process lifetimes.
+
+**Optional, if diagnostics stay too opaque after Task 2:**
+
+- `Sources/Quickey/Services/ToggleDiagnosticEvent.swift`
+  Purpose: centralize structured trace formatting instead of continuing to build ad hoc log strings inside `AppSwitcher`.
+- `scripts/toggle-trace-summary.sh`
+  Purpose: grep-friendly summarizer for one attempt window in `~/.config/Quickey/debug.log`.
+
+## Task Plan
+
+### Task 1: Freeze the Current Failure Model in Tests
+
+**Files:**
+- Create: `Tests/QuickeyTests/ToggleLaunchLifecycleTests.swift`
+- Modify: `Tests/QuickeyTests/AppSwitcherTests.swift`
+- Modify: `Tests/QuickeyTests/ApplicationObservationTests.swift`
+- Modify: `Tests/QuickeyTests/ToggleSessionCoordinatorTests.swift`
+- Modify: `Tests/QuickeyTests/ShortcutManagerStatusTests.swift` only if accepted-trigger or diagnostics boundaries need explicit protection
+
+- [ ] Add a failing regression test for "app terminated, relaunched, second press must not go through stale owned state".
+- [ ] Add a failing regression test for "launch path creates owned pending lifecycle state instead of returning fire-and-forget".
+- [ ] Add a failing regression test for "second press during owned launch cannot route to `hide_untracked`".
+- [ ] Add a failing regression test for "hidden/minimized owned app routes through explicit visibility recovery lane instead of generic activate".
+- [ ] Add a failing regression test for "frontmost regular app with no visible/focused/main window cannot be promoted to stable toggle-on success".
+- [ ] Add or adjust coordinator regression coverage so expiry / retry / previousBundle semantics remain explicit under the new single-source model.
+- [ ] Add or adjust `ShortcutManager` coverage if needed to prove matched-trigger acceptance semantics stay unchanged and diagnostics do not leak into unrelated key events.
+- [ ] Run:
+  - `swift test --filter ApplicationObservationTests`
+  - `swift test --filter AppSwitcherTests`
+  - `swift test --filter ToggleSessionCoordinatorTests`
+  - `swift test --filter ShortcutManagerStatusTests`
+  - `swift test --filter ToggleLaunchLifecycleTests`
+- [ ] Expected before implementation: failures that mention stale session state, missing launch tracking, or `.regular` apps being promoted to stable without window evidence.
+
+### Task 2: Make Lifecycle Ownership Single-Source and pid-Aware
+
+**Files:**
+- Modify: `Sources/Quickey/Services/AppSwitcher.swift`
+- Modify: `Sources/Quickey/Services/ToggleSessionCoordinator.swift`
+
+- [ ] Introduce one canonical `ToggleSession` model with explicit `launching`, `activating`, `activeStable`, `deactivating`, `degraded`, and `idle` phases.
+- [ ] Move canonical lifecycle ownership into `ToggleSessionCoordinator` and reduce AppSwitcher-local lifecycle storage to derived views or remove it entirely.
+- [ ] Delete or demote superseded AppSwitcher-local lifecycle storage in the same task rather than keeping an adapter layer that writes both old and new models.
+- [ ] Add pid attachment/update rules so the same bundle under a new pid is treated as a new process generation.
+- [ ] Route termination and reset handling through the single owner, not two loosely synchronized owners.
+- [ ] Preserve bounded expiry and retry semantics already covered by `ToggleSessionCoordinatorTests`; do not replace them with open-ended polling.
+- [ ] Run:
+  - `swift test --filter AppSwitcherTests`
+  - `swift test --filter ToggleSessionCoordinatorTests`
+  - `swift test --filter ToggleLaunchLifecycleTests`
+- [ ] Expected after implementation: termination and relaunch tests pass without weakening existing toggle/coordinator tests.
+
+### Task 3: Rebuild the Launch Path as a Real Pending Activation
+
+**Files:**
+- Modify: `Sources/Quickey/Services/AppSwitcher.swift`
+- Modify: `Sources/Quickey/Services/ApplicationObservation.swift`
+
+- [ ] Replace the current `NOT RUNNING → launching` fire-and-forget branch with owned `launching` session creation.
+- [ ] Attach launch completion to the same confirmation path used by activate/unhide, so launch and activate share one stabilization pipeline.
+- [ ] Split owned visibility recovery into explicit lanes: `launch`, `unhide`, and `focus-visible`, instead of treating them as one generic activation path.
+- [ ] Tighten stabilization rules so regular apps do not report success until there is usable window evidence; do not add a permissive "best effort success" fallback for incomplete observations.
+- [ ] Preserve success for non-regular/system-utility targets only when `activationPolicy != .regular` explicitly justifies it; do not introduce bundle-specific exceptions.
+- [ ] Keep AX observation scoped to the target app for the active session only; do not introduce any extra pre-match observation or global sampling loop.
+- [ ] On second press for the same bundle:
+  - if stable now, promote and evaluate toggle-off in the same turn
+  - if not stable yet, block with explicit reason and continue confirming
+- [ ] Keep `hide_untracked` only for truly external frontmost ownership, never for our own just-launched target.
+- [ ] Run:
+  - `swift test --filter ApplicationObservationTests`
+  - `swift test --filter AppSwitcherTests`
+  - `swift test --filter ToggleLaunchLifecycleTests`
+- [ ] Expected after implementation: no test depends on `hide_untracked` immediately after an owned launch, and no regular app can become "stable" through a no-window fallback.
+
+### Task 4: Upgrade Diagnostics from Outcome Logs to Transition Logs
+
+**Files:**
+- Modify: `Sources/Quickey/Services/AppSwitcher.swift`
+- Modify: `Sources/Quickey/Services/ShortcutManager.swift`
+- Optional Create: `Sources/Quickey/Services/ToggleDiagnosticEvent.swift`
+- Optional Create: `scripts/toggle-trace-summary.sh`
+
+- [ ] Add attempt/session identifiers to every launch/activate/hide transition line.
+- [ ] Emit explicit branch reasons for:
+  - stale state invalidation
+  - launch-pending blocking
+  - frontmost-without-window false-positive prevention
+  - external untracked hide
+  - partial hide degradation
+  - pid rollover / termination reset
+- [ ] Emit companion shortcut-capture diagnostics when a hotkey is blocked by cooldown, missing registration, or system conflict, so toggle failures and capture failures stop looking the same in the log stream.
+- [ ] Keep existing `TOGGLE_*` outcome lines for continuity, but add `TOGGLE_TRACE_*` lines that explain branch choice.
+- [ ] Do not use diagnostics as a substitute for fallback behavior. Logs should explain the chosen primary branch, not hide an ambiguous best-effort rescue path.
+- [ ] Keep diagnostics off the raw key path for unrelated events; emit detailed trace lines only after a shortcut is matched or explicitly blocked.
+- [ ] If the inline log strings become too dense, extract a small formatter type rather than growing `AppSwitcher.swift` further.
+- [ ] Run:
+  - `swift test --filter AppSwitcherTests`
+  - `swift test --filter ShortcutManagerStatusTests`
+- [ ] Manual spot-check: grep one attempt window in `~/.config/Quickey/debug.log` and confirm it is traceable end-to-end by `attemptId`.
+
+### Task 5: Validate the Real Failure Matrix on macOS
+
+**Files:**
+- Modify: `docs/handoff-notes.md`
+- Modify: `docs/lessons-learned.md`
+
+- [ ] Validate fresh-launch path:
+  - target app not running
+  - shortcut launches it
+  - second press hides it without `hide_untracked` or `phase=no_session`
+- [ ] Validate relaunch path:
+  - target app becomes stable
+  - target app quits
+  - shortcut relaunches it
+  - second press still hides cleanly
+- [ ] Validate external activation path:
+  - user activates target outside Quickey
+  - Quickey still handles it via explicit `hide_untracked` only when unowned
+- [ ] Validate frontmost/no-window path:
+  - target app becomes frontmost without restoring a usable window
+  - Quickey records the case as visibility recovery or degraded, not stable success
+- [ ] Run:
+  - `swift test`
+  - `bash scripts/package-app.sh`
+  - `codesign --verify --deep --strict --verbose=2 build/Quickey.app`
+- [ ] Record the exact log signatures that count as success and failure in the handoff docs.
+- [ ] During macOS validation, confirm no perceptible hotkey-latency regression when repeatedly triggering a matched shortcut under normal use.
+- [ ] Update:
+  - `docs/architecture.md`
+  - `docs/README.md`
+  - `docs/handoff-notes.md`
+  - `docs/lessons-learned.md`
+
+## Risks and Non-Goals
+
+- Do not rewrite the Carbon hotkey or Hyper event-tap capture path as part of this work.
+- Do not add a full graphical debug UI in this cycle unless the improved trace logs still leave failures ambiguous.
+- Do not treat Zed as a feature-by-feature template. Its reference value is architecture and observability discipline, not app-toggle semantics.
+- Do not leave a compatibility shim that preserves both the old and new lifecycle models after rollout.
+- Do not add "best effort" stabilization fallbacks for regular apps that are only justified by making the symptom disappear in one log sample.
+- Do not add bundle-specific allowlists or special cases to rescue ambiguous no-window observations.
+- Do not regress the existing O(1) trigger lookup path or add new global polling in the name of reliability.
+
+## Success Criteria
+
+- No owned launch/relaunch path can fall through to `phase=no_session` on the next press.
+- No second press immediately after an owned launch can route to `hide_untracked`.
+- `hide_untracked` remains available only for truly external activation.
+- Hidden or minimized owned targets recover through an explicit visibility lane instead of relying on accidental `activate`/`hide` behavior.
+- No regular app can be marked toggle-on successful solely because it became frontmost while still lacking usable window evidence.
+- Shortcut matching remains O(1) pre-dispatch, with no new AX work or detailed logging on unrelated key events.
+- Shortcut capture failures, system-reserved conflicts, and toggle-lifecycle failures are distinguishable in logs without additional instrumentation.
+- One failed attempt window in `debug.log` is enough to identify branch, pid, phase, and reset reason.
+- Full `swift test` remains green before any macOS runtime signoff.

--- a/scripts/e2e-lib.bats
+++ b/scripts/e2e-lib.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+
+@test "detect_capture_requirement returns standard for standard-only shortcuts" {
+  local shortcuts="$BATS_TEST_TMPDIR/shortcuts.json"
+  cat >"$shortcuts" <<'JSON'
+[
+  {
+    "appName": "Safari",
+    "bundleIdentifier": "com.apple.Safari",
+    "id": "11111111-1111-1111-1111-111111111111",
+    "isEnabled": true,
+    "keyEquivalent": "s",
+    "modifierFlags": ["command", "shift"]
+  }
+]
+JSON
+
+  run bash -lc "source '$BATS_TEST_DIRNAME/e2e-lib.sh'; detect_capture_requirement '$shortcuts' 1"
+
+  local result="${output##*$'\n'}"
+  [ "$status" -eq 0 ]
+  [ "$result" = "standard" ]
+}
+
+@test "detect_capture_requirement returns mixed when hyper and standard shortcuts are both enabled" {
+  local shortcuts="$BATS_TEST_TMPDIR/shortcuts.json"
+  cat >"$shortcuts" <<'JSON'
+[
+  {
+    "appName": "Safari",
+    "bundleIdentifier": "com.apple.Safari",
+    "id": "11111111-1111-1111-1111-111111111111",
+    "isEnabled": true,
+    "keyEquivalent": "s",
+    "modifierFlags": ["command", "shift"]
+  },
+  {
+    "appName": "IINA",
+    "bundleIdentifier": "com.colliderli.iina",
+    "id": "22222222-2222-2222-2222-222222222222",
+    "isEnabled": true,
+    "keyEquivalent": "a",
+    "modifierFlags": ["command", "option", "control", "shift"]
+  }
+]
+JSON
+
+  run bash -lc "source '$BATS_TEST_DIRNAME/e2e-lib.sh'; detect_capture_requirement '$shortcuts' 1"
+
+  local result="${output##*$'\n'}"
+  [ "$status" -eq 0 ]
+  [ "$result" = "mixed" ]
+}
+
+@test "capture_requirement_satisfied accepts standard readiness without event tap" {
+  local log_file="$BATS_TEST_TMPDIR/debug.log"
+  cat >"$log_file" <<'LOG'
+2026-04-09T04:24:42Z Quickey starting, version 0.2.0
+2026-04-09T04:24:42Z attemptStart: shortcuts=1 triggerIndex=1 carbon=true eventTap=false
+2026-04-09T04:24:45Z checkPermission: ax=true im=true carbon=true eventTap=false
+LOG
+
+  run bash -lc "source '$BATS_TEST_DIRNAME/e2e-lib.sh'; capture_requirement_satisfied standard '$log_file'"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "capture_requirement_satisfied requires both transports for mixed mode" {
+  local log_file="$BATS_TEST_TMPDIR/debug.log"
+  cat >"$log_file" <<'LOG'
+2026-04-09T04:24:42Z Quickey starting, version 0.2.0
+2026-04-09T04:24:42Z attemptStart: shortcuts=2 triggerIndex=2 carbon=true eventTap=false
+2026-04-09T04:24:45Z checkPermission: ax=true im=true carbon=true eventTap=false
+LOG
+
+  run bash -lc "source '$BATS_TEST_DIRNAME/e2e-lib.sh'; capture_requirement_satisfied mixed '$log_file'"
+
+  [ "$status" -eq 1 ]
+}
+
+@test "bundle_has_configured_shortcut matches a configured standard shortcut" {
+  local shortcuts="$BATS_TEST_TMPDIR/shortcuts.json"
+  cat >"$shortcuts" <<'JSON'
+[
+  {
+    "appName": "Safari",
+    "bundleIdentifier": "com.apple.Safari",
+    "id": "11111111-1111-1111-1111-111111111111",
+    "isEnabled": true,
+    "keyEquivalent": "s",
+    "modifierFlags": ["command", "shift"]
+  }
+]
+JSON
+
+  run bash -lc "source '$BATS_TEST_DIRNAME/e2e-lib.sh'; bundle_has_configured_shortcut 'com.apple.Safari' standard '$shortcuts' 1"
+
+  [ "$status" -eq 0 ]
+}
+
+@test "bundle_has_configured_shortcut rejects a missing hyper shortcut" {
+  local shortcuts="$BATS_TEST_TMPDIR/shortcuts.json"
+  cat >"$shortcuts" <<'JSON'
+[
+  {
+    "appName": "Safari",
+    "bundleIdentifier": "com.apple.Safari",
+    "id": "11111111-1111-1111-1111-111111111111",
+    "isEnabled": true,
+    "keyEquivalent": "s",
+    "modifierFlags": ["command", "shift"]
+  }
+]
+JSON
+
+  run bash -lc "source '$BATS_TEST_DIRNAME/e2e-lib.sh'; bundle_has_configured_shortcut 'com.colliderli.iina' hyper '$shortcuts' 1"
+
+  [ "$status" -eq 1 ]
+}

--- a/scripts/e2e-lib.sh
+++ b/scripts/e2e-lib.sh
@@ -7,9 +7,10 @@ set -euo pipefail
 # --- Constants ---
 E2E_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$E2E_LIB_DIR/.." && pwd)"
-APP_PATH="$PROJECT_DIR/build/Quickey.app"
-LOG_FILE="$HOME/.config/Quickey/debug.log"
-QUICKEY_BUNDLE_ID="com.quickey.app"
+APP_PATH="${E2E_APP_PATH:-$PROJECT_DIR/build/Quickey.app}"
+LOG_FILE="${E2E_LOG_FILE:-$HOME/.config/Quickey/debug.log}"
+QUICKEY_BUNDLE_ID="${E2E_BUNDLE_ID:-com.quickey.app}"
+SHORTCUTS_FILE="${E2E_SHORTCUTS_FILE:-$HOME/Library/Application Support/Quickey/shortcuts.json}"
 CGEVENT_HELPER="$E2E_LIB_DIR/cgevent-helper"
 CGEVENT_SRC="$E2E_LIB_DIR/cgevent-helper.swift"
 
@@ -77,6 +78,133 @@ wait_for_log() {
         sleep 1
         ((elapsed++)) || true
     done
+    return 1
+}
+
+hyper_key_enabled_flag() {
+    defaults read "$QUICKEY_BUNDLE_ID" hyperKeyEnabled 2>/dev/null || echo "0"
+}
+
+detect_capture_requirement() {
+    local shortcuts_file="${1:-$SHORTCUTS_FILE}"
+    local hyper_enabled="${2:-$(hyper_key_enabled_flag)}"
+
+    if [ ! -f "$shortcuts_file" ]; then
+        echo "none"
+        return 0
+    fi
+
+    /usr/bin/ruby -rjson -e '
+        shortcuts = JSON.parse(File.read(ARGV[0])) rescue []
+        hyper_enabled = ARGV[1] == "1"
+        standard = false
+        hyper = false
+
+        shortcuts.each do |shortcut|
+          next if shortcut["isEnabled"] == false
+
+          modifiers = Array(shortcut["modifierFlags"]).map { |flag| flag.to_s.downcase }
+          is_hyper_combo = modifiers.length == 4 &&
+            %w[command option control shift].all? { |flag| modifiers.include?(flag) }
+
+          if hyper_enabled && is_hyper_combo
+            hyper = true
+          else
+            standard = true
+          end
+        end
+
+        if standard && hyper
+          puts "mixed"
+        elsif hyper
+          puts "hyper"
+        elsif standard
+          puts "standard"
+        else
+          puts "none"
+        end
+    ' "$shortcuts_file" "$hyper_enabled"
+}
+
+bundle_has_configured_shortcut() {
+    local bundle_id="$1"
+    local expected_route="$2"
+    local shortcuts_file="${3:-$SHORTCUTS_FILE}"
+    local hyper_enabled="${4:-$(hyper_key_enabled_flag)}"
+
+    if [ ! -f "$shortcuts_file" ]; then
+        return 1
+    fi
+
+    /usr/bin/ruby -rjson -e '
+        shortcuts = JSON.parse(File.read(ARGV[0])) rescue []
+        hyper_enabled = ARGV[1] == "1"
+        bundle_id = ARGV[2]
+        expected_route = ARGV[3]
+
+        matched = shortcuts.any? do |shortcut|
+          next false if shortcut["isEnabled"] == false
+          next false unless shortcut["bundleIdentifier"] == bundle_id
+
+          modifiers = Array(shortcut["modifierFlags"]).map { |flag| flag.to_s.downcase }
+          is_hyper_combo = modifiers.length == 4 &&
+            %w[command option control shift].all? { |flag| modifiers.include?(flag) }
+          route = hyper_enabled && is_hyper_combo ? "hyper" : "standard"
+
+          route == expected_route
+        end
+
+        exit(matched ? 0 : 1)
+    ' "$shortcuts_file" "$hyper_enabled" "$bundle_id" "$expected_route"
+}
+
+_standard_capture_ready() {
+    local log_file="${1:-$LOG_FILE}"
+    grep -Eq 'attemptStart: .*carbon=true|checkPermission: ax=true .*carbon=true' "$log_file" 2>/dev/null
+}
+
+_hyper_capture_ready() {
+    local log_file="${1:-$LOG_FILE}"
+    grep -Eq 'Event tap started|attemptStart: .*eventTap=true|checkPermission: ax=true im=true .*eventTap=true' "$log_file" 2>/dev/null
+}
+
+capture_requirement_satisfied() {
+    local requirement="$1"
+    local log_file="${2:-$LOG_FILE}"
+
+    case "$requirement" in
+        standard)
+            _standard_capture_ready "$log_file"
+            ;;
+        hyper)
+            _hyper_capture_ready "$log_file"
+            ;;
+        mixed)
+            _standard_capture_ready "$log_file" && _hyper_capture_ready "$log_file"
+            ;;
+        none)
+            grep -q "Quickey starting" "$log_file" 2>/dev/null
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+wait_for_capture_requirement() {
+    local requirement="$1"
+    local timeout="$2"
+    local log_file="${3:-$LOG_FILE}"
+    local elapsed=0
+
+    while [ "$elapsed" -lt "$timeout" ]; do
+        if capture_requirement_satisfied "$requirement" "$log_file"; then
+            return 0
+        fi
+        sleep 1
+        ((elapsed++)) || true
+    done
+
     return 1
 }
 
@@ -259,9 +387,7 @@ ensure_app_stopped() {
 }
 
 is_hyper_key_enabled() {
-    local val
-    val=$(defaults read "$QUICKEY_BUNDLE_ID" hyperKeyEnabled 2>/dev/null || echo "0")
-    [ "$val" = "1" ]
+    [ "$(hyper_key_enabled_flag)" = "1" ]
 }
 
 # --- Module support ---
@@ -274,6 +400,7 @@ for arg in "$@"; do
 done
 
 e2e_launch_app() {
+    local requirement
     if [ ! -d "$APP_PATH" ]; then
         echo -e "${RED}ERROR: Quickey.app not found at $APP_PATH${NC}"
         echo "    Run: ./scripts/package-app.sh"
@@ -290,11 +417,13 @@ e2e_launch_app() {
 
     open "$APP_PATH"
 
-    echo "    Waiting for event tap to start..."
-    if wait_for_log "Event tap started" 30 0; then
-        echo -e "    ${GREEN}Event tap started${NC}"
+    requirement=$(detect_capture_requirement "$SHORTCUTS_FILE" "$(hyper_key_enabled_flag)")
+
+    echo "    Waiting for capture readiness (${requirement})..."
+    if wait_for_capture_requirement "$requirement" 30 "$LOG_FILE"; then
+        echo -e "    ${GREEN}Capture ready${NC} (${requirement})"
     else
-        echo -e "    ${RED}Event tap failed to start within 30s${NC}"
+        echo -e "    ${RED}Capture failed to become ready within 30s${NC} (${requirement})"
         if grep -q "tapCreate.*failed" "$LOG_FILE" 2>/dev/null; then
             echo "    Check permissions:"
             echo "    System Settings > Privacy & Security > Accessibility -> add Quickey"
@@ -333,4 +462,11 @@ e2e_verdict() {
         echo -e "${GREEN}${BOLD}$module_name: PASS${NC} ($PASSES passed)"
         return 0
     fi
+}
+
+e2e_skip_module() {
+    local reason="$1"
+    echo -e "    ${YELLOW}SKIP${NC}: $reason"
+    e2e_maybe_stop
+    exit 2
 }

--- a/scripts/e2e-test-debounce.sh
+++ b/scripts/e2e-test-debounce.sh
@@ -8,22 +8,26 @@ e2e_maybe_launch "$MODULE_NAME"
 echo ""
 echo "=== $MODULE_NAME ==="
 
+if ! bundle_has_configured_shortcut "com.apple.Safari" standard; then
+    e2e_skip_module "Safari standard shortcut not configured"
+fi
+
 ensure_app_running "Safari"
 sleep 1
 
 # --- Part 1: Ultra-rapid presses (single osascript, accurate sub-200ms timing) ---
 echo ""
-echo "  -- Part 1: Ultra-rapid presses (3x @ 50ms, expect debounce) --"
+echo "  -- Part 1: Ultra-rapid presses (3x @ 50ms, expect cooldown protection on standard route) --"
 
 PRE=$(log_line_count)
 send_rapid_keystrokes "s" "{shift down, command down}" 3 0.05
 sleep 3
 
 SLICE=$(get_log_slice "$PRE")
-echo "    Swallowed=$(count_in_slice "$SLICE" "EVENT_TAP_SWALLOW:"), MATCHED=$(count_in_slice "$SLICE" "MATCHED:"), Debounced=$(count_in_slice "$SLICE" "DEBOUNCE_BLOCKED")"
+echo "    MATCHED=$(count_in_slice "$SLICE" "MATCHED:"), Cooldown=$(count_in_slice "$SLICE" "BLOCKED cooldown"), Debounced=$(count_in_slice "$SLICE" "DEBOUNCE_BLOCKED")"
 
-assert_count_ge "$SLICE" "EVENT_TAP_SWALLOW:" 2 "Multiple events swallowed at tap level"
-assert_count_ge "$SLICE" "DEBOUNCE_BLOCKED" 1 "At least one press debounce-blocked"
+assert_count_ge "$SLICE" "MATCHED:" 1 "At least one press matched"
+assert_count_ge "$SLICE" "BLOCKED cooldown" 1 "At least one press cooldown-blocked"
 
 # --- Part 2: Medium-rapid presses (expect cooldown) ---
 echo ""

--- a/scripts/e2e-test-hyper-key.sh
+++ b/scripts/e2e-test-hyper-key.sh
@@ -9,9 +9,11 @@ echo ""
 echo "=== $MODULE_NAME ==="
 
 if ! is_hyper_key_enabled; then
-    echo -e "    ${YELLOW}SKIP${NC}: Hyper Key not enabled, cannot test"
-    e2e_maybe_stop
-    exit 0
+    e2e_skip_module "Hyper Key not enabled"
+fi
+
+if ! bundle_has_configured_shortcut "com.colliderli.iina" hyper; then
+    e2e_skip_module "IINA Hyper shortcut not configured"
 fi
 
 # Probe CGEvent delivery; fall back to osascript if needed

--- a/scripts/e2e-test-loop-prevention.sh
+++ b/scripts/e2e-test-loop-prevention.sh
@@ -11,6 +11,10 @@ e2e_maybe_launch "$MODULE_NAME"
 echo ""
 echo "=== $MODULE_NAME ==="
 
+if ! bundle_has_configured_shortcut "com.apple.Safari" standard; then
+    e2e_skip_module "Safari standard shortcut not configured"
+fi
+
 ensure_app_running "Safari"
 sleep 1
 

--- a/scripts/e2e-test-multi-shortcut.sh
+++ b/scripts/e2e-test-multi-shortcut.sh
@@ -8,6 +8,10 @@ e2e_maybe_launch "$MODULE_NAME"
 echo ""
 echo "=== $MODULE_NAME ==="
 
+if ! bundle_has_configured_shortcut "com.apple.Safari" standard; then
+    e2e_skip_module "Safari standard shortcut not configured"
+fi
+
 ensure_app_running "Safari"
 sleep 1
 
@@ -24,7 +28,7 @@ assert_count_ge "$SLICE" "MATCHED: Safari" 1 "Safari shortcut matched"
 assert_not_contains "$SLICE" "MATCHED: IINA" "IINA not triggered by Safari shortcut"
 
 # --- Step 2: Hyper+A -> only IINA ---
-if is_hyper_key_enabled; then
+if is_hyper_key_enabled && bundle_has_configured_shortcut "com.colliderli.iina" hyper; then
     _probe_cgevent
     echo ""
     echo "  -- Step 2: Hyper+A -> only IINA --"
@@ -41,7 +45,7 @@ if is_hyper_key_enabled; then
     ensure_app_stopped "IINA"
 else
     echo ""
-    echo -e "  -- Step 2: ${YELLOW}SKIP${NC} (Hyper Key not enabled) --"
+    echo -e "  -- Step 2: ${YELLOW}SKIP${NC} (IINA Hyper shortcut not configured) --"
 fi
 
 # --- Step 3: Safari again ---

--- a/scripts/e2e-test-standard-toggle.sh
+++ b/scripts/e2e-test-standard-toggle.sh
@@ -8,6 +8,10 @@ e2e_maybe_launch "$MODULE_NAME"
 echo ""
 echo "=== $MODULE_NAME ==="
 
+if ! bundle_has_configured_shortcut "com.apple.Safari" standard; then
+    e2e_skip_module "Safari standard shortcut not configured"
+fi
+
 # Ensure Safari running but not frontmost
 ensure_app_running "Safari"
 open -a Finder  # push Safari to background
@@ -24,7 +28,7 @@ sleep 3
 SLICE=$(get_log_slice "$PRE")
 
 assert_count_eq "$SLICE" "MATCHED: Safari" 1 "Single MATCHED: Safari"
-assert_count_ge "$SLICE" "EVENT_TAP_SWALLOW:" 1 "Event swallowed"
+assert_contains "$SLICE" "SHORTCUT_TRACE_DECISION event=matched bundle=com.apple.Safari route=standard" "Matched via standard route"
 assert_count_ge "$SLICE" "TOGGLE_ATTEMPT" 1 "Toggle attempt logged"
 assert_app_frontmost "com.apple.Safari" "Safari is frontmost after toggle ON"
 
@@ -40,8 +44,8 @@ sleep 3
 SLICE=$(get_log_slice "$PRE")
 
 assert_count_eq "$SLICE" "MATCHED: Safari" 1 "Single MATCHED: Safari"
-assert_count_ge "$SLICE" "TOGGLE_RESTORE_ATTEMPT" 1 "Toggle restore attempted"
-assert_contains "$SLICE" "IS ACTIVE.*restored=true" "Restore path: IS ACTIVE -> restored"
+assert_count_ge "$SLICE" "HIDE_REQUEST" 1 "Hide request logged"
+assert_count_ge "$SLICE" "TOGGLE_HIDE_CONFIRMED" 1 "Hide confirmed"
 assert_app_not_frontmost "com.apple.Safari" "Safari not frontmost after toggle OFF"
 
 e2e_maybe_stop

--- a/scripts/e2e-test-startup.sh
+++ b/scripts/e2e-test-startup.sh
@@ -8,6 +8,8 @@ e2e_maybe_launch "$MODULE_NAME"
 echo ""
 echo "=== $MODULE_NAME ==="
 
+REQUIREMENT=$(detect_capture_requirement "$SHORTCUTS_FILE" "$(hyper_key_enabled_flag)")
+
 # Wait for first permission check (3s interval) before reading log
 echo "    Waiting for first permission check..."
 wait_for_log "checkPermission:" 10 0 || true
@@ -15,11 +17,8 @@ wait_for_log "checkPermission:" 10 0 || true
 SLICE=$(get_log_slice 0)
 
 assert_contains "$SLICE" "Quickey starting" "App startup logged"
-assert_contains "$SLICE" "tapCreate: SUCCESS" "Event tap created"
-assert_contains "$SLICE" "Event tap started" "Event tap running"
-assert_contains "$SLICE" "checkPermission: ax=true im=true tapRunning=true" "Permissions OK"
-assert_contains "$SLICE" "attemptStart: starting event tap, shortcuts count" "Shortcuts indexed"
-assert_contains "$SLICE" "shortcuts count: [1-9]" "Shortcut count > 0"
+assert_contains "$SLICE" "attemptStart: shortcuts=[0-9][0-9]* triggerIndex=[0-9][0-9]*" "Shortcuts indexed"
+assert_contains "$SLICE" "triggerIndex=[1-9]" "Shortcut count > 0"
 
 if is_hyper_key_enabled; then
     assert_contains "$SLICE" "Hyper Key mapping re-applied" "Hyper Key mapping re-applied on launch"
@@ -27,11 +26,29 @@ else
     echo -e "    ${YELLOW}SKIP${NC}: Hyper Key not enabled"
 fi
 
+case "$REQUIREMENT" in
+    standard)
+        assert_contains "$SLICE" "checkPermission: ax=true .*carbon=true" "Standard capture ready"
+        ;;
+    hyper)
+        assert_contains "$SLICE" "Event tap started" "Event tap running"
+        assert_contains "$SLICE" "checkPermission: ax=true im=true .*eventTap=true" "Hyper capture ready"
+        ;;
+    mixed)
+        assert_contains "$SLICE" "checkPermission: ax=true .*carbon=true" "Standard capture ready"
+        assert_contains "$SLICE" "Event tap started" "Event tap running"
+        assert_contains "$SLICE" "checkPermission: ax=true im=true .*eventTap=true" "Hyper capture ready"
+        ;;
+    none)
+        echo -e "    ${YELLOW}SKIP${NC}: No enabled shortcuts configured"
+        ;;
+esac
+
 # Permission timer: wait for second check cycle
 echo "    Waiting 4s for permission timer cycle..."
 sleep 4
 SLICE_AFTER=$(get_log_slice 0)
-assert_count_ge "$SLICE_AFTER" "checkPermission: ax=true im=true tapRunning=true" 2 "Permission timer running"
+assert_count_ge "$SLICE_AFTER" "checkPermission:" 2 "Permission timer running"
 
 e2e_maybe_stop
 e2e_verdict "$MODULE_NAME"


### PR DESCRIPTION
## Summary
- make `ToggleSessionCoordinator` the canonical toggle lifecycle owner, add pid/attempt-aware `TOGGLE_TRACE_*` diagnostics, and tighten regular-app activation confirmation around real window evidence
- attach `NSWorkspace.openApplication` completions back into owned launch sessions, preserve deactivation ownership for `hide_untracked`, and replay persisted Hyper state before shortcut capture starts
- update the E2E harness to use transport-aware readiness and config-aware fixture skips so standard Carbon coverage no longer fails waiting for an event tap

## Root cause
The runtime bug was a combination of split lifecycle ownership and missing process identity on launch. Owned launch attempts could lose their session boundary between launch and confirmation, which let the next press fall through to `hide_untracked` or stale/no-session branches. External frontmost paths had a similar ownership gap on hide because the branch logged `hide_untracked` before allocating a coordinator-owned deactivation session.

The validation side had drifted too: the shell harness still treated `Event tap started` and older restore-path logs as universal success signals. That was no longer true once standard shortcuts moved to Carbon-first readiness and toggle-off settled on `HIDE_REQUEST` / `TOGGLE_HIDE_CONFIRMED`.

## Impact
- owned launch / relaunch paths now stay on a single session through launch attachment, stable confirmation, hide, termination, and pid rollover
- regular apps without visible/focused/main-window evidence can no longer be misclassified as successful toggle-on activations
- runtime logs now identify branch, attempt, pid, phase, and reset reason end-to-end without adding noisy per-key diagnostics
- the packaged E2E suite now passes on the current local fixture, with Hyper coverage surfacing as a warning when the expected IINA Hyper shortcut is not configured instead of a false failure

## Validation
- `swift test`
- `bats scripts/e2e-lib.bats`
- `bash scripts/package-app.sh`
- `codesign --verify --deep --strict --verbose=2 build/Quickey.app`
- `bash scripts/e2e-full-test.sh`
