### PR TITLE
cleanup: unify CarbonHotKeyProvider main-actor dispatch

### DIFF
--- a/Sources/Quickey/Services/CarbonHotKeyProvider.swift
+++ b/Sources/Quickey/Services/CarbonHotKeyProvider.swift
@@ -4,7 +4,8 @@ import Foundation
 
 private let carbonHotKeySignature: OSType = 0x514B4559 // 'QKEY'
 
-private final class CarbonHotKeyCallbackBox {
+private final class CarbonHotKeyCallbackBox: @unchecked Sendable {
+    // weak reference reads are atomic; provider is set once in init and never mutated.
     weak var provider: CarbonHotKeyProvider?
 
     init(provider: CarbonHotKeyProvider) {
@@ -35,10 +36,10 @@ private func carbonHotKeyCallbackImpl(
     }
 
     let box = Unmanaged<CarbonHotKeyCallbackBox>.fromOpaque(userData).takeUnretainedValue()
-    if let provider = box.provider {
-        DispatchQueue.main.async {
-            provider.handleHotKeyEvent(identifier: hotKeyID.id)
-        }
+    // Carbon hotkey events installed on GetApplicationEventTarget() are delivered
+    // on the main thread, so isolation can be asserted without an async hop.
+    MainActor.assumeIsolated {
+        box.provider?.handleHotKeyEvent(identifier: hotKeyID.id)
     }
     return noErr
 }
@@ -214,9 +215,6 @@ final class CarbonHotKeyProvider: ShortcutCaptureProvider {
               let onKeyPress else {
             return
         }
-
-        Task { @MainActor in
-            onKeyPress(registration.keyPress)
-        }
+        onKeyPress(registration.keyPress)
     }
 }


### PR DESCRIPTION
## Summary

- Drop the double main-actor hop on the Carbon hotkey path. Carbon events installed on `GetApplicationEventTarget()` are delivered on the main thread, so use `MainActor.assumeIsolated` for a single synchronous hop (no async dispatch) and remove the inner `Task { @MainActor in }` from `handleHotKeyEvent`.
- Matches the pattern already used for the `queue: .main` NSWorkspace observer in `AppSwitcher`.
- Mark `CarbonHotKeyCallbackBox` as `@unchecked Sendable` so the C-callback can reference it from the main-actor closure under Swift 6 strict concurrency (weak reference reads are atomic; `provider` is set once in init and never mutated).

This is a minor deviation from the issue's literal `Task { @MainActor in }` suggestion: under Swift 6 strict concurrency, the task-isolated capture of `hotKeyID.id` into a main-actor-isolated task closure is flagged as a sending risk. `MainActor.assumeIsolated` satisfies the same goal (single, clearly-expressed main-actor hop) without the async dispatch and matches the existing NSWorkspace-observer convention in this codebase.

Closes #161

## Testing
- [x] `swift build`
- [x] `swift test` — 214 passed

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Functional behavior is unchanged (same callbacks fire, same main-actor method is called); please verify a standard (non-Hyper) shortcut still triggers its toggle on macOS.