### PR TITLE
feat: auto-open settings on first launch (#177)

### DIFF
--- a/Sources/Quickey/AppController.swift
+++ b/Sources/Quickey/AppController.swift
@@ -49,15 +49,12 @@ final class AppController {
             isHyperEnabled: { hyperKeyService.isEnabled },
             setHyperKeyEnabled: { shortcutManager.setHyperKeyEnabled($0) },
             startShortcutManager: { shortcutManager.start() },
-            installMenuBar: { menuBarController.install() },
-            isFirstLaunch: { [userDefaults] in
-                !userDefaults.bool(forKey: Self.firstLaunchCompletedDefaultsKey)
-            },
-            markFirstLaunchComplete: { [userDefaults] in
-                userDefaults.set(true, forKey: Self.firstLaunchCompletedDefaultsKey)
-            },
-            openSettings: { [weak self] in self?.openSettings() }
+            installMenuBar: { menuBarController.install() }
         )
+
+        if Self.consumeFirstLaunchFlag(userDefaults: userDefaults) {
+            openSettings()
+        }
     }
 
     func stop() {
@@ -77,10 +74,7 @@ final class AppController {
         isHyperEnabled: @MainActor () -> Bool,
         setHyperKeyEnabled: @MainActor (Bool) -> Void,
         startShortcutManager: @MainActor () -> Void,
-        installMenuBar: @MainActor () -> Void,
-        isFirstLaunch: @MainActor () -> Bool,
-        markFirstLaunchComplete: @MainActor () -> Void,
-        openSettings: @MainActor () -> Void
+        installMenuBar: @MainActor () -> Void
     ) {
         do {
             replaceShortcuts(try loadShortcuts())
@@ -93,9 +87,13 @@ final class AppController {
         setHyperKeyEnabled(isHyperEnabled())
         startShortcutManager()
         installMenuBar()
-        if isFirstLaunch() {
-            openSettings()
-            markFirstLaunchComplete()
-        }
+    }
+
+    /// Returns true exactly once per install: marks the flag synchronously before
+    /// returning so a crash in the caller's follow-up work won't cause a re-prompt.
+    static func consumeFirstLaunchFlag(userDefaults: UserDefaults) -> Bool {
+        guard !userDefaults.bool(forKey: firstLaunchCompletedDefaultsKey) else { return false }
+        userDefaults.set(true, forKey: firstLaunchCompletedDefaultsKey)
+        return true
     }
 }

--- a/Sources/Quickey/AppController.swift
+++ b/Sources/Quickey/AppController.swift
@@ -52,7 +52,10 @@ final class AppController {
             installMenuBar: { menuBarController.install() }
         )
 
-        if Self.consumeFirstLaunchFlag(userDefaults: userDefaults) {
+        if Self.consumeFirstLaunchFlag(
+            userDefaults: userDefaults,
+            hasExistingShortcuts: !shortcutStore.shortcuts.isEmpty
+        ) {
             openSettings()
         }
     }
@@ -89,11 +92,16 @@ final class AppController {
         installMenuBar()
     }
 
-    /// Returns true exactly once per install: marks the flag synchronously before
-    /// returning so a crash in the caller's follow-up work won't cause a re-prompt.
-    static func consumeFirstLaunchFlag(userDefaults: UserDefaults) -> Bool {
+    /// Returns true exactly once per install, and only when no shortcuts exist yet.
+    /// Marks the flag synchronously so a crash in the caller's follow-up work won't
+    /// cause a re-prompt. Existing users upgrading from a pre-flag build (who already
+    /// have shortcuts) get silently marked as onboarded without seeing the prompt.
+    static func consumeFirstLaunchFlag(
+        userDefaults: UserDefaults,
+        hasExistingShortcuts: Bool
+    ) -> Bool {
         guard !userDefaults.bool(forKey: firstLaunchCompletedDefaultsKey) else { return false }
         userDefaults.set(true, forKey: firstLaunchCompletedDefaultsKey)
-        return true
+        return !hasExistingShortcuts
     }
 }

--- a/Sources/Quickey/AppController.swift
+++ b/Sources/Quickey/AppController.swift
@@ -3,10 +3,13 @@ import ApplicationServices
 
 @MainActor
 final class AppController {
+    static let firstLaunchCompletedDefaultsKey = "com.quickey.firstLaunchCompleted"
+
     private let shortcutStore = ShortcutStore()
     private let persistenceService = PersistenceService()
     private let usageTracker = UsageTracker()
     private let hyperKeyService = HyperKeyService()
+    private let userDefaults: UserDefaults
     private lazy var appSwitcher = AppSwitcher()
     private lazy var shortcutManager = ShortcutManager(
         shortcutStore: shortcutStore,
@@ -26,6 +29,10 @@ final class AppController {
         hyperKeyService: hyperKeyService
     )
 
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
     func start() {
         DiagnosticLog.rotateIfNeeded()
         DiagnosticLog.log("Quickey starting, version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?")")
@@ -42,7 +49,14 @@ final class AppController {
             isHyperEnabled: { hyperKeyService.isEnabled },
             setHyperKeyEnabled: { shortcutManager.setHyperKeyEnabled($0) },
             startShortcutManager: { shortcutManager.start() },
-            installMenuBar: { menuBarController.install() }
+            installMenuBar: { menuBarController.install() },
+            isFirstLaunch: { [userDefaults] in
+                !userDefaults.bool(forKey: Self.firstLaunchCompletedDefaultsKey)
+            },
+            markFirstLaunchComplete: { [userDefaults] in
+                userDefaults.set(true, forKey: Self.firstLaunchCompletedDefaultsKey)
+            },
+            openSettings: { [weak self] in self?.openSettings() }
         )
     }
 
@@ -63,7 +77,10 @@ final class AppController {
         isHyperEnabled: @MainActor () -> Bool,
         setHyperKeyEnabled: @MainActor (Bool) -> Void,
         startShortcutManager: @MainActor () -> Void,
-        installMenuBar: @MainActor () -> Void
+        installMenuBar: @MainActor () -> Void,
+        isFirstLaunch: @MainActor () -> Bool,
+        markFirstLaunchComplete: @MainActor () -> Void,
+        openSettings: @MainActor () -> Void
     ) {
         do {
             replaceShortcuts(try loadShortcuts())
@@ -76,5 +93,9 @@ final class AppController {
         setHyperKeyEnabled(isHyperEnabled())
         startShortcutManager()
         installMenuBar()
+        if isFirstLaunch() {
+            openSettings()
+            markFirstLaunchComplete()
+        }
     }
 }

--- a/Tests/QuickeyTests/AppControllerTests.swift
+++ b/Tests/QuickeyTests/AppControllerTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import Quickey
 
@@ -28,16 +29,6 @@ func startupSequenceAppliesPersistedHyperStateBeforeStartingShortcutManager() {
         },
         installMenuBar: {
             events.append("installMenuBar")
-        },
-        isFirstLaunch: {
-            events.append("isFirstLaunch")
-            return false
-        },
-        markFirstLaunchComplete: {
-            events.append("markFirstLaunchComplete")
-        },
-        openSettings: {
-            events.append("openSettings")
         }
     )
 
@@ -48,63 +39,17 @@ func startupSequenceAppliesPersistedHyperStateBeforeStartingShortcutManager() {
         "readHyperEnabled",
         "setHyper:true",
         "startShortcutManager",
-        "installMenuBar",
-        "isFirstLaunch"
+        "installMenuBar"
     ])
 }
 
-@Test @MainActor
-func startupSequenceOpensSettingsAndMarksCompleteOnFirstLaunch() {
-    var events: [String] = []
+@Test
+func consumeFirstLaunchFlagReturnsTrueOnceThenFalse() throws {
+    let suiteName = "AppControllerTests.firstLaunch.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
 
-    AppController.runStartupSequence(
-        loadShortcuts: { [] },
-        replaceShortcuts: { _ in },
-        reapplyHyperIfNeeded: {},
-        isHyperEnabled: { false },
-        setHyperKeyEnabled: { _ in },
-        startShortcutManager: {},
-        installMenuBar: {
-            events.append("installMenuBar")
-        },
-        isFirstLaunch: { true },
-        markFirstLaunchComplete: {
-            events.append("markFirstLaunchComplete")
-        },
-        openSettings: {
-            events.append("openSettings")
-        }
-    )
-
-    #expect(events == [
-        "installMenuBar",
-        "openSettings",
-        "markFirstLaunchComplete"
-    ])
-}
-
-@Test @MainActor
-func startupSequenceSkipsOpeningSettingsOnSubsequentLaunches() {
-    var openedSettings = false
-    var markedComplete = false
-
-    AppController.runStartupSequence(
-        loadShortcuts: { [] },
-        replaceShortcuts: { _ in },
-        reapplyHyperIfNeeded: {},
-        isHyperEnabled: { false },
-        setHyperKeyEnabled: { _ in },
-        startShortcutManager: {},
-        installMenuBar: {},
-        isFirstLaunch: { false },
-        markFirstLaunchComplete: {
-            markedComplete = true
-        },
-        openSettings: {
-            openedSettings = true
-        }
-    )
-
-    #expect(openedSettings == false)
-    #expect(markedComplete == false)
+    #expect(AppController.consumeFirstLaunchFlag(userDefaults: defaults) == true)
+    #expect(AppController.consumeFirstLaunchFlag(userDefaults: defaults) == false)
+    #expect(AppController.consumeFirstLaunchFlag(userDefaults: defaults) == false)
 }

--- a/Tests/QuickeyTests/AppControllerTests.swift
+++ b/Tests/QuickeyTests/AppControllerTests.swift
@@ -28,6 +28,16 @@ func startupSequenceAppliesPersistedHyperStateBeforeStartingShortcutManager() {
         },
         installMenuBar: {
             events.append("installMenuBar")
+        },
+        isFirstLaunch: {
+            events.append("isFirstLaunch")
+            return false
+        },
+        markFirstLaunchComplete: {
+            events.append("markFirstLaunchComplete")
+        },
+        openSettings: {
+            events.append("openSettings")
         }
     )
 
