### PR TITLE
fix: follow live time-zone changes in UsageTracker date bucketing

### DIFF
--- a/Sources/Quickey/Services/UsageTracker.swift
+++ b/Sources/Quickey/Services/UsageTracker.swift
@@ -67,7 +67,7 @@ actor UsageTracker: UsageTracking {
 
         let idString = shortcutId.uuidString
         sqlite3_bind_text(stmt, 1, (idString as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
-        sqlite3_bind_text(stmt, 2, (dateString(for: date) as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, (dateString(for: date, in: timeZoneProvider()) as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
 
         if sqlite3_step(stmt) != SQLITE_DONE {
             let errMsg = String(cString: sqlite3_errmsg(self.db!))
@@ -216,14 +216,17 @@ actor UsageTracker: UsageTracking {
 
     private func windowStartString(days: Int, relativeTo now: Date) -> String {
         let clampedDays = max(days, 1)
+        // Snapshot the time zone once so the cutoff arithmetic and its
+        // formatted representation always share the same reference frame,
+        // even if the system time zone changes mid-query.
+        let tz = timeZoneProvider()
         var calendar = Calendar.current
-        calendar.timeZone = timeZoneProvider()
+        calendar.timeZone = tz
         let start = calendar.date(byAdding: .day, value: -(clampedDays - 1), to: now) ?? now
-        return dateString(for: start)
+        return dateString(for: start, in: tz)
     }
 
-    private func dateString(for date: Date) -> String {
-        let tz = timeZoneProvider()
+    private func dateString(for date: Date, in tz: TimeZone) -> String {
         if tz.identifier != dateFormatterTimeZoneIdentifier {
             (dateFormatter, dateFormatterTimeZoneIdentifier) = Self.makeDateFormatter(for: tz)
         }

--- a/Sources/Quickey/Services/UsageTracker.swift
+++ b/Sources/Quickey/Services/UsageTracker.swift
@@ -14,21 +14,32 @@ actor UsageTracker: UsageTracking {
     /// preventing use-after-free when the source NSString buffer is deallocated.
     private static let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
-    private static let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = .current
-        return formatter
-    }()
+    /// Resolves the current time zone for date-key bucketing. Overridable for tests.
+    /// Rechecked on every recordUsage / query so the tracker follows user time-zone changes
+    /// (cross-zone travel, DST transitions, manual system-clock edits) without a restart.
+    private let timeZoneProvider: @Sendable () -> TimeZone
+    private var dateFormatter: DateFormatter
+    private var dateFormatterTimeZoneIdentifier: String
 
-    init() {
+    init(
+        timeZoneProvider: @escaping @Sendable () -> TimeZone = { TimeZone.current }
+    ) {
+        self.timeZoneProvider = timeZoneProvider
+        let tz = timeZoneProvider()
+        (self.dateFormatter, self.dateFormatterTimeZoneIdentifier) = Self.makeDateFormatter(for: tz)
         db = Self.openDatabase(path: Self.defaultDatabasePath())
         if let db {
             Self.createTable(db: db)
         }
     }
 
-    init(databasePath: String) {
+    init(
+        databasePath: String,
+        timeZoneProvider: @escaping @Sendable () -> TimeZone = { TimeZone.current }
+    ) {
+        self.timeZoneProvider = timeZoneProvider
+        let tz = timeZoneProvider()
+        (self.dateFormatter, self.dateFormatterTimeZoneIdentifier) = Self.makeDateFormatter(for: tz)
         db = Self.openDatabase(path: databasePath)
         if let db {
             Self.createTable(db: db)
@@ -205,11 +216,24 @@ actor UsageTracker: UsageTracking {
 
     private func windowStartString(days: Int, relativeTo now: Date) -> String {
         let clampedDays = max(days, 1)
-        let start = Calendar.current.date(byAdding: .day, value: -(clampedDays - 1), to: now) ?? now
+        var calendar = Calendar.current
+        calendar.timeZone = timeZoneProvider()
+        let start = calendar.date(byAdding: .day, value: -(clampedDays - 1), to: now) ?? now
         return dateString(for: start)
     }
 
     private func dateString(for date: Date) -> String {
-        return Self.dateFormatter.string(from: date)
+        let tz = timeZoneProvider()
+        if tz.identifier != dateFormatterTimeZoneIdentifier {
+            (dateFormatter, dateFormatterTimeZoneIdentifier) = Self.makeDateFormatter(for: tz)
+        }
+        return dateFormatter.string(from: date)
+    }
+
+    private static func makeDateFormatter(for timeZone: TimeZone) -> (DateFormatter, String) {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = timeZone
+        return (formatter, timeZone.identifier)
     }
 }

--- a/Tests/QuickeyTests/UsageTrackerWindowTests.swift
+++ b/Tests/QuickeyTests/UsageTrackerWindowTests.swift
@@ -68,6 +68,24 @@ struct UsageTrackerWindowTests {
     }
 
     @Test
+    func windowStartStringSnapshotsTimeZoneOncePerQuery() async {
+        // Regression for Codex review on PR #163: windowStartString previously
+        // read `timeZoneProvider()` once for the Calendar and a second time
+        // inside `dateString(for:)`. If the system zone changed between those
+        // reads, the cutoff was computed in one zone and formatted in another.
+        // With the fix the query path takes exactly one snapshot per call.
+        let counter = CountingTimeZoneBox(TimeZone(secondsFromGMT: 0)!)
+        let tracker = UsageTracker(databasePath: ":memory:", timeZoneProvider: { counter.provide() })
+
+        await tracker.recordUsage(shortcutId: UUID(), on: isoDate("2026-03-21"))
+        counter.reset()
+
+        _ = await tracker.usageCounts(days: 7, relativeTo: isoDate("2026-03-21"))
+
+        #expect(counter.count == 1)
+    }
+
+    @Test
     func windowStartStringUsesCurrentTimeZone() async {
         let box = MutableTimeZoneBox(initial: TimeZone(secondsFromGMT: -10 * 3600)!)
         let tracker = UsageTracker(databasePath: ":memory:", timeZoneProvider: { box.current })
@@ -83,6 +101,30 @@ struct UsageTrackerWindowTests {
         // which has no records — the GMT-10 entry sits in a different bucket.
         let counts = await tracker.usageCounts(days: 1, relativeTo: moment)
         #expect(counts[id] == nil)
+    }
+}
+
+private final class CountingTimeZoneBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _count = 0
+    private let tz: TimeZone
+
+    init(_ tz: TimeZone) { self.tz = tz }
+
+    var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _count
+    }
+
+    func provide() -> TimeZone {
+        lock.lock(); defer { lock.unlock() }
+        _count += 1
+        return tz
+    }
+
+    func reset() {
+        lock.lock(); defer { lock.unlock() }
+        _count = 0
     }
 }
 

--- a/Tests/QuickeyTests/UsageTrackerWindowTests.swift
+++ b/Tests/QuickeyTests/UsageTrackerWindowTests.swift
@@ -47,6 +47,57 @@ struct UsageTrackerWindowTests {
         let total = await tracker.totalSwitches(days: 30, relativeTo: today)
         #expect(total == 1)
     }
+
+    @Test
+    func recordUsageFollowsLiveTimeZoneChange() async {
+        let box = MutableTimeZoneBox(initial: TimeZone(secondsFromGMT: -10 * 3600)!)
+        let tracker = UsageTracker(databasePath: ":memory:", timeZoneProvider: { box.current })
+        let id = UUID()
+        let moment = isoDate("2026-03-21") // 2026-03-21T12:00:00Z
+
+        // GMT-10 → 2026-03-21 02:00 local → bucket "2026-03-21"
+        await tracker.recordUsage(shortcutId: id, on: moment)
+
+        // GMT+12 → 2026-03-22 00:00 local → bucket "2026-03-22"
+        box.current = TimeZone(secondsFromGMT: 12 * 3600)!
+        await tracker.recordUsage(shortcutId: id, on: moment)
+
+        let counts = await tracker.dailyCounts(days: 7, relativeTo: moment)
+        let dates = counts[id.uuidString]?.map(\.date).sorted() ?? []
+        #expect(dates == ["2026-03-21", "2026-03-22"])
+    }
+
+    @Test
+    func windowStartStringUsesCurrentTimeZone() async {
+        let box = MutableTimeZoneBox(initial: TimeZone(secondsFromGMT: -10 * 3600)!)
+        let tracker = UsageTracker(databasePath: ":memory:", timeZoneProvider: { box.current })
+        let id = UUID()
+        let moment = isoDate("2026-03-21") // 2026-03-21T12:00:00Z
+
+        // Pre-seed the bucket that's "today" in GMT+12 but "yesterday" in GMT-10.
+        await tracker.recordUsage(shortcutId: id, on: moment) // GMT-10: "2026-03-21"
+
+        // Switch to GMT+12 where the same moment is "2026-03-22".
+        box.current = TimeZone(secondsFromGMT: 12 * 3600)!
+        // 1-day window anchored at `moment` in GMT+12 covers only "2026-03-22",
+        // which has no records — the GMT-10 entry sits in a different bucket.
+        let counts = await tracker.usageCounts(days: 1, relativeTo: moment)
+        #expect(counts[id] == nil)
+    }
+}
+
+private final class MutableTimeZoneBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _current: TimeZone
+
+    init(initial: TimeZone) {
+        self._current = initial
+    }
+
+    var current: TimeZone {
+        get { lock.lock(); defer { lock.unlock() }; return _current }
+        set { lock.lock(); defer { lock.unlock() }; _current = newValue }
+    }
 }
 
 private func isoDate(_ value: String) -> Date {


### PR DESCRIPTION
## Summary

- Replace the process-lifetime `static let dateFormatter` with an actor-owned formatter that recaches by `TimeZone.identifier`. A new `timeZoneProvider` (default: `{ TimeZone.current }`) is consulted on every `recordUsage` / query and the formatter is rebuilt when the zone changes.
- Anchor `windowStartString`'s `Calendar` to the same provider so the day-offset math stays consistent with the formatted key.
- Tests: added cross-time-zone regression cases — one for `recordUsage` after a live zone change and one confirming the query window uses the current zone, not the launch-time zone.

Closes #160

## Testing
- [x] `swift build`
- [x] `swift test` — 216 passed (214 + 2 new)

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

Pure data logic change in `UsageTracker` actor; no TCC/event taps/activation paths touched. Covered by unit tests.