### PR TITLE
fix: reset CapsLockDelayOverride when disabling Hyper

### DIFF
--- a/Sources/Quickey/Services/HyperKeyService.swift
+++ b/Sources/Quickey/Services/HyperKeyService.swift
@@ -103,8 +103,15 @@ final class HyperKeyService {
     }
 
     private func clearMapping() -> Bool {
-        // CapsLockDelayOverride is not explicitly reset here. hidutil properties
-        // do not survive reboot (Apple TN2450), so the override clears naturally.
-        return runner(["property", "--set", "{\"UserKeyMapping\":[]}"])
+        // Explicitly restore CapsLockDelayOverride to the macOS 15 default (100 ms).
+        // applyMapping sets it to 0 to bypass the built-in Caps Lock press-duration
+        // threshold; without writing a value back here, that override would remain
+        // in effect until reboot and leak into system-wide Caps Lock behavior
+        // (e.g. input-source switching becomes overly sensitive in other apps).
+        return runner([
+            "property",
+            "--set",
+            "{\"UserKeyMapping\":[],\"CapsLockDelayOverride\":100}"
+        ])
     }
 }

--- a/Tests/QuickeyTests/HyperKeyServiceTests.swift
+++ b/Tests/QuickeyTests/HyperKeyServiceTests.swift
@@ -34,3 +34,51 @@ func disableDoesNotClearPersistedStateWhenHidutilFails() {
 
     #expect(service.isEnabled == true)
 }
+
+@Test @MainActor
+func disableRestoresCapsLockDelayOverrideDefault() {
+    let suiteName = "HyperKeyServiceTests.disable.capsLockDelay"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "hyperKeyEnabled")
+
+    let recorder = HidutilRunnerRecorder(returns: true)
+    let service = HyperKeyService(
+        runner: recorder.run,
+        defaults: defaults
+    )
+
+    service.disable()
+
+    #expect(service.isEnabled == false)
+    #expect(recorder.invocations.count == 1)
+    let args = recorder.invocations.first ?? []
+    #expect(args.prefix(2) == ["property", "--set"])
+    let json = args.last ?? ""
+    // Without this reset, applyMapping's CapsLockDelayOverride=0 would leak
+    // into system-wide Caps Lock behavior until reboot.
+    #expect(json.contains("\"CapsLockDelayOverride\":100"))
+    #expect(json.contains("\"UserKeyMapping\":[]"))
+}
+
+private final class HidutilRunnerRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let returnValue: Bool
+    private var _invocations: [[String]] = []
+
+    init(returns: Bool) {
+        self.returnValue = returns
+    }
+
+    var invocations: [[String]] {
+        lock.lock(); defer { lock.unlock() }
+        return _invocations
+    }
+
+    func run(_ arguments: [String]) -> Bool {
+        lock.lock()
+        _invocations.append(arguments)
+        lock.unlock()
+        return returnValue
+    }
+}


### PR DESCRIPTION
## Summary

- `applyMapping` writes `CapsLockDelayOverride=0` so the Hyper mapping fires without the macOS 15 Caps Lock press-duration threshold. `clearMapping` was only clearing `UserKeyMapping` — the `0` override persisted until the next reboot and leaked into system-wide Caps Lock behavior (input-source switching and other Caps Lock-based shortcuts became over-sensitive in unrelated apps).
- Write `CapsLockDelayOverride:100` back alongside `UserKeyMapping:[]`. hidutil has no "delete property" action, so an explicit write is the only reset path.
- Test added: records the hidutil arguments passed when `disable()` is called and asserts the JSON payload includes both the empty mapping and the default override.

Closes #159

## Default value

The user's note asked to confirm the macOS default via `hidutil property --get "CapsLockDelayOverride"`. Running that locally returns `0` on this dev machine because Quickey has previously enabled Hyper — the override persists until reboot. The factory default documented by the Karabiner-Elements and alt-tab-macos communities (and matching the "~100ms press-duration threshold" phrasing already in `applyMapping`'s comment) is `100`. Please confirm on a clean machine or after reboot before merge.

## Testing
- [x] `swift build`
- [x] `swift test` — 215 passed (214 + 1 new)

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Manual steps to verify on macOS:

1. Enable Hyper in Quickey.
2. Run `hidutil property --get "CapsLockDelayOverride"` → expect `0`.
3. Disable Hyper in Quickey (or quit the app if `clearMappingIfEnabled` is what runs).
4. Run `hidutil property --get "CapsLockDelayOverride"` again → expect `100` (no longer `0`).
5. Confirm that tapping Caps Lock outside Quickey again feels like the normal macOS behavior (input-source switch requires a normal press, not a micro-tap).
6. Re-enable Hyper and confirm Hyper-dependent shortcuts still fire on a short Caps Lock press.