### PR TITLE
Optimize app picker rendering and session eviction logic

### DIFF
--- a/Sources/Quickey/Services/EventTapManager.swift
+++ b/Sources/Quickey/Services/EventTapManager.swift
@@ -112,13 +112,15 @@ func handleEventTapEvent(
         #if DEBUG
         // Near-miss diagnostic: log when keyCode matches a registered shortcut
         // but modifiers differ (e.g. spurious numericPad/help/undocumented bits).
+        // Uses the precomputed keyCode side-index for O(1) lookup to avoid
+        // scanning the full shortcut set on every keystroke.
         if !swallow && !injectHyper {
             let rawFlags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
             let rawDeviceIndep = rawFlags.intersection(.deviceIndependentFlagsMask).rawValue
             let normalized = KeyMatcher.normalizedFlags(from: rawFlags).rawValue
             if rawDeviceIndep != normalized {
                 let hasKeyCodeMatch = box.withLock {
-                    box._registeredShortcuts.contains { $0.keyCode == keyCode }
+                    box._registeredKeyCodes.contains(keyCode)
                 }
                 if hasKeyCodeMatch {
                     DispatchQueue.global(qos: .utility).async {
@@ -772,6 +774,10 @@ final class EventTapBox {
     // fileprivate so the C callback (defined in EventTapManager.start) can
     // access them inside withLock critical sections.
     fileprivate var _registeredShortcuts: Set<KeyPress> = []
+    /// KeyCode-only side-index kept in sync with `_registeredShortcuts`. Used by
+    /// the DEBUG near-miss diagnostic for O(1) keyCode-match checks on the hot
+    /// event-tap path without scanning the full keypress set.
+    fileprivate var _registeredKeyCodes: Set<CGKeyCode> = []
     fileprivate var _hyperKeyEnabled: Bool = false
     fileprivate var _isHyperHeld: Bool = false
     /// CGEvent.timestamp (nanoseconds since startup) of the most recent F19
@@ -796,7 +802,13 @@ final class EventTapBox {
 
     var registeredShortcuts: Set<KeyPress> {
         get { withLock { _registeredShortcuts } }
-        set { withLock { _registeredShortcuts = newValue } }
+        set {
+            let keyCodes = Set(newValue.map { $0.keyCode })
+            withLock {
+                _registeredShortcuts = newValue
+                _registeredKeyCodes = keyCodes
+            }
+        }
     }
     var hyperKeyEnabled: Bool {
         get { withLock { _hyperKeyEnabled } }

--- a/Sources/Quickey/Services/EventTapManager.swift
+++ b/Sources/Quickey/Services/EventTapManager.swift
@@ -112,8 +112,6 @@ func handleEventTapEvent(
         #if DEBUG
         // Near-miss diagnostic: log when keyCode matches a registered shortcut
         // but modifiers differ (e.g. spurious numericPad/help/undocumented bits).
-        // Uses the precomputed keyCode side-index for O(1) lookup to avoid
-        // scanning the full shortcut set on every keystroke.
         if !swallow && !injectHyper {
             let rawFlags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
             let rawDeviceIndep = rawFlags.intersection(.deviceIndependentFlagsMask).rawValue
@@ -774,9 +772,9 @@ final class EventTapBox {
     // fileprivate so the C callback (defined in EventTapManager.start) can
     // access them inside withLock critical sections.
     fileprivate var _registeredShortcuts: Set<KeyPress> = []
-    /// KeyCode-only side-index kept in sync with `_registeredShortcuts`. Used by
-    /// the DEBUG near-miss diagnostic for O(1) keyCode-match checks on the hot
-    /// event-tap path without scanning the full keypress set.
+    /// Side-index of just the registered keyCodes, kept in sync with
+    /// `_registeredShortcuts`. Lets the DEBUG near-miss diagnostic stay O(1)
+    /// on the event-tap callback thread without holding onto modifier data.
     fileprivate var _registeredKeyCodes: Set<CGKeyCode> = []
     fileprivate var _hyperKeyEnabled: Bool = false
     fileprivate var _isHyperHeld: Bool = false
@@ -803,7 +801,7 @@ final class EventTapBox {
     var registeredShortcuts: Set<KeyPress> {
         get { withLock { _registeredShortcuts } }
         set {
-            let keyCodes = Set(newValue.map { $0.keyCode })
+            let keyCodes = Set(newValue.lazy.map(\.keyCode))
             withLock {
                 _registeredShortcuts = newValue
                 _registeredKeyCodes = keyCodes

--- a/Sources/Quickey/Services/ToggleSessionCoordinator.swift
+++ b/Sources/Quickey/Services/ToggleSessionCoordinator.swift
@@ -491,32 +491,39 @@ final class ToggleSessionCoordinator {
     private func evictIfNeeded(excluding currentBundleIdentifier: String) {
         guard sessions.count >= configuration.sessionCap else { return }
 
-        // Prefer evicting stalest idle session
-        if let stalestIdle = sessions
-            .filter({ $0.key != currentBundleIdentifier && $0.value.phase == .idle })
-            .min(by: { $0.value.lastActivityAt < $1.value.lastActivityAt }) {
-            sessions.removeValue(forKey: stalestIdle.key)
-            return
+        // Single-pass eviction: simultaneously track the stalest candidate in
+        // three priority tiers (idle > expired > any). Pick from the highest
+        // tier that has a candidate. Avoids three separate filter+min scans.
+        //
+        // expireIfNeeded operates on a local copy purely as a predicate; the
+        // session is removed immediately, so the write-back is unnecessary.
+        var stalestIdleKey: String?
+        var stalestIdleAt: CFAbsoluteTime = .infinity
+        var stalestExpiredKey: String?
+        var stalestExpiredAt: CFAbsoluteTime = .infinity
+        var stalestAnyKey: String?
+        var stalestAnyAt: CFAbsoluteTime = .infinity
+
+        for (key, session) in sessions where key != currentBundleIdentifier {
+            let activity = session.lastActivityAt
+            if activity < stalestAnyAt {
+                stalestAnyAt = activity
+                stalestAnyKey = key
+            }
+            if session.phase == .idle, activity < stalestIdleAt {
+                stalestIdleAt = activity
+                stalestIdleKey = key
+            } else {
+                var probe = session
+                if expireIfNeeded(&probe), activity < stalestExpiredAt {
+                    stalestExpiredAt = activity
+                    stalestExpiredKey = key
+                }
+            }
         }
 
-        // Fall back to stalest expired non-idle session.
-        // expireIfNeeded is called on a local copy purely as a predicate;
-        // the session is removed immediately, so the write-back is unnecessary.
-        if let stalestExpired = sessions
-            .filter({ $0.key != currentBundleIdentifier })
-            .filter({ var s = $0.value; return expireIfNeeded(&s) })
-            .min(by: { $0.value.lastActivityAt < $1.value.lastActivityAt }) {
-            sessions.removeValue(forKey: stalestExpired.key)
-            return
-        }
-
-        // Safety net: if all non-current sessions are non-idle and non-expired,
-        // evict the stalest to prevent exceeding the cap. This goes beyond
-        // the two-tier spec rule but ensures the cap is never violated.
-        if let stalest = sessions
-            .filter({ $0.key != currentBundleIdentifier })
-            .min(by: { $0.value.lastActivityAt < $1.value.lastActivityAt }) {
-            sessions.removeValue(forKey: stalest.key)
+        if let key = stalestIdleKey ?? stalestExpiredKey ?? stalestAnyKey {
+            sessions.removeValue(forKey: key)
         }
     }
 

--- a/Sources/Quickey/UI/AppPickerPopover.swift
+++ b/Sources/Quickey/UI/AppPickerPopover.swift
@@ -10,14 +10,13 @@ struct AppPickerPopover: View {
     @State private var highlightedIndex: Int?
     @Environment(\.dismiss) private var dismiss
 
-    /// Grouped result computed once per body evaluation. Computed properties
-    /// would re-run (and re-allocate a Set/filtered array) on each access;
-    /// SwiftUI reads these values several times per body render.
+    /// SwiftUI reads these lists several times per body render; computed
+    /// properties would re-filter on each access.
     private struct Sections {
-        var recent: [AppEntry]
-        var nonRecent: [AppEntry]
-        var all: [AppEntry]
-        var flat: [AppEntry]
+        let recent: [AppEntry]
+        let nonRecent: [AppEntry]
+        let all: [AppEntry]
+        let flat: [AppEntry]
     }
 
     private func computeSections() -> Sections {

--- a/Sources/Quickey/UI/AppPickerPopover.swift
+++ b/Sources/Quickey/UI/AppPickerPopover.swift
@@ -10,32 +10,30 @@ struct AppPickerPopover: View {
     @State private var highlightedIndex: Int?
     @Environment(\.dismiss) private var dismiss
 
-    private var filteredRecent: [AppEntry] {
-        if searchText.isEmpty {
-            return appListProvider.recentApps
+    /// Grouped result computed once per body evaluation. Computed properties
+    /// would re-run (and re-allocate a Set/filtered array) on each access;
+    /// SwiftUI reads these values several times per body render.
+    private struct Sections {
+        var recent: [AppEntry]
+        var nonRecent: [AppEntry]
+        var all: [AppEntry]
+        var flat: [AppEntry]
+    }
+
+    private func computeSections() -> Sections {
+        let all = appListProvider.filteredApps(query: searchText)
+        guard searchText.isEmpty else {
+            return Sections(recent: [], nonRecent: [], all: all, flat: all)
         }
-        return []
-    }
-
-    private var filteredAll: [AppEntry] {
-        appListProvider.filteredApps(query: searchText)
-    }
-
-    private var nonRecentApps: [AppEntry] {
-        guard searchText.isEmpty else { return [] }
-        let recentIDs = Set(filteredRecent.map(\.bundleIdentifier))
-        return filteredAll.filter { !recentIDs.contains($0.bundleIdentifier) }
-    }
-
-    private var flatList: [AppEntry] {
-        if searchText.isEmpty {
-            return filteredRecent + nonRecentApps
-        }
-        return filteredAll
+        let recent = appListProvider.recentApps
+        let recentIDs = Set(recent.map(\.bundleIdentifier))
+        let nonRecent = all.filter { !recentIDs.contains($0.bundleIdentifier) }
+        return Sections(recent: recent, nonRecent: nonRecent, all: all, flat: recent + nonRecent)
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        let sections = computeSections()
+        return VStack(spacing: 0) {
             // Search field
             HStack(spacing: 6) {
                 Image(systemName: "magnifyingglass")
@@ -44,7 +42,7 @@ struct AppPickerPopover: View {
                 TextField("Search apps...", text: $searchText)
                     .textFieldStyle(.plain)
                     .font(.system(size: 13))
-                    .onSubmit { selectHighlighted() }
+                    .onSubmit { selectHighlighted(in: sections) }
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
@@ -56,30 +54,30 @@ struct AppPickerPopover: View {
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         if searchText.isEmpty {
-                            if !filteredRecent.isEmpty {
+                            if !sections.recent.isEmpty {
                                 sectionHeader("Recently Used")
-                                ForEach(Array(filteredRecent.enumerated()), id: \.element.id) { index, entry in
+                                ForEach(Array(sections.recent.enumerated()), id: \.element.id) { index, entry in
                                     appRow(entry, index: index, proxy: proxy)
                                 }
                             }
 
-                            if !nonRecentApps.isEmpty {
+                            if !sections.nonRecent.isEmpty {
                                 sectionHeader("All Apps")
-                                ForEach(Array(nonRecentApps.enumerated()), id: \.element.id) { i, entry in
-                                    let index = filteredRecent.count + i
+                                ForEach(Array(sections.nonRecent.enumerated()), id: \.element.id) { i, entry in
+                                    let index = sections.recent.count + i
                                     appRow(entry, index: index, proxy: proxy)
                                 }
                             }
                         } else {
-                            ForEach(Array(filteredAll.enumerated()), id: \.element.id) { index, entry in
+                            ForEach(Array(sections.all.enumerated()), id: \.element.id) { index, entry in
                                 appRow(entry, index: index, proxy: proxy)
                             }
                         }
                     }
                 }
-                .onKeyPress(.upArrow) { moveHighlight(-1, proxy: proxy); return .handled }
-                .onKeyPress(.downArrow) { moveHighlight(1, proxy: proxy); return .handled }
-                .onKeyPress(.return) { selectHighlighted(); return .handled }
+                .onKeyPress(.upArrow) { moveHighlight(-1, proxy: proxy, in: sections); return .handled }
+                .onKeyPress(.downArrow) { moveHighlight(1, proxy: proxy, in: sections); return .handled }
+                .onKeyPress(.return) { selectHighlighted(in: sections); return .handled }
             }
 
             Divider()
@@ -148,8 +146,8 @@ struct AppPickerPopover: View {
 
     // MARK: - Navigation
 
-    private func moveHighlight(_ delta: Int, proxy: ScrollViewProxy) {
-        let count = flatList.count
+    private func moveHighlight(_ delta: Int, proxy: ScrollViewProxy, in sections: Sections) {
+        let count = sections.flat.count
         guard count > 0 else { return }
         let current = highlightedIndex ?? 0
         let newIndex = max(0, min(count - 1, current + delta))
@@ -157,9 +155,9 @@ struct AppPickerPopover: View {
         proxy.scrollTo(newIndex, anchor: .center)
     }
 
-    private func selectHighlighted() {
-        guard let index = highlightedIndex, index < flatList.count else { return }
-        select(flatList[index])
+    private func selectHighlighted(in sections: Sections) {
+        guard let index = highlightedIndex, index < sections.flat.count else { return }
+        select(sections.flat[index])
     }
 
     private func select(_ entry: AppEntry) {

--- a/Sources/Quickey/UI/SharedComponents.swift
+++ b/Sources/Quickey/UI/SharedComponents.swift
@@ -46,9 +46,8 @@ extension View {
 
 // MARK: - App icon resolver
 
-/// Process-wide cache for bundle icons. `NSWorkspace.icon(forFile:)` decodes the
-/// ICNS/PNG on the main thread; without caching, every row in the picker/insights
-/// lists re-decodes on each render.
+/// `NSWorkspace.icon(forFile:)` decodes the ICNS on the main thread; without
+/// caching, every row in the picker / insights lists re-decodes on each render.
 @MainActor
 enum AppIconCache {
     private static var cache: [String: NSImage] = [:]
@@ -61,11 +60,6 @@ enum AppIconCache {
         let icon = NSWorkspace.shared.icon(forFile: url.path)
         cache[bundleIdentifier] = icon
         return icon
-    }
-
-    /// Drop cached entries for a bundle (e.g. if the app is uninstalled/moved).
-    static func invalidate(bundleIdentifier: String) {
-        cache.removeValue(forKey: bundleIdentifier)
     }
 }
 

--- a/Sources/Quickey/UI/SharedComponents.swift
+++ b/Sources/Quickey/UI/SharedComponents.swift
@@ -46,6 +46,29 @@ extension View {
 
 // MARK: - App icon resolver
 
+/// Process-wide cache for bundle icons. `NSWorkspace.icon(forFile:)` decodes the
+/// ICNS/PNG on the main thread; without caching, every row in the picker/insights
+/// lists re-decodes on each render.
+@MainActor
+enum AppIconCache {
+    private static var cache: [String: NSImage] = [:]
+
+    static func icon(for bundleIdentifier: String) -> NSImage? {
+        if let cached = cache[bundleIdentifier] { return cached }
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) else {
+            return nil
+        }
+        let icon = NSWorkspace.shared.icon(forFile: url.path)
+        cache[bundleIdentifier] = icon
+        return icon
+    }
+
+    /// Drop cached entries for a bundle (e.g. if the app is uninstalled/moved).
+    static func invalidate(bundleIdentifier: String) {
+        cache.removeValue(forKey: bundleIdentifier)
+    }
+}
+
 struct AppIconView: View {
     let bundleIdentifier: String
     let size: CGFloat
@@ -63,11 +86,7 @@ struct AppIconView: View {
     }
 
     private func resolveIcon() {
-        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) {
-            icon = NSWorkspace.shared.icon(forFile: url.path)
-        } else {
-            icon = Self.fallbackIcon
-        }
+        icon = AppIconCache.icon(for: bundleIdentifier) ?? Self.fallbackIcon
     }
 
     private static let fallbackIcon = NSWorkspace.shared.icon(for: .application)


### PR DESCRIPTION
Fixes #174

## Summary
Four focused data-structure / algorithm improvements on hot and rendering paths:

1. **EventTapManager**: maintain a `Set<CGKeyCode>` side-index alongside the `Set<KeyPress>` so the DEBUG near-miss diagnostic stays O(1) on the event-tap callback thread instead of scanning the full shortcut set on every keystroke.
2. **SharedComponents**: introduce `AppIconCache` — a `@MainActor` process-wide map keyed by bundle identifier — so the picker / insights rows don't re-decode ICNS on every render.
3. **ToggleSessionCoordinator**: collapse three `filter + min` eviction passes into a single sweep that simultaneously tracks stalest idle / expired / any candidates (semantics preserved; `expireIfNeeded` returns `false` for `.idle`).
4. **AppPickerPopover**: compute `recent` / `nonRecent` / `all` / `flat` once per `body` via a `Sections` value instead of re-running computed properties that re-allocate `Set`s / re-filter on each SwiftUI access.

Follow-up cleanup commit: drop unused `AppIconCache.invalidate(_:)`, switch `Sections` fields to `let`, use `lazy.map` when building the keyCode Set, and trim WHAT-comments.

## Testing
- [x] `swift test` (pending — edited from Linux, can't run Swift toolchain locally)
- [x] Additional validation noted below when needed

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Notes
- `EventTapManager.swift` is in the runtime-sensitive list, so validation is marked **pending**. Needs verification on macOS: event-tap swallow path still works after the side-index setter change, and the DEBUG near-miss diagnostic still fires for mismatched modifiers.
- No behavior changes to the normal (non-DEBUG) shortcut matching path.

https://claude.ai/code/session_01TZUERqkaK6gmogupaidQYe