@@ -38,6 +48,63 @@ func startupSequenceAppliesPersistedHyperStateBeforeStartingShortcutManager() {
         "readHyperEnabled",
         "setHyper:true",
         "startShortcutManager",
-        "installMenuBar"
+        "installMenuBar",
+        "isFirstLaunch"
     ])
+}
+
+@Test @MainActor
+func startupSequenceOpensSettingsAndMarksCompleteOnFirstLaunch() {
+    var events: [String] = []
+
+    AppController.runStartupSequence(
+        loadShortcuts: { [] },
+        replaceShortcuts: { _ in },
+        reapplyHyperIfNeeded: {},
+        isHyperEnabled: { false },
+        setHyperKeyEnabled: { _ in },
+        startShortcutManager: {},
+        installMenuBar: {
+            events.append("installMenuBar")
+        },
+        isFirstLaunch: { true },
+        markFirstLaunchComplete: {
+            events.append("markFirstLaunchComplete")
+        },
+        openSettings: {
+            events.append("openSettings")
+        }
+    )
+
+    #expect(events == [
+        "installMenuBar",
+        "openSettings",
+        "markFirstLaunchComplete"
+    ])
+}
+
+@Test @MainActor
+func startupSequenceSkipsOpeningSettingsOnSubsequentLaunches() {
+    var openedSettings = false
+    var markedComplete = false
+
+    AppController.runStartupSequence(
+        loadShortcuts: { [] },
+        replaceShortcuts: { _ in },
+        reapplyHyperIfNeeded: {},
+        isHyperEnabled: { false },
+        setHyperKeyEnabled: { _ in },
+        startShortcutManager: {},
+        installMenuBar: {},
+        isFirstLaunch: { false },
+        markFirstLaunchComplete: {
+            markedComplete = true
+        },
+        openSettings: {
+            openedSettings = true
+        }
+    )
+
+    #expect(openedSettings == false)
+    #expect(markedComplete == false)
 }

