### PR TITLE
fix: tear down NSWorkspace observers on dealloc

### DIFF
--- a/Sources/Quickey/Services/AppSwitcher.swift
+++ b/Sources/Quickey/Services/AppSwitcher.swift
@@ -187,7 +187,20 @@ final class AppSwitcher: AppSwitching {
     private let deactivationConfirmationInitialDelay: TimeInterval = 0.05
     private let deactivationConfirmationPollInterval: TimeInterval = 0.05
     private let deactivationConfirmationTimeout: TimeInterval = 0.3
-    private var workspaceHideObserver: Any?
+    // nonisolated(unsafe): written only while @MainActor-isolated (from init)
+    // but read from the nonisolated deinit below, where NotificationCenter.removeObserver
+    // is thread-safe.
+    private nonisolated(unsafe) var workspaceHideObserver: Any?
+
+    deinit {
+        if let workspaceHideObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(workspaceHideObserver)
+        }
+        // AppSwitcher owns the lifecycle of the workspace observers it asked
+        // sessionCoordinator to install, so stop them even if the coordinator
+        // is kept alive by another owner.
+        sessionCoordinator.stopObservingWorkspaceNotifications()
+    }
 
     init(
         frontmostTracker: FrontmostApplicationTracker = FrontmostApplicationTracker(),

--- a/Sources/Quickey/Services/ToggleSessionCoordinator.swift
+++ b/Sources/Quickey/Services/ToggleSessionCoordinator.swift
@@ -369,8 +369,15 @@ final class ToggleSessionCoordinator {
 
     // MARK: - Live notification wiring
 
-    private var activationObserver: Any?
-    private var terminationObserver: Any?
+    // nonisolated(unsafe): tokens are written only while @MainActor-isolated
+    // (from start/stop) but also read from the nonisolated deinit below, where
+    // NotificationCenter.removeObserver is thread-safe.
+    private nonisolated(unsafe) var activationObserver: Any?
+    private nonisolated(unsafe) var terminationObserver: Any?
+
+    deinit {
+        stopObservingWorkspaceNotifications()
+    }
 
     func startObservingWorkspaceNotifications() {
         let center = NSWorkspace.shared.notificationCenter
@@ -400,7 +407,7 @@ final class ToggleSessionCoordinator {
         }
     }
 
-    func stopObservingWorkspaceNotifications() {
+    nonisolated func stopObservingWorkspaceNotifications() {
         let center = NSWorkspace.shared.notificationCenter
         if let activationObserver {
             center.removeObserver(activationObserver)

--- a/Tests/QuickeyTests/AppSwitcherTests.swift
+++ b/Tests/QuickeyTests/AppSwitcherTests.swift
@@ -1300,6 +1300,34 @@ func hideToggleLogsStructuredMetricFields() {
     #expect(message.contains("com.test.MetricsApp"))
 }
 
+@Test @MainActor
+func appSwitcherDeinitRemovesWorkspaceObservers() {
+    weak var weakSwitcher: AppSwitcher?
+    do {
+        let switcher = AppSwitcher(frontmostTracker: makeTrackerForAppSwitcherTests())
+        weakSwitcher = switcher
+    }
+    // Strong ref dropped at end of scope; nonisolated deinit must remove both
+    // the workspaceHideObserver and the activation/termination observers that
+    // sessionCoordinator installed on behalf of the switcher.
+    #expect(weakSwitcher == nil, "AppSwitcher should deallocate after scope exit")
+
+    // Posting notifications after release must be safe; a leaked observer block
+    // would fire on a dangling context.
+    NSWorkspace.shared.notificationCenter.post(
+        name: NSWorkspace.didHideApplicationNotification,
+        object: nil
+    )
+    NSWorkspace.shared.notificationCenter.post(
+        name: NSWorkspace.didActivateApplicationNotification,
+        object: nil
+    )
+    NSWorkspace.shared.notificationCenter.post(
+        name: NSWorkspace.didTerminateApplicationNotification,
+        object: nil
+    )
+}
+
 @MainActor
 private func makeTrackerForAppSwitcherTests() -> FrontmostApplicationTracker {
     FrontmostApplicationTracker(client: .init(

--- a/Tests/QuickeyTests/ToggleSessionCoordinatorTests.swift
+++ b/Tests/QuickeyTests/ToggleSessionCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreFoundation
 import Testing
 @testable import Quickey
@@ -372,6 +373,40 @@ func handleFrontmostChangeKeepsDeactivatingSessionAliveUntilHideConfirmation() {
     coordinator.handleFrontmostChange(newFrontmostBundle: "com.apple.Terminal")
 
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .deactivating)
+}
+
+@Test @MainActor
+func deinitRemovesWorkspaceObservers() {
+    weak var weakCoordinator: ToggleSessionCoordinator?
+    do {
+        let coordinator = ToggleSessionCoordinator()
+        coordinator.startObservingWorkspaceNotifications()
+        weakCoordinator = coordinator
+    }
+    // Strong ref was dropped at end of scope; nonisolated deinit runs
+    // synchronously on the releasing thread and tears down the observer tokens.
+    #expect(weakCoordinator == nil, "coordinator should deallocate after scope exit")
+
+    // Posting notifications that the coordinator used to observe must be safe
+    // after release. If the observer wasn't removed on deinit, the block would
+    // be retained forever and could fire on a dangling context.
+    NSWorkspace.shared.notificationCenter.post(
+        name: NSWorkspace.didActivateApplicationNotification,
+        object: nil
+    )
+    NSWorkspace.shared.notificationCenter.post(
+        name: NSWorkspace.didTerminateApplicationNotification,
+        object: nil
+    )
+}
+
+@Test @MainActor
+func stopObservingWorkspaceNotificationsIsIdempotent() {
+    let coordinator = ToggleSessionCoordinator()
+    coordinator.startObservingWorkspaceNotifications()
+    coordinator.stopObservingWorkspaceNotifications()
+    // Calling again must be a safe no-op, not a double-remove crash.
+    coordinator.stopObservingWorkspaceNotifications()
 }
 
 private final class CoordinatorTestClock: @unchecked Sendable {


### PR DESCRIPTION
## Summary

- `AppSwitcher.workspaceHideObserver` and the pair of `NSWorkspace` observers installed by `ToggleSessionCoordinator.startObservingWorkspaceNotifications` never had a matching `removeObserver`. Apple's block-based `addObserver(forName:object:queue:using:)` API requires explicit removal — without a `deinit` every rebuilt instance leaks its closure and the observer block outlives the `[weak self]` target.
- Add a nonisolated `deinit` to each class that removes the observers it installed. `ToggleSessionCoordinator` makes its observer storage `nonisolated(unsafe)` and its `stopObservingWorkspaceNotifications` nonisolated so `deinit` can call it on whichever thread drops the last reference (`NotificationCenter.removeObserver` is thread-safe). `AppSwitcher.deinit` removes its hide observer and also calls `sessionCoordinator.stopObservingWorkspaceNotifications()`, since the switcher's init is what started those observers and the coordinator may outlive the switcher when injected externally.
- Regression tests added: weak-ref + post-dealloc notification posts for both classes, plus an idempotency check for `stopObservingWorkspaceNotifications`.

Closes #158

## Testing
- [x] `swift build`
- [x] `swift test` — 217 passed (214 + 3 new)

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Behavior in the hot path (shortcut → activation → toggle) is unchanged; the fix applies only when instances are deallocated (test rebuilds, eventual shutdown). Quick sanity check on macOS: repeatedly toggle a bound shortcut to confirm activation/hide still works and nothing regresses.