--- a/Tests/QuickeyTests/AppControllerTests.swift
+++ b/Tests/QuickeyTests/AppControllerTests.swift
@@ -43,7 +43,7 @@ func startupSequenceAppliesPersistedHyperStateBeforeStartingShortcutManager() {
     ])
 }
 
-@Test
+@Test @MainActor
 func consumeFirstLaunchFlagReturnsTrueOnceThenFalse() throws {
     let suiteName = "AppControllerTests.firstLaunch.\(UUID().uuidString)"
     let defaults = try #require(UserDefaults(suiteName: suiteName))

--- a/Tests/QuickeyTests/AppControllerTests.swift
+++ b/Tests/QuickeyTests/AppControllerTests.swift
@@ -44,12 +44,21 @@ func startupSequenceAppliesPersistedHyperStateBeforeStartingShortcutManager() {
 }
 
 @Test @MainActor
-func consumeFirstLaunchFlagReturnsTrueOnceThenFalse() throws {
+func consumeFirstLaunchFlagReturnsTrueOnceForFreshInstall() throws {
     let suiteName = "AppControllerTests.firstLaunch.\(UUID().uuidString)"
     let defaults = try #require(UserDefaults(suiteName: suiteName))
     defer { defaults.removePersistentDomain(forName: suiteName) }
 
-    #expect(AppController.consumeFirstLaunchFlag(userDefaults: defaults) == true)
-    #expect(AppController.consumeFirstLaunchFlag(userDefaults: defaults) == false)
-    #expect(AppController.consumeFirstLaunchFlag(userDefaults: defaults) == false)
+    #expect(AppController.consumeFirstLaunchFlag(userDefaults: defaults, hasExistingShortcuts: false) == true)
+    #expect(AppController.consumeFirstLaunchFlag(userDefaults: defaults, hasExistingShortcuts: false) == false)
+}
+
+@Test @MainActor
+func consumeFirstLaunchFlagSilentlyMarksMigratingUsersOnboarded() throws {
+    let suiteName = "AppControllerTests.firstLaunch.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+
+    #expect(AppController.consumeFirstLaunchFlag(userDefaults: defaults, hasExistingShortcuts: true) == false)
+    #expect(AppController.consumeFirstLaunchFlag(userDefaults: defaults, hasExistingShortcuts: false) == false)
 }


### PR DESCRIPTION
Fixes #177

## Summary
- Auto-open the settings window the very first time Quickey launches, so new users see how to configure shortcuts instead of having to hunt for the menu bar icon.
- Persist a `com.quickey.firstLaunchCompleted` flag in `UserDefaults`; the flag is marked before opening so a crash in the window setup won't cause a re-prompt next launch.
- `AppController` exposes a `consumeFirstLaunchFlag(userDefaults:)` static helper, isolated from the UI side effect for testability.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Notes
- Touches `Sources/Quickey/AppController.swift` (runtime-sensitive).
- Manual macOS validation completed on April 20, 2026:
  - existing install with persisted `shortcuts.json` but no `com.quickey.firstLaunchCompleted` flag silently marked onboarding complete without opening Settings
  - fresh-install simulation with no persisted shortcuts opened Settings on first launch and did not reopen it on the second launch
  - `./scripts/package-app.sh` succeeded
  - `bash scripts/e2e-full-test.sh` passed in follow-up verification on the packaged app
