### PR TITLE
feat: 菜单栏下拉菜单展示所有已绑定快捷键

### DIFF
--- a/Sources/Quickey/AppController.swift
+++ b/Sources/Quickey/AppController.swift
@@ -17,7 +17,8 @@ final class AppController {
     )
     private lazy var menuBarController = MenuBarController(
         onOpenSettings: { [weak self] in self?.openSettings() },
-        onQuit: { NSApplication.shared.terminate(nil) }
+        onQuit: { NSApplication.shared.terminate(nil) },
+        shortcutStore: shortcutStore
     )
     private lazy var settingsWindowController = SettingsWindowController(
         shortcutStore: shortcutStore,

--- a/Sources/Quickey/UI/MenuBarController.swift
+++ b/Sources/Quickey/UI/MenuBarController.swift
@@ -181,7 +181,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func makeShortcutItem(from presentation: MenuBarShortcutItemPresentation) -> NSMenuItem {
-        let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        let item = NSMenuItem(title: shortcutItemTitle(for: presentation), action: nil, keyEquivalent: "")
         item.isEnabled = false
         item.view = MenuBarShortcutRowView(presentation: presentation)
         item.representedObject = MenuBarControllerMenuItemMarker.shortcutRow
@@ -210,6 +210,13 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         menu.items.forEach { $0.target = self }
         rebuildShortcutSection(in: menu, presentations: shortcutPresentations())
         return menu
+    }
+
+    private func shortcutItemTitle(for presentation: MenuBarShortcutItemPresentation) -> String {
+        if let statusText = presentation.statusText, !statusText.isEmpty {
+            return "\(presentation.titleText) (\(statusText))"
+        }
+        return presentation.titleText
     }
 
     private func refreshLaunchAtLoginItem() {

--- a/Sources/Quickey/UI/MenuBarController.swift
+++ b/Sources/Quickey/UI/MenuBarController.swift
@@ -168,6 +168,13 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         menu.insertItem(makeShortcutDivider(), at: insertionIndex)
     }
 
+    func shortcutPresentations() -> [MenuBarShortcutItemPresentation] {
+        MenuBarShortcutItemPresentation.build(
+            from: shortcutStore.shortcuts,
+            runningBundleIdentifiers: runningBundleIdentifiers()
+        )
+    }
+
     private func removeShortcutSection(from menu: NSMenu) {
         for item in menu.items.reversed() where isShortcutSectionItem(item) {
             menu.removeItem(item)

--- a/Sources/Quickey/UI/MenuBarController.swift
+++ b/Sources/Quickey/UI/MenuBarController.swift
@@ -114,7 +114,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
-        rebuildShortcutSection(in: menu, presentations: shortcutPresentations())
         menu.items.forEach { $0.target = self }
         statusItem.menu = menu
     }
@@ -148,7 +147,6 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     func menuWillOpen(_ menu: NSMenu) {
-        rebuildShortcutSection(in: menu, presentations: shortcutPresentations())
         refreshLaunchAtLoginItem()
     }
 
@@ -158,19 +156,16 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     ) {
         removeShortcutSection(from: menu)
 
+        guard !presentations.isEmpty else {
+            return
+        }
+
         var insertionIndex = 0
         for presentation in presentations {
             menu.insertItem(makeShortcutItem(from: presentation), at: insertionIndex)
             insertionIndex += 1
         }
         menu.insertItem(makeShortcutDivider(), at: insertionIndex)
-    }
-
-    private func shortcutPresentations() -> [MenuBarShortcutItemPresentation] {
-        MenuBarShortcutItemPresentation.build(
-            from: shortcutStore.shortcuts,
-            runningBundleIdentifiers: runningBundleIdentifiers()
-        )
     }
 
     private func removeShortcutSection(from menu: NSMenu) {

--- a/Sources/Quickey/UI/MenuBarController.swift
+++ b/Sources/Quickey/UI/MenuBarController.swift
@@ -1,5 +1,10 @@
 import AppKit
 
+enum MenuBarControllerMenuItemMarker {
+    static let shortcutRow = "quickey.menu-bar-controller.shortcut-row"
+    static let shortcutDivider = "quickey.menu-bar-controller.shortcut-divider"
+}
+
 enum MenuBarLaunchAtLoginToggleState: Equatable {
     case on
     case off
@@ -67,16 +72,24 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     private let onOpenSettings: () -> Void
     private let onQuit: () -> Void
     private let launchAtLoginService: LaunchAtLoginService
+    private let shortcutStore: ShortcutStore
+    private let runningBundleIdentifiers: @MainActor () -> Set<String>
     private var launchAtLoginItem: NSMenuItem?
 
     init(
         onOpenSettings: @escaping () -> Void,
         onQuit: @escaping () -> Void,
-        launchAtLoginService: LaunchAtLoginService = LaunchAtLoginService()
+        launchAtLoginService: LaunchAtLoginService = LaunchAtLoginService(),
+        shortcutStore: ShortcutStore = ShortcutStore(),
+        runningBundleIdentifiers: @escaping @MainActor () -> Set<String> = {
+            Set(NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier))
+        }
     ) {
         self.onOpenSettings = onOpenSettings
         self.onQuit = onQuit
         self.launchAtLoginService = launchAtLoginService
+        self.shortcutStore = shortcutStore
+        self.runningBundleIdentifiers = runningBundleIdentifiers
         super.init()
     }
 
@@ -101,6 +114,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
+        rebuildShortcutSection(in: menu, presentations: shortcutPresentations())
         menu.items.forEach { $0.target = self }
         statusItem.menu = menu
     }
@@ -134,7 +148,53 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     func menuWillOpen(_ menu: NSMenu) {
+        rebuildShortcutSection(in: menu, presentations: shortcutPresentations())
         refreshLaunchAtLoginItem()
+    }
+
+    func rebuildShortcutSection(
+        in menu: NSMenu,
+        presentations: [MenuBarShortcutItemPresentation]
+    ) {
+        removeShortcutSection(from: menu)
+
+        var insertionIndex = 0
+        for presentation in presentations {
+            menu.insertItem(makeShortcutItem(from: presentation), at: insertionIndex)
+            insertionIndex += 1
+        }
+        menu.insertItem(makeShortcutDivider(), at: insertionIndex)
+    }
+
+    private func shortcutPresentations() -> [MenuBarShortcutItemPresentation] {
+        MenuBarShortcutItemPresentation.build(
+            from: shortcutStore.shortcuts,
+            runningBundleIdentifiers: runningBundleIdentifiers()
+        )
+    }
+
+    private func removeShortcutSection(from menu: NSMenu) {
+        for item in menu.items.reversed() where isShortcutSectionItem(item) {
+            menu.removeItem(item)
+        }
+    }
+
+    private func isShortcutSectionItem(_ item: NSMenuItem) -> Bool {
+        (item.representedObject as? String) == MenuBarControllerMenuItemMarker.shortcutRow
+            || (item.representedObject as? String) == MenuBarControllerMenuItemMarker.shortcutDivider
+    }
+
+    private func makeShortcutItem(from presentation: MenuBarShortcutItemPresentation) -> NSMenuItem {
+        let item = NSMenuItem(title: presentation.titleText, action: nil, keyEquivalent: "")
+        item.isEnabled = presentation.isEnabled
+        item.representedObject = MenuBarControllerMenuItemMarker.shortcutRow
+        return item
+    }
+
+    private func makeShortcutDivider() -> NSMenuItem {
+        let item = NSMenuItem.separator()
+        item.representedObject = MenuBarControllerMenuItemMarker.shortcutDivider
+        return item
     }
 
     private func refreshLaunchAtLoginItem() {

--- a/Sources/Quickey/UI/MenuBarController.swift
+++ b/Sources/Quickey/UI/MenuBarController.swift
@@ -102,20 +102,13 @@ final class MenuBarController: NSObject, NSMenuDelegate {
             button.image?.size = NSSize(width: 18, height: 18)
         }
 
-        let menu = NSMenu()
-        menu.delegate = self
-        menu.addItem(NSMenuItem(title: "Settings", action: #selector(openSettings), keyEquivalent: ","))
-        menu.addItem(.separator())
+        statusItem.menu = makeInstalledMenu()
+    }
 
-        let loginItem = NSMenuItem(title: "Launch at Login", action: #selector(toggleLaunchAtLogin), keyEquivalent: "")
-        launchAtLoginItem = loginItem
-        menu.addItem(loginItem)
-        refreshLaunchAtLoginItem()
-
-        menu.addItem(.separator())
-        menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
-        menu.items.forEach { $0.target = self }
+    func installMenuForTesting() -> NSMenu {
+        let menu = makeInstalledMenu()
         statusItem.menu = menu
+        return menu
     }
 
     @objc
@@ -148,6 +141,7 @@ final class MenuBarController: NSObject, NSMenuDelegate {
 
     func menuWillOpen(_ menu: NSMenu) {
         refreshLaunchAtLoginItem()
+        rebuildShortcutSection(in: menu, presentations: shortcutPresentations())
     }
 
     func rebuildShortcutSection(
@@ -187,8 +181,9 @@ final class MenuBarController: NSObject, NSMenuDelegate {
     }
 
     private func makeShortcutItem(from presentation: MenuBarShortcutItemPresentation) -> NSMenuItem {
-        let item = NSMenuItem(title: presentation.titleText, action: nil, keyEquivalent: "")
-        item.isEnabled = presentation.isEnabled
+        let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        item.view = MenuBarShortcutRowView(presentation: presentation)
         item.representedObject = MenuBarControllerMenuItemMarker.shortcutRow
         return item
     }
@@ -197,6 +192,24 @@ final class MenuBarController: NSObject, NSMenuDelegate {
         let item = NSMenuItem.separator()
         item.representedObject = MenuBarControllerMenuItemMarker.shortcutDivider
         return item
+    }
+
+    private func makeInstalledMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.delegate = self
+        menu.addItem(NSMenuItem(title: "Settings", action: #selector(openSettings), keyEquivalent: ","))
+        menu.addItem(.separator())
+
+        let loginItem = NSMenuItem(title: "Launch at Login", action: #selector(toggleLaunchAtLogin), keyEquivalent: "")
+        launchAtLoginItem = loginItem
+        menu.addItem(loginItem)
+        refreshLaunchAtLoginItem()
+
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
+        menu.items.forEach { $0.target = self }
+        rebuildShortcutSection(in: menu, presentations: shortcutPresentations())
+        return menu
     }
 
     private func refreshLaunchAtLoginItem() {

--- a/Sources/Quickey/UI/MenuBarShortcutItemPresentation.swift
+++ b/Sources/Quickey/UI/MenuBarShortcutItemPresentation.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct MenuBarShortcutItemPresentation: Equatable {
+    let bundleIdentifier: String?
+    let titleText: String
+    let shortcutText: String?
+    let statusText: String?
+    let isEnabled: Bool
+    let isRunning: Bool
+    let isPlaceholder: Bool
+
+    static func build(
+        from shortcuts: [AppShortcut],
+        runningBundleIdentifiers: Set<String>
+    ) -> [MenuBarShortcutItemPresentation] {
+        guard !shortcuts.isEmpty else {
+            return [
+                MenuBarShortcutItemPresentation(
+                    bundleIdentifier: nil,
+                    titleText: "No shortcuts configured",
+                    shortcutText: nil,
+                    statusText: nil,
+                    isEnabled: false,
+                    isRunning: false,
+                    isPlaceholder: true
+                )
+            ]
+        }
+
+        return shortcuts.map { shortcut in
+            MenuBarShortcutItemPresentation(
+                bundleIdentifier: shortcut.bundleIdentifier,
+                titleText: shortcut.appName,
+                shortcutText: shortcut.displayText,
+                statusText: shortcut.isEnabled ? nil : "disabled",
+                isEnabled: shortcut.isEnabled,
+                isRunning: runningBundleIdentifiers.contains(shortcut.bundleIdentifier),
+                isPlaceholder: false
+            )
+        }
+    }
+}

--- a/Sources/Quickey/UI/MenuBarShortcutRowView.swift
+++ b/Sources/Quickey/UI/MenuBarShortcutRowView.swift
@@ -26,6 +26,10 @@ final class MenuBarShortcutRowView: NSView {
         NSSize(width: 320, height: 42)
     }
 
+    var renderedTitleColor: NSColor { titleLabel.textColor ?? .labelColor }
+    var renderedShortcutColor: NSColor { shortcutLabel.textColor ?? .secondaryLabelColor }
+    var renderedIconAlpha: CGFloat { iconView.alphaValue }
+
     private func setupView() {
         let leadingStack = NSStackView()
         leadingStack.orientation = .horizontal
@@ -101,6 +105,16 @@ final class MenuBarShortcutRowView: NSView {
         runningDot.isHidden = !presentation.isRunning
         shortcutLabel.stringValue = presentation.shortcutText ?? ""
         shortcutLabel.isHidden = presentation.shortcutText == nil
+
+        if presentation.isEnabled {
+            titleLabel.textColor = .labelColor
+            shortcutLabel.textColor = .secondaryLabelColor
+            iconView.alphaValue = 1.0
+        } else {
+            titleLabel.textColor = .disabledControlTextColor
+            shortcutLabel.textColor = .disabledControlTextColor
+            iconView.alphaValue = 0.5
+        }
 
         let icon = if let bundleIdentifier = presentation.bundleIdentifier {
             AppIconCache.icon(for: bundleIdentifier) ?? Self.fallbackIcon

--- a/Sources/Quickey/UI/MenuBarShortcutRowView.swift
+++ b/Sources/Quickey/UI/MenuBarShortcutRowView.swift
@@ -108,7 +108,7 @@ final class MenuBarShortcutRowView: NSView {
         titleLabel.stringValue = presentation.titleText
         statusLabel.stringValue = presentation.statusText ?? ""
         statusLabel.isHidden = presentation.statusText == nil
-        runningDot.isHidden = !presentation.isEnabled || !presentation.isRunning
+        runningDot.isHidden = !presentation.isRunning
         shortcutLabel.stringValue = presentation.shortcutText ?? ""
         shortcutLabel.isHidden = presentation.shortcutText == nil
 

--- a/Sources/Quickey/UI/MenuBarShortcutRowView.swift
+++ b/Sources/Quickey/UI/MenuBarShortcutRowView.swift
@@ -8,6 +8,7 @@ final class MenuBarShortcutRowView: NSView {
     private let statusLabel = NSTextField(labelWithString: "")
     private let runningDot = NSView()
     private let shortcutLabel = NSTextField(labelWithString: "")
+    private var usingFallbackIcon = false
 
     init(presentation: MenuBarShortcutItemPresentation) {
         self.presentation = presentation
@@ -29,6 +30,11 @@ final class MenuBarShortcutRowView: NSView {
     var renderedTitleColor: NSColor { titleLabel.textColor ?? .labelColor }
     var renderedShortcutColor: NSColor { shortcutLabel.textColor ?? .secondaryLabelColor }
     var renderedIconAlpha: CGFloat { iconView.alphaValue }
+    var renderedStatusColor: NSColor { statusLabel.textColor ?? .secondaryLabelColor }
+    var renderedStatusText: String { statusLabel.stringValue }
+    var isStatusLabelHidden: Bool { statusLabel.isHidden }
+    var isRunningDotHidden: Bool { runningDot.isHidden }
+    var isUsingFallbackIcon: Bool { usingFallbackIcon }
 
     private func setupView() {
         let leadingStack = NSStackView()
@@ -102,26 +108,29 @@ final class MenuBarShortcutRowView: NSView {
         titleLabel.stringValue = presentation.titleText
         statusLabel.stringValue = presentation.statusText ?? ""
         statusLabel.isHidden = presentation.statusText == nil
-        runningDot.isHidden = !presentation.isRunning
+        runningDot.isHidden = !presentation.isEnabled || !presentation.isRunning
         shortcutLabel.stringValue = presentation.shortcutText ?? ""
         shortcutLabel.isHidden = presentation.shortcutText == nil
 
         if presentation.isEnabled {
             titleLabel.textColor = .labelColor
+            statusLabel.textColor = .secondaryLabelColor
             shortcutLabel.textColor = .secondaryLabelColor
             iconView.alphaValue = 1.0
         } else {
             titleLabel.textColor = .disabledControlTextColor
+            statusLabel.textColor = .disabledControlTextColor
             shortcutLabel.textColor = .disabledControlTextColor
             iconView.alphaValue = 0.5
         }
 
-        let icon = if let bundleIdentifier = presentation.bundleIdentifier {
-            AppIconCache.icon(for: bundleIdentifier) ?? Self.fallbackIcon
+        let resolvedIcon = if let bundleIdentifier = presentation.bundleIdentifier {
+            AppIconCache.icon(for: bundleIdentifier)
         } else {
-            Self.fallbackIcon
+            nil
         }
-        iconView.image = icon
+        usingFallbackIcon = resolvedIcon == nil
+        iconView.image = resolvedIcon ?? Self.fallbackIcon
     }
 
     private static let fallbackIcon = NSWorkspace.shared.icon(for: .application)

--- a/Sources/Quickey/UI/MenuBarShortcutRowView.swift
+++ b/Sources/Quickey/UI/MenuBarShortcutRowView.swift
@@ -1,0 +1,114 @@
+import AppKit
+
+final class MenuBarShortcutRowView: NSView {
+    let presentation: MenuBarShortcutItemPresentation
+
+    private let iconView = NSImageView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let statusLabel = NSTextField(labelWithString: "")
+    private let runningDot = NSView()
+    private let shortcutLabel = NSTextField(labelWithString: "")
+
+    init(presentation: MenuBarShortcutItemPresentation) {
+        self.presentation = presentation
+        super.init(frame: NSRect(x: 0, y: 0, width: 320, height: 42))
+        translatesAutoresizingMaskIntoConstraints = false
+        setupView()
+        applyPresentation()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: 320, height: 42)
+    }
+
+    private func setupView() {
+        let leadingStack = NSStackView()
+        leadingStack.orientation = .horizontal
+        leadingStack.alignment = .centerY
+        leadingStack.spacing = 10
+        leadingStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let textStack = NSStackView()
+        textStack.orientation = .vertical
+        textStack.alignment = .leading
+        textStack.spacing = 2
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let titleRow = NSStackView()
+        titleRow.orientation = .horizontal
+        titleRow.alignment = .centerY
+        titleRow.spacing = 6
+        titleRow.translatesAutoresizingMaskIntoConstraints = false
+
+        iconView.translatesAutoresizingMaskIntoConstraints = false
+        iconView.imageScaling = .scaleProportionallyUpOrDown
+
+        titleLabel.font = .systemFont(ofSize: 13, weight: .medium)
+        titleLabel.cell?.lineBreakMode = .byTruncatingTail
+        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        runningDot.translatesAutoresizingMaskIntoConstraints = false
+        runningDot.wantsLayer = true
+        runningDot.layer?.backgroundColor = NSColor.systemGreen.cgColor
+        runningDot.layer?.cornerRadius = 3
+
+        statusLabel.font = .systemFont(ofSize: 11)
+        statusLabel.textColor = .secondaryLabelColor
+        statusLabel.cell?.lineBreakMode = .byTruncatingTail
+
+        shortcutLabel.font = .monospacedSystemFont(ofSize: 12, weight: .medium)
+        shortcutLabel.textColor = .secondaryLabelColor
+        shortcutLabel.alignment = .right
+        shortcutLabel.setContentHuggingPriority(.required, for: .horizontal)
+        shortcutLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        titleRow.addArrangedSubview(titleLabel)
+        titleRow.addArrangedSubview(runningDot)
+        textStack.addArrangedSubview(titleRow)
+        textStack.addArrangedSubview(statusLabel)
+
+        leadingStack.addArrangedSubview(iconView)
+        leadingStack.addArrangedSubview(textStack)
+
+        addSubview(leadingStack)
+        addSubview(shortcutLabel)
+
+        NSLayoutConstraint.activate([
+            iconView.widthAnchor.constraint(equalToConstant: 18),
+            iconView.heightAnchor.constraint(equalToConstant: 18),
+            runningDot.widthAnchor.constraint(equalToConstant: 6),
+            runningDot.heightAnchor.constraint(equalToConstant: 6),
+
+            leadingStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            leadingStack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            leadingStack.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: 8),
+            leadingStack.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -8),
+            shortcutLabel.leadingAnchor.constraint(greaterThanOrEqualTo: leadingStack.trailingAnchor, constant: 12),
+            shortcutLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            shortcutLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+
+    private func applyPresentation() {
+        titleLabel.stringValue = presentation.titleText
+        statusLabel.stringValue = presentation.statusText ?? ""
+        statusLabel.isHidden = presentation.statusText == nil
+        runningDot.isHidden = !presentation.isRunning
+        shortcutLabel.stringValue = presentation.shortcutText ?? ""
+        shortcutLabel.isHidden = presentation.shortcutText == nil
+
+        let icon = if let bundleIdentifier = presentation.bundleIdentifier {
+            AppIconCache.icon(for: bundleIdentifier) ?? Self.fallbackIcon
+        } else {
+            Self.fallbackIcon
+        }
+        iconView.image = icon
+    }
+
+    private static let fallbackIcon = NSWorkspace.shared.icon(for: .application)
+}

--- a/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
+++ b/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
@@ -91,10 +91,12 @@ struct MenuBarControllerShortcutMenuTests {
         #expect(firstRow.presentation.isRunning == true)
         #expect(firstRow.presentation.statusText == nil)
         #expect(firstRow.presentation.shortcutText == "⌃⌥S")
+        #expect(menu.items[0].title == "Safari")
         #expect(secondRow.presentation.titleText == "IINA")
         #expect(secondRow.presentation.isRunning == false)
         #expect(secondRow.presentation.statusText == "disabled")
         #expect(secondRow.presentation.shortcutText == "⌃⌥I")
+        #expect(menu.items[1].title == "IINA (disabled)")
     }
 
     @Test @MainActor
@@ -255,5 +257,30 @@ struct MenuBarControllerShortcutMenuTests {
         #expect(row.presentation.titleText == "Terminal")
         #expect(row.presentation.isRunning == true)
         #expect(row.presentation.shortcutText == "⌘T")
+    }
+
+    @Test @MainActor
+    func disabledShortcutRow_rendersMutedAppearanceAndSemanticTitle() {
+        let controller = MenuBarController(onOpenSettings: {}, onQuit: {})
+        let menu = NSMenu()
+        let presentation = MenuBarShortcutItemPresentation(
+            bundleIdentifier: "com.colliderli.iina",
+            titleText: "IINA",
+            shortcutText: "⌃⌥I",
+            statusText: "disabled",
+            isEnabled: false,
+            isRunning: false,
+            isPlaceholder: false
+        )
+
+        controller.rebuildShortcutSection(in: menu, presentations: [presentation])
+
+        let item = menu.items[0]
+        let row = try #require(item.view as? MenuBarShortcutRowView)
+
+        #expect(item.title == "IINA (disabled)")
+        #expect(row.renderedTitleColor != NSColor.labelColor)
+        #expect(row.renderedShortcutColor != NSColor.secondaryLabelColor)
+        #expect(row.renderedIconAlpha < 1.0)
     }
 }

--- a/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
+++ b/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
@@ -76,7 +76,7 @@ struct MenuBarControllerShortcutMenuTests {
     }
 
     @Test @MainActor
-    func rebuildShortcutSection_usesInjectedShortcutStoreDataWhenPresentationsAreBuiltFromIt() {
+    func shortcutPresentations_reflectInjectedShortcutStoreAndRunningBundleIdentifiers() {
         let store = ShortcutStore()
         store.replaceAll(with: [
             AppShortcut(
@@ -91,29 +91,16 @@ struct MenuBarControllerShortcutMenuTests {
             onOpenSettings: {},
             onQuit: {},
             shortcutStore: store,
-            runningBundleIdentifiers: { ["com.apple.Safari"] }
-        )
-        let menu = NSMenu()
-
-        menu.addItem(NSMenuItem(title: "Settings", action: nil, keyEquivalent: ","))
-        menu.addItem(.separator())
-        menu.addItem(NSMenuItem(title: "Launch at Login", action: nil, keyEquivalent: ""))
-        menu.addItem(.separator())
-        menu.addItem(NSMenuItem(title: "Quit", action: nil, keyEquivalent: "q"))
-
-        let presentations = MenuBarShortcutItemPresentation.build(
-            from: store.shortcuts,
-            runningBundleIdentifiers: ["com.apple.Safari"]
+            runningBundleIdentifiers: { ["com.apple.Safari", "com.apple.Terminal"] }
         )
 
-        controller.rebuildShortcutSection(in: menu, presentations: presentations)
+        let presentations = controller.shortcutPresentations()
 
-        #expect(menu.items[0].title == "Safari")
-        #expect((menu.items[0].representedObject as? String) == MenuBarControllerMenuItemMarker.shortcutRow)
-        #expect(menu.items[1].isSeparatorItem)
-        #expect((menu.items[1].representedObject as? String) == MenuBarControllerMenuItemMarker.shortcutDivider)
-        #expect(menu.items[2].title == "Settings")
-        #expect(menu.items[4].title == "Launch at Login")
-        #expect(menu.items[6].title == "Quit")
+        #expect(presentations.count == 1)
+        #expect(presentations[0].bundleIdentifier == "com.apple.Safari")
+        #expect(presentations[0].titleText == "Safari")
+        #expect(presentations[0].shortcutText == "⌃⌥S")
+        #expect(presentations[0].isRunning == true)
+        #expect(presentations[0].isEnabled == true)
     }
 }

--- a/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
+++ b/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
@@ -48,4 +48,72 @@ struct MenuBarControllerShortcutMenuTests {
         #expect(menu.items[5].isSeparatorItem)
         #expect(menu.items[6].title == "Quit")
     }
+
+    @Test @MainActor
+    func rebuildShortcutSection_removesExistingDynamicItemsWhenPresentationsAreEmpty() {
+        let controller = MenuBarController(onOpenSettings: {}, onQuit: {})
+        let menu = NSMenu()
+
+        menu.addItem(NSMenuItem(title: "Safari", action: nil, keyEquivalent: ""))
+        menu.items[0].representedObject = MenuBarControllerMenuItemMarker.shortcutRow
+        menu.addItem(.separator())
+        menu.items[1].representedObject = MenuBarControllerMenuItemMarker.shortcutDivider
+        menu.addItem(NSMenuItem(title: "Settings", action: nil, keyEquivalent: ","))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Launch at Login", action: nil, keyEquivalent: ""))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Quit", action: nil, keyEquivalent: "q"))
+
+        controller.rebuildShortcutSection(in: menu, presentations: [])
+
+        #expect(menu.items.count == 5)
+        #expect(menu.items[0].title == "Settings")
+        #expect(menu.items[1].isSeparatorItem)
+        #expect(menu.items[2].title == "Launch at Login")
+        #expect(menu.items[3].isSeparatorItem)
+        #expect(menu.items[4].title == "Quit")
+        #expect(menu.items.allSatisfy { ($0.representedObject as? String) == nil })
+    }
+
+    @Test @MainActor
+    func rebuildShortcutSection_usesInjectedShortcutStoreDataWhenPresentationsAreBuiltFromIt() {
+        let store = ShortcutStore()
+        store.replaceAll(with: [
+            AppShortcut(
+                appName: "Safari",
+                bundleIdentifier: "com.apple.Safari",
+                keyEquivalent: "s",
+                modifierFlags: ["control", "option"]
+            )
+        ])
+
+        let controller = MenuBarController(
+            onOpenSettings: {},
+            onQuit: {},
+            shortcutStore: store,
+            runningBundleIdentifiers: { ["com.apple.Safari"] }
+        )
+        let menu = NSMenu()
+
+        menu.addItem(NSMenuItem(title: "Settings", action: nil, keyEquivalent: ","))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Launch at Login", action: nil, keyEquivalent: ""))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Quit", action: nil, keyEquivalent: "q"))
+
+        let presentations = MenuBarShortcutItemPresentation.build(
+            from: store.shortcuts,
+            runningBundleIdentifiers: ["com.apple.Safari"]
+        )
+
+        controller.rebuildShortcutSection(in: menu, presentations: presentations)
+
+        #expect(menu.items[0].title == "Safari")
+        #expect((menu.items[0].representedObject as? String) == MenuBarControllerMenuItemMarker.shortcutRow)
+        #expect(menu.items[1].isSeparatorItem)
+        #expect((menu.items[1].representedObject as? String) == MenuBarControllerMenuItemMarker.shortcutDivider)
+        #expect(menu.items[2].title == "Settings")
+        #expect(menu.items[4].title == "Launch at Login")
+        #expect(menu.items[6].title == "Quit")
+    }
 }

--- a/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
+++ b/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
@@ -5,6 +5,99 @@ import Testing
 @Suite("Menu bar controller shortcut menu")
 struct MenuBarControllerShortcutMenuTests {
     @Test @MainActor
+    func installMenuForTesting_buildsDynamicRowsAboveStaticSection() {
+        let store = ShortcutStore()
+        store.replaceAll(with: [
+            AppShortcut(
+                appName: "Safari",
+                bundleIdentifier: "com.apple.Safari",
+                keyEquivalent: "s",
+                modifierFlags: ["control", "option"]
+            )
+        ])
+
+        let controller = MenuBarController(
+            onOpenSettings: {},
+            onQuit: {},
+            shortcutStore: store,
+            runningBundleIdentifiers: { ["com.apple.Safari"] }
+        )
+
+        let menu = controller.installMenuForTesting()
+        let row = try #require(menu.items[0].view as? MenuBarShortcutRowView)
+
+        #expect(menu.items.count == 7)
+        #expect(row.presentation.titleText == "Safari")
+        #expect(menu.items[1].isSeparatorItem)
+        #expect(menu.items[2].title == "Settings")
+        #expect(menu.items[4].title == "Launch at Login")
+        #expect(menu.items[6].title == "Quit")
+    }
+
+    @Test @MainActor
+    func menuWillOpen_rebuildsCustomShortcutRowsFromInjectedStoreAndRunningBundles() {
+        let store = ShortcutStore()
+        store.replaceAll(with: [
+            AppShortcut(
+                appName: "Safari",
+                bundleIdentifier: "com.apple.Safari",
+                keyEquivalent: "s",
+                modifierFlags: ["control", "option"]
+            ),
+            AppShortcut(
+                appName: "IINA",
+                bundleIdentifier: "com.colliderli.iina",
+                keyEquivalent: "i",
+                modifierFlags: ["control", "option"],
+                isEnabled: false
+            )
+        ])
+
+        let controller = MenuBarController(
+            onOpenSettings: {},
+            onQuit: {},
+            shortcutStore: store,
+            runningBundleIdentifiers: { ["com.apple.Safari"] }
+        )
+        let menu = NSMenu()
+
+        menu.addItem(NSMenuItem(title: "Settings", action: nil, keyEquivalent: ","))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Launch at Login", action: nil, keyEquivalent: ""))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Quit", action: nil, keyEquivalent: "q"))
+
+        controller.menuWillOpen(menu)
+
+        let shortcutRows = menu.items.filter {
+            ($0.representedObject as? String) == MenuBarControllerMenuItemMarker.shortcutRow
+        }
+
+        #expect(shortcutRows.count == 2)
+        #expect(menu.items.count == 8)
+        #expect(menu.items[0].view is MenuBarShortcutRowView)
+        #expect(menu.items[1].view is MenuBarShortcutRowView)
+        #expect(menu.items[2].isSeparatorItem)
+        #expect(menu.items[3].title == "Settings")
+        #expect(menu.items[4].isSeparatorItem)
+        #expect(menu.items[5].title == "Launch at Login")
+        #expect(menu.items[6].isSeparatorItem)
+        #expect(menu.items[7].title == "Quit")
+
+        let firstRow = try #require(menu.items[0].view as? MenuBarShortcutRowView)
+        let secondRow = try #require(menu.items[1].view as? MenuBarShortcutRowView)
+
+        #expect(firstRow.presentation.titleText == "Safari")
+        #expect(firstRow.presentation.isRunning == true)
+        #expect(firstRow.presentation.statusText == nil)
+        #expect(firstRow.presentation.shortcutText == "⌃⌥S")
+        #expect(secondRow.presentation.titleText == "IINA")
+        #expect(secondRow.presentation.isRunning == false)
+        #expect(secondRow.presentation.statusText == "disabled")
+        #expect(secondRow.presentation.shortcutText == "⌃⌥I")
+    }
+
+    @Test @MainActor
     func rebuildShortcutSection_replacesPreviousDynamicSectionAndPreservesStaticItems() {
         let controller = MenuBarController(onOpenSettings: {}, onQuit: {})
         let menu = NSMenu()
@@ -40,13 +133,16 @@ struct MenuBarControllerShortcutMenuTests {
         #expect(shortcutRowMarkers.count == 1)
         #expect(shortcutDividerMarkers.count == 1)
         #expect(menu.items.count == 7)
-        #expect(menu.items[0].title == "Safari")
+        #expect(menu.items[0].view is MenuBarShortcutRowView)
         #expect(menu.items[1].isSeparatorItem)
         #expect(menu.items[2].title == "Settings")
         #expect(menu.items[3].isSeparatorItem)
         #expect(menu.items[4].title == "Launch at Login")
         #expect(menu.items[5].isSeparatorItem)
         #expect(menu.items[6].title == "Quit")
+
+        let row = try #require(menu.items[0].view as? MenuBarShortcutRowView)
+        #expect(row.presentation.titleText == "Safari")
     }
 
     @Test @MainActor
@@ -102,5 +198,62 @@ struct MenuBarControllerShortcutMenuTests {
         #expect(presentations[0].shortcutText == "⌃⌥S")
         #expect(presentations[0].isRunning == true)
         #expect(presentations[0].isEnabled == true)
+    }
+
+    @Test @MainActor
+    func menuWillOpen_replacesPreviousDynamicRowsDeterministicallyAcrossRepeatedOpens() {
+        let store = ShortcutStore()
+        store.replaceAll(with: [
+            AppShortcut(
+                appName: "Safari",
+                bundleIdentifier: "com.apple.Safari",
+                keyEquivalent: "s",
+                modifierFlags: ["control", "option"]
+            )
+        ])
+
+        var runningBundles: Set<String> = ["com.apple.Safari"]
+        let controller = MenuBarController(
+            onOpenSettings: {},
+            onQuit: {},
+            shortcutStore: store,
+            runningBundleIdentifiers: { runningBundles }
+        )
+        let menu = NSMenu()
+
+        menu.addItem(NSMenuItem(title: "Settings", action: nil, keyEquivalent: ","))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Launch at Login", action: nil, keyEquivalent: ""))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Quit", action: nil, keyEquivalent: "q"))
+
+        controller.menuWillOpen(menu)
+
+        store.replaceAll(with: [
+            AppShortcut(
+                appName: "Terminal",
+                bundleIdentifier: "com.apple.Terminal",
+                keyEquivalent: "t",
+                modifierFlags: ["command"]
+            )
+        ])
+        runningBundles = ["com.apple.Terminal"]
+
+        controller.menuWillOpen(menu)
+
+        let shortcutRows = menu.items.filter {
+            ($0.representedObject as? String) == MenuBarControllerMenuItemMarker.shortcutRow
+        }
+        let shortcutDividers = menu.items.filter {
+            ($0.representedObject as? String) == MenuBarControllerMenuItemMarker.shortcutDivider
+        }
+        let row = try #require(menu.items[0].view as? MenuBarShortcutRowView)
+
+        #expect(shortcutRows.count == 1)
+        #expect(shortcutDividers.count == 1)
+        #expect(menu.items.count == 7)
+        #expect(row.presentation.titleText == "Terminal")
+        #expect(row.presentation.isRunning == true)
+        #expect(row.presentation.shortcutText == "⌘T")
     }
 }

--- a/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
+++ b/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
@@ -1,0 +1,51 @@
+import AppKit
+import Testing
+@testable import Quickey
+
+@Suite("Menu bar controller shortcut menu")
+struct MenuBarControllerShortcutMenuTests {
+    @Test @MainActor
+    func rebuildShortcutSection_replacesPreviousDynamicSectionAndPreservesStaticItems() {
+        let controller = MenuBarController(onOpenSettings: {}, onQuit: {})
+        let menu = NSMenu()
+
+        menu.addItem(NSMenuItem(title: "Settings", action: nil, keyEquivalent: ","))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Launch at Login", action: nil, keyEquivalent: ""))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Quit", action: nil, keyEquivalent: "q"))
+
+        let presentations = [
+            MenuBarShortcutItemPresentation(
+                bundleIdentifier: "com.apple.Safari",
+                titleText: "Safari",
+                shortcutText: "⌃⌥S",
+                statusText: nil,
+                isEnabled: true,
+                isRunning: true,
+                isPlaceholder: false
+            )
+        ]
+
+        controller.rebuildShortcutSection(in: menu, presentations: presentations)
+        controller.rebuildShortcutSection(in: menu, presentations: presentations)
+
+        let shortcutRowMarkers = menu.items.filter {
+            ($0.representedObject as? String) == MenuBarControllerMenuItemMarker.shortcutRow
+        }
+        let shortcutDividerMarkers = menu.items.filter {
+            ($0.representedObject as? String) == MenuBarControllerMenuItemMarker.shortcutDivider
+        }
+
+        #expect(shortcutRowMarkers.count == 1)
+        #expect(shortcutDividerMarkers.count == 1)
+        #expect(menu.items.count == 7)
+        #expect(menu.items[0].title == "Safari")
+        #expect(menu.items[1].isSeparatorItem)
+        #expect(menu.items[2].title == "Settings")
+        #expect(menu.items[3].isSeparatorItem)
+        #expect(menu.items[4].title == "Launch at Login")
+        #expect(menu.items[5].isSeparatorItem)
+        #expect(menu.items[6].title == "Quit")
+    }
+}

--- a/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
+++ b/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
@@ -288,7 +288,7 @@ struct MenuBarControllerShortcutMenuTests {
     }
 
     @Test @MainActor
-    func disabledRunningShortcutRow_suppressesBrightRunningIndicatorAndUsesFallbackIconWhenNeeded() {
+    func disabledRunningShortcutRow_keepsRunningIndicatorVisibleAndUsesFallbackIconWhenNeeded() {
         let controller = MenuBarController(onOpenSettings: {}, onQuit: {})
         let menu = NSMenu()
         let presentation = MenuBarShortcutItemPresentation(
@@ -305,7 +305,7 @@ struct MenuBarControllerShortcutMenuTests {
 
         let row = try #require(menu.items[0].view as? MenuBarShortcutRowView)
 
-        #expect(row.isRunningDotHidden == true)
+        #expect(row.isRunningDotHidden == false)
         #expect(row.isUsingFallbackIcon == true)
     }
 }

--- a/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
+++ b/Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
@@ -282,5 +282,30 @@ struct MenuBarControllerShortcutMenuTests {
         #expect(row.renderedTitleColor != NSColor.labelColor)
         #expect(row.renderedShortcutColor != NSColor.secondaryLabelColor)
         #expect(row.renderedIconAlpha < 1.0)
+        #expect(row.renderedStatusText == "disabled")
+        #expect(row.isStatusLabelHidden == false)
+        #expect(row.renderedStatusColor != NSColor.secondaryLabelColor)
+    }
+
+    @Test @MainActor
+    func disabledRunningShortcutRow_suppressesBrightRunningIndicatorAndUsesFallbackIconWhenNeeded() {
+        let controller = MenuBarController(onOpenSettings: {}, onQuit: {})
+        let menu = NSMenu()
+        let presentation = MenuBarShortcutItemPresentation(
+            bundleIdentifier: "invalid.bundle.identifier",
+            titleText: "Missing App",
+            shortcutText: "⌘M",
+            statusText: "disabled",
+            isEnabled: false,
+            isRunning: true,
+            isPlaceholder: false
+        )
+
+        controller.rebuildShortcutSection(in: menu, presentations: [presentation])
+
+        let row = try #require(menu.items[0].view as? MenuBarShortcutRowView)
+
+        #expect(row.isRunningDotHidden == true)
+        #expect(row.isUsingFallbackIcon == true)
     }
 }

--- a/Tests/QuickeyTests/MenuBarShortcutItemPresentationTests.swift
+++ b/Tests/QuickeyTests/MenuBarShortcutItemPresentationTests.swift
@@ -1,0 +1,45 @@
+import Testing
+@testable import Quickey
+
+@Suite("MenuBar shortcut item presentation")
+struct MenuBarShortcutItemPresentationTests {
+    @Test
+    func preservesShortcutOrderAndMarksRunningBundles() {
+        let shortcuts = [
+            AppShortcut(
+                appName: "Safari",
+                bundleIdentifier: "com.apple.Safari",
+                keyEquivalent: "s",
+                modifierFlags: ["control", "option"]
+            ),
+            AppShortcut(
+                appName: "IINA",
+                bundleIdentifier: "com.colliderli.iina",
+                keyEquivalent: "i",
+                modifierFlags: ["control", "option"],
+                isEnabled: false
+            )
+        ]
+
+        let presentations = MenuBarShortcutItemPresentation.build(
+            from: shortcuts,
+            runningBundleIdentifiers: ["com.apple.Safari"]
+        )
+
+        #expect(presentations.map(\.titleText) == ["Safari", "IINA"])
+        #expect(presentations.map(\.isRunning) == [true, false])
+        #expect(presentations.map(\.statusText) == [nil, "disabled"])
+    }
+
+    @Test
+    func returnsPlaceholderWhenShortcutListIsEmpty() {
+        let presentations = MenuBarShortcutItemPresentation.build(
+            from: [],
+            runningBundleIdentifiers: []
+        )
+
+        #expect(presentations.count == 1)
+        #expect(presentations[0].isPlaceholder == true)
+        #expect(presentations[0].titleText == "No shortcuts configured")
+    }
+}

--- a/docs/superpowers/plans/2026-04-18-menu-bar-shortcut-list.md
+++ b/docs/superpowers/plans/2026-04-18-menu-bar-shortcut-list.md
@@ -1,0 +1,469 @@
+# Menu Bar Shortcut List Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show every saved Quickey shortcut at the top of the menu bar dropdown as a read-only custom row with app icon, app name, running-state dot, disabled marker, and shortcut text, while keeping the existing static menu items intact.
+
+**Architecture:** Keep `MenuBarController` as the single owner of the AppKit menu, but split the new feature into a small presentation builder plus a dedicated custom row view. Rebuild the dynamic shortcut section on each `menuWillOpen(_:)` from `ShortcutStore.shortcuts` and a one-shot running-bundle snapshot, mark dynamic items so they can be removed deterministically, and leave `Settings`, `Launch at Login`, and `Quit` below a dedicated divider.
+
+**Tech Stack:** Swift 6, AppKit, `NSMenu` / `NSMenuItem`, `NSWorkspace`, Swift Testing
+
+---
+
+## Inputs
+
+- Spec: [2026-04-18-menu-bar-shortcut-list-design.md](/home/yvan/developer/Quickey/docs/superpowers/specs/2026-04-18-menu-bar-shortcut-list-design.md)
+- Existing menu owner: [MenuBarController.swift](/home/yvan/developer/Quickey/Sources/Quickey/UI/MenuBarController.swift)
+- Startup wiring: [AppController.swift](/home/yvan/developer/Quickey/Sources/Quickey/AppController.swift)
+- Existing menu tests: [MenuBarLaunchAtLoginPresentationTests.swift](/home/yvan/developer/Quickey/Tests/QuickeyTests/MenuBarLaunchAtLoginPresentationTests.swift)
+
+## File Map
+
+**Create:**
+
+- `Sources/Quickey/UI/MenuBarShortcutItemPresentation.swift`
+  Purpose: convert `AppShortcut` plus a running-bundle snapshot into deterministic menu-row presentation data, including the empty placeholder row.
+- `Sources/Quickey/UI/MenuBarShortcutRowView.swift`
+  Purpose: render the compact custom AppKit row used inside `NSMenuItem.view`.
+- `Tests/QuickeyTests/MenuBarShortcutItemPresentationTests.swift`
+  Purpose: lock down ordering, running-dot semantics, disabled labeling, and empty-state behavior.
+- `Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift`
+  Purpose: lock down dynamic-section rebuild behavior, duplicate prevention, and the `menuWillOpen(_:)` refresh path.
+
+**Modify:**
+
+- `Sources/Quickey/UI/MenuBarController.swift`
+  Purpose: inject `ShortcutStore`, compute running bundles on open, rebuild the dynamic section, and keep the existing static actions stable below the shortcut section.
+- `Sources/Quickey/AppController.swift`
+  Purpose: pass the shared `ShortcutStore` into `MenuBarController` so the menu can read the saved shortcut list.
+
+## Constraints To Preserve
+
+- Dynamic shortcut rows are informational only; they must not trigger app switching or settings actions.
+- Shortcut order must match `ShortcutStore.shortcuts`; do not add a second sorting rule.
+- The green dot means “at least one running instance exists for this bundle,” not “frontmost” or “Quickey owns the activation.”
+- Disabled shortcuts stay visible with muted styling plus an explicit `disabled` label.
+- Repeated menu opens must not accumulate duplicate dynamic rows or duplicate dividers.
+- AppKit layout and icon rendering must be manually validated on macOS before claiming completion; Linux-only inspection is insufficient.
+
+## Task Plan
+
+### Task 1: Freeze The Shortcut Row Presentation Rules
+
+**Files:**
+
+- Create: `Sources/Quickey/UI/MenuBarShortcutItemPresentation.swift`
+- Create: `Tests/QuickeyTests/MenuBarShortcutItemPresentationTests.swift`
+- Reference: `Sources/Quickey/Models/AppShortcut.swift`
+- Reference: `Sources/Quickey/Models/RecordedShortcut.swift`
+
+- [ ] **Step 1: Write the failing presentation tests**
+
+Create `Tests/QuickeyTests/MenuBarShortcutItemPresentationTests.swift` with a focused `@Suite` that verifies:
+
+```swift
+import Testing
+@testable import Quickey
+
+@Suite("MenuBar shortcut item presentation")
+struct MenuBarShortcutItemPresentationTests {
+    @Test
+    func preservesShortcutOrderAndMarksRunningBundles() {
+        let shortcuts = [
+            AppShortcut(appName: "Safari", bundleIdentifier: "com.apple.Safari", keyEquivalent: "s", modifierFlags: ["control", "option"]),
+            AppShortcut(appName: "IINA", bundleIdentifier: "com.colliderli.iina", keyEquivalent: "i", modifierFlags: ["control", "option"], isEnabled: false),
+        ]
+
+        let presentations = MenuBarShortcutItemPresentation.build(
+            from: shortcuts,
+            runningBundleIdentifiers: ["com.apple.Safari"]
+        )
+
+        #expect(presentations.map(\.titleText) == ["Safari", "IINA"])
+        #expect(presentations.map(\.isRunning) == [true, false])
+        #expect(presentations.map(\.statusText) == [nil, "disabled"])
+    }
+
+    @Test
+    func returnsPlaceholderWhenShortcutListIsEmpty() {
+        let presentations = MenuBarShortcutItemPresentation.build(
+            from: [],
+            runningBundleIdentifiers: []
+        )
+
+        #expect(presentations.count == 1)
+        #expect(presentations[0].isPlaceholder == true)
+        #expect(presentations[0].titleText == "No shortcuts configured")
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run on a macOS host:
+
+```bash
+swift test --filter MenuBarShortcutItemPresentationTests
+```
+
+Expected: FAIL because `MenuBarShortcutItemPresentation` and its `build` helper do not exist yet.
+
+- [ ] **Step 3: Write the minimal presentation builder**
+
+Create `Sources/Quickey/UI/MenuBarShortcutItemPresentation.swift`:
+
+```swift
+import Foundation
+
+struct MenuBarShortcutItemPresentation: Equatable {
+    let bundleIdentifier: String?
+    let titleText: String
+    let shortcutText: String?
+    let statusText: String?
+    let isEnabled: Bool
+    let isRunning: Bool
+    let isPlaceholder: Bool
+
+    static func build(
+        from shortcuts: [AppShortcut],
+        runningBundleIdentifiers: Set<String>
+    ) -> [MenuBarShortcutItemPresentation] {
+        guard !shortcuts.isEmpty else {
+            return [
+                MenuBarShortcutItemPresentation(
+                    bundleIdentifier: nil,
+                    titleText: "No shortcuts configured",
+                    shortcutText: nil,
+                    statusText: nil,
+                    isEnabled: false,
+                    isRunning: false,
+                    isPlaceholder: true
+                )
+            ]
+        }
+
+        return shortcuts.map { shortcut in
+            MenuBarShortcutItemPresentation(
+                bundleIdentifier: shortcut.bundleIdentifier,
+                titleText: shortcut.appName,
+                shortcutText: shortcut.displayText,
+                statusText: shortcut.isEnabled ? nil : "disabled",
+                isEnabled: shortcut.isEnabled,
+                isRunning: runningBundleIdentifiers.contains(shortcut.bundleIdentifier),
+                isPlaceholder: false
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run on a macOS host:
+
+```bash
+swift test --filter MenuBarShortcutItemPresentationTests
+```
+
+Expected: PASS. If you are implementing from Linux and cannot run the macOS-targeted test suite, record this verification as pending instead of claiming success.
+
+- [ ] **Step 5: Commit the presentation-model checkpoint**
+
+```bash
+git add Sources/Quickey/UI/MenuBarShortcutItemPresentation.swift Tests/QuickeyTests/MenuBarShortcutItemPresentationTests.swift
+git commit -m "test: add menu bar shortcut presentation rules"
+```
+
+### Task 2: Freeze Dynamic Section Rebuild Behavior
+
+**Files:**
+
+- Create: `Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift`
+- Modify: `Sources/Quickey/UI/MenuBarController.swift`
+- Reference: `Sources/Quickey/UI/MenuBarShortcutItemPresentation.swift`
+
+- [ ] **Step 1: Write the failing menu-composition tests**
+
+Create `Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift` with a `@MainActor` suite that builds a local `NSMenu`, seeds the existing static items, and asserts that rebuilding the shortcut section is deterministic:
+
+```swift
+import AppKit
+import Testing
+@testable import Quickey
+
+@Suite("MenuBarController shortcut section")
+struct MenuBarControllerShortcutMenuTests {
+    @Test @MainActor
+    func rebuildShortcutSectionInsertsRowsAboveStaticItemsWithoutDuplication() {
+        let controller = MenuBarController(
+            shortcutStore: ShortcutStore(),
+            onOpenSettings: {},
+            onQuit: {},
+            runningBundleIdentifiers: { [] }
+        )
+
+        let menu = NSMenu()
+        menu.addItem(NSMenuItem(title: "Settings", action: nil, keyEquivalent: ""))
+        let loginItem = NSMenuItem(title: "Launch at Login", action: nil, keyEquivalent: "")
+        menu.addItem(loginItem)
+        menu.addItem(NSMenuItem(title: "Quit", action: nil, keyEquivalent: ""))
+
+        let presentations = [
+            MenuBarShortcutItemPresentation(
+                bundleIdentifier: "com.apple.Safari",
+                titleText: "Safari",
+                shortcutText: "⌃⌥S",
+                statusText: nil,
+                isEnabled: true,
+                isRunning: true,
+                isPlaceholder: false
+            )
+        ]
+
+        controller.rebuildShortcutSection(in: menu, presentations: presentations)
+        controller.rebuildShortcutSection(in: menu, presentations: presentations)
+
+        #expect(menu.items.filter { $0.representedObject as? String == MenuBarController.shortcutRowMarker }.count == 1)
+        #expect(menu.items.filter { $0.representedObject as? String == MenuBarController.shortcutDividerMarker }.count == 1)
+        #expect(menu.items.last?.title == "Quit")
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run on a macOS host:
+
+```bash
+swift test --filter MenuBarControllerShortcutMenuTests
+```
+
+Expected: FAIL because `MenuBarController` does not yet accept `ShortcutStore`, expose running-bundle injection, or provide rebuild markers/helpers.
+
+- [ ] **Step 3: Implement deterministic section rebuild**
+
+Modify `Sources/Quickey/UI/MenuBarController.swift` so it:
+
+- accepts `shortcutStore: ShortcutStore`
+- accepts `runningBundleIdentifiers: @escaping @MainActor () -> Set<String>` with a live default using `NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier)`
+- defines internal markers for shortcut rows and the shortcut divider
+- exposes an internal `rebuildShortcutSection(in:presentations:)` helper for tests
+- removes all existing marked items before inserting the new dynamic section at the top of the menu
+
+Implementation sketch:
+
+```swift
+@MainActor
+final class MenuBarController: NSObject, NSMenuDelegate {
+    static let shortcutRowMarker = "menuBar.shortcutRow"
+    static let shortcutDividerMarker = "menuBar.shortcutDivider"
+
+    private let shortcutStore: ShortcutStore
+    private let runningBundleIdentifiers: @MainActor () -> Set<String>
+
+    func rebuildShortcutSection(in menu: NSMenu, presentations: [MenuBarShortcutItemPresentation]) {
+        for item in menu.items.reversed() {
+            guard let marker = item.representedObject as? String else { continue }
+            guard marker == Self.shortcutRowMarker || marker == Self.shortcutDividerMarker else { continue }
+            menu.removeItem(item)
+        }
+
+        var insertionIndex = 0
+        for presentation in presentations {
+            let item = NSMenuItem(title: presentation.titleText, action: nil, keyEquivalent: "")
+            item.isEnabled = false
+            item.representedObject = Self.shortcutRowMarker
+            menu.insertItem(item, at: insertionIndex)
+            insertionIndex += 1
+        }
+
+        let divider = NSMenuItem.separator()
+        divider.representedObject = Self.shortcutDividerMarker
+        menu.insertItem(divider, at: insertionIndex)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run on a macOS host:
+
+```bash
+swift test --filter MenuBarControllerShortcutMenuTests
+```
+
+Expected: PASS. The helper may still use placeholder plain menu items at this stage; the next task will swap in the real custom row view while keeping the composition tests green.
+
+- [ ] **Step 5: Commit the rebuild-behavior checkpoint**
+
+```bash
+git add Sources/Quickey/UI/MenuBarController.swift Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
+git commit -m "test: lock down menu bar shortcut section rebuilds"
+```
+
+### Task 3: Render Custom Rows And Wire The Live Refresh Path
+
+**Files:**
+
+- Create: `Sources/Quickey/UI/MenuBarShortcutRowView.swift`
+- Modify: `Sources/Quickey/UI/MenuBarController.swift`
+- Modify: `Sources/Quickey/AppController.swift`
+- Modify: `Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift`
+- Reference: `Sources/Quickey/UI/SharedComponents.swift`
+
+- [ ] **Step 1: Write the failing integration-style menu tests**
+
+Extend `Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift` with `@MainActor` tests that drive `menuWillOpen(_:)` through the real `ShortcutStore` and verify the live refresh path:
+
+```swift
+@Test @MainActor
+func menuWillOpenBuildsCustomRowsFromShortcutStoreAndRunningSnapshot() {
+    let store = ShortcutStore()
+    store.replaceAll(with: [
+        AppShortcut(appName: "Safari", bundleIdentifier: "com.apple.Safari", keyEquivalent: "s", modifierFlags: ["control", "option"]),
+        AppShortcut(appName: "IINA", bundleIdentifier: "com.colliderli.iina", keyEquivalent: "i", modifierFlags: ["control", "option"], isEnabled: false),
+    ])
+
+    let controller = MenuBarController(
+        shortcutStore: store,
+        onOpenSettings: {},
+        onQuit: {},
+        runningBundleIdentifiers: { ["com.apple.Safari"] }
+    )
+
+    let menu = controller.installMenuForTesting()
+    controller.menuWillOpen(menu)
+
+    let shortcutItems = menu.items.filter {
+        $0.representedObject as? String == MenuBarController.shortcutRowMarker
+    }
+
+    #expect(shortcutItems.count == 2)
+    #expect(shortcutItems.allSatisfy { $0.view is MenuBarShortcutRowView })
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run on a macOS host:
+
+```bash
+swift test --filter MenuBarControllerShortcutMenuTests
+```
+
+Expected: FAIL because the menu still uses placeholder plain `NSMenuItem` rows and the controller is not yet building rows from the live store during `menuWillOpen(_:)`.
+
+- [ ] **Step 3: Implement the custom row view and live menu refresh**
+
+Create `Sources/Quickey/UI/MenuBarShortcutRowView.swift` and finish the controller integration:
+
+```swift
+import AppKit
+
+final class MenuBarShortcutRowView: NSView {
+    init(presentation: MenuBarShortcutItemPresentation) {
+        super.init(frame: .zero)
+
+        let iconView = NSImageView(image: AppIconCache.icon(for: presentation.bundleIdentifier ?? "") ?? NSWorkspace.shared.icon(for: .application))
+        let nameField = NSTextField(labelWithString: presentation.titleText)
+        let shortcutField = NSTextField(labelWithString: presentation.shortcutText ?? "")
+
+        // Build one-line horizontal layout.
+        // Hide the running dot when presentation.isRunning == false.
+        // Show the disabled label when presentation.statusText != nil.
+        // Mutate text colors for disabled rows without making the row interactive.
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { nil }
+}
+```
+
+Then modify `Sources/Quickey/UI/MenuBarController.swift` to:
+
+- hold the injected `ShortcutStore`
+- build `MenuBarShortcutItemPresentation.build(from:runningBundleIdentifiers:)` inside `menuWillOpen(_:)`
+- call `rebuildShortcutSection(in:presentations:)`
+- replace placeholder plain items with `NSMenuItem` instances whose `view` is `MenuBarShortcutRowView`
+- keep the marker-based removal logic so repeated opens stay deterministic
+- keep `Settings`, `Launch at Login`, and `Quit` below the shortcut divider
+
+Update `Sources/Quickey/AppController.swift` so the live `MenuBarController` receives the shared `shortcutStore`:
+
+```swift
+private lazy var menuBarController = MenuBarController(
+    shortcutStore: shortcutStore,
+    onOpenSettings: { [weak self] in self?.openSettings() },
+    onQuit: { NSApplication.shared.terminate(nil) }
+)
+```
+
+- [ ] **Step 4: Run targeted tests and the full suite**
+
+Run on a macOS host:
+
+```bash
+swift test --filter MenuBarControllerShortcutMenuTests
+swift test
+```
+
+Expected:
+
+- `MenuBarControllerShortcutMenuTests`: PASS
+- full `swift test`: PASS
+
+If you are implementing from Linux or another non-macOS host, do not claim these commands passed. Record build/test verification as pending for a macOS machine.
+
+- [ ] **Step 5: Commit the feature implementation**
+
+```bash
+git add Sources/Quickey/AppController.swift Sources/Quickey/UI/MenuBarController.swift Sources/Quickey/UI/MenuBarShortcutRowView.swift Tests/QuickeyTests/MenuBarControllerShortcutMenuTests.swift
+git commit -m "feat: show shortcuts in the menu bar menu"
+```
+
+### Task 4: Verify On macOS And Record Pending Work Truthfully
+
+**Files:**
+
+- Modify if needed: `docs/handoff-notes.md`
+
+- [ ] **Step 1: Run local build/test/package verification on macOS**
+
+```bash
+swift build
+swift test
+swift build -c release
+```
+
+Expected: PASS on a macOS host.
+
+- [ ] **Step 2: Validate the menu behavior manually on macOS**
+
+Check all of the following against a real menu bar session:
+
+- shortcut rows appear above `Settings`
+- enabled and disabled rows are visually distinct
+- the green dot appears for running bundles only
+- repeated menu opens do not duplicate rows or separators
+- an empty shortcut store shows `No shortcuts configured`
+
+- [ ] **Step 3: Validate a mixed shortcut fixture**
+
+Use at least one enabled shortcut for a currently running app and one disabled shortcut for a not-running app. Confirm the menu still preserves the saved order rather than grouping by status.
+
+- [ ] **Step 4: Record truthfully if macOS validation did not happen**
+
+If you are not on macOS, or if you could not run the visual validation:
+
+- update the final work summary to say macOS UI validation is pending
+- do not claim the feature is complete from Linux-only inspection
+- if you maintain `docs/handoff-notes.md` for this branch, add a brief note that issue #180 implementation exists but menu rendering verification is still pending on macOS
+
+- [ ] **Step 5: Commit only if documentation changed during verification**
+
+```bash
+git add docs/handoff-notes.md
+git commit -m "docs: note menu bar shortcut list validation status"
+```
+
+Skip this commit if verification produced no documentation changes.

--- a/docs/superpowers/specs/2026-04-18-menu-bar-shortcut-list-design.md
+++ b/docs/superpowers/specs/2026-04-18-menu-bar-shortcut-list-design.md
@@ -1,0 +1,253 @@
+# Menu Bar Shortcut List Design
+
+## Summary
+
+Quickey's menu bar menu currently exposes only static utility actions such as `Settings`, `Launch at Login`, and `Quit`. Issue #180 adds a high-frequency reference surface directly inside the menu: when the user clicks the menu bar icon, Quickey should show every saved shortcut at the top of the menu, including app icon, app name, shortcut text, disabled state, and whether the target app currently has a running instance.
+
+The chosen design keeps `MenuBarController` as the single menu owner, but adds a dynamic shortcut section rendered with custom `NSView`-backed menu rows. Each row is read-only and optimized for fast scanning: app icon on the left, compact running-state dot beside the app name, shortcut text on the right, and a muted disabled presentation when the shortcut is turned off. The dynamic section is rebuilt each time the menu opens from a fresh `ShortcutStore` + running-app snapshot, then separated from the existing static actions with a divider.
+
+## Goals
+
+- Let the user inspect all configured shortcuts without opening Settings.
+- Show shortcut metadata in a compact, scan-friendly menu layout.
+- Indicate whether a target app currently has at least one running instance.
+- Make disabled shortcuts visible without making them look active.
+- Preserve the current static menu actions and keep the implementation consistent with the existing AppKit menu structure.
+
+## Non-Goals
+
+- Making shortcut rows clickable, editable, reorderable, or otherwise interactive.
+- Showing usage stats, launch-at-login state, or richer runtime diagnostics in the shortcut rows.
+- Replacing the entire menu with SwiftUI or adding persistent workspace observers just for menu status.
+- Re-sorting shortcuts independently from the saved order shown elsewhere in the app.
+- Claiming macOS visual/runtime correctness from Linux-only validation.
+
+## Current State
+
+As of 2026-04-18:
+
+- `MenuBarController` builds a fixed `NSMenu` with `Settings`, `Launch at Login`, and `Quit`.
+- `ShortcutStore` already owns the in-memory `[AppShortcut]` list on the main actor.
+- `AppShortcut` already exposes the displayable shortcut string via `displayText`.
+- Quickey already has AppKit patterns for resolving application icons and falling back to a generic app icon.
+- No menu-level model currently exists for representing shortcut rows or running-app status.
+
+## Approaches Considered
+
+### 1. Plain `NSMenuItem` text rows
+
+Use ordinary menu items with `title`, `image`, and `isEnabled`, then approximate the layout with string formatting.
+
+Pros:
+
+- Smallest code change.
+- Minimal AppKit surface area.
+
+Cons:
+
+- Weak control over visual hierarchy.
+- Harder to place the running-state dot cleanly next to the app name.
+- Disabled marker and shortcut alignment become string-formatting problems instead of view layout.
+
+### 2. Custom `NSView` menu rows
+
+Create a dedicated read-only menu row view for each shortcut and host it inside `NSMenuItem.view`.
+
+Pros:
+
+- Matches the chosen compact layout exactly.
+- Gives precise control over icon/name/dot/shortcut alignment.
+- Keeps future room for small UI refinements without rewriting menu composition.
+
+Cons:
+
+- More AppKit code than plain menu items.
+- Requires explicit view/model seams to keep logic testable.
+
+### 3. Shortcut list in a submenu
+
+Keep the top-level menu mostly unchanged and move all bindings under a `Shortcuts` submenu.
+
+Pros:
+
+- Shorter top-level menu.
+
+Cons:
+
+- Fails the issue goal of “click and immediately see all bound shortcuts.”
+- Adds one extra navigation step to a supposed quick reference panel.
+
+## Recommended Design
+
+Use approach 2: custom `NSView` menu rows, rendered as a compact single-line list at the top of the existing menu.
+
+The final row layout is:
+
+- leading app icon
+- optional green running-state dot beside the app name
+- app name text
+- optional `disabled` marker when the shortcut is turned off
+- trailing shortcut text badge
+
+Rows are informational only. Clicking them should do nothing.
+
+## Data Semantics
+
+### Shortcut Order
+
+The dynamic shortcut section should preserve the current `ShortcutStore.shortcuts` order. Quickey should not apply an additional sort in the menu, because the menu is meant to be a fast reflection of the saved configuration rather than a second ordering system.
+
+### Running-State Dot
+
+The green dot means: **the target bundle currently has at least one running application instance**.
+
+It does **not** mean:
+
+- the app is frontmost
+- the app is visible
+- the app is active because Quickey launched or activated it
+
+This keeps the status simple, truthful, and cheap to compute from a single workspace snapshot.
+
+### Disabled Rows
+
+Disabled shortcuts remain visible in the list. They should be visually muted and explicitly marked with `disabled`, but still show app identity and shortcut text so the menu remains a complete reference surface.
+
+### Empty State
+
+If no shortcuts are configured, the menu should still reserve the dynamic section with a single read-only placeholder row such as `No shortcuts configured`, then show the divider and existing static actions below it. This avoids the menu abruptly collapsing to a totally different structure.
+
+## Architecture
+
+### `MenuBarController` Remains The Owner
+
+`MenuBarController` should continue to own:
+
+- menu creation
+- menu refresh on open
+- static menu items
+- launch-at-login item updates
+
+No additional controller should be introduced for this feature. The new behavior belongs to the existing menu composition boundary.
+
+### Add A Small Presentation Model
+
+The implementation should introduce a thin presentation model dedicated to menu rows. Its responsibility is to convert `AppShortcut` plus a running-app bundle set into view-friendly data such as:
+
+- `appName`
+- `bundleIdentifier`
+- `shortcutText`
+- `isEnabled`
+- `isRunning`
+- `isPlaceholder`
+
+This keeps state derivation separate from AppKit view construction, which makes the feature easier to test without snapshot-heavy UI tests.
+
+### Add A Dedicated Row View
+
+Each shortcut row should be rendered by a focused custom AppKit view, for example a small `NSView` subclass or helper view builder hosted inside `NSMenuItem.view`.
+
+The row view should be responsible only for presentation:
+
+- icon display with fallback icon behavior
+- single-line compact layout
+- green dot visibility
+- disabled styling
+- shortcut badge styling
+
+It should not own menu refresh logic or query global application state directly.
+
+## Refresh Flow
+
+### Rebuild On `menuWillOpen(_:)`
+
+Each time the menu opens:
+
+1. Read the current `ShortcutStore.shortcuts`.
+2. Read a workspace snapshot of currently running applications.
+3. Build the presentation rows from those two inputs.
+4. Remove the existing dynamic shortcut items and their dedicated divider.
+5. Insert the newly built shortcut rows at the top of the menu.
+6. Leave the static actions (`Settings`, `Launch at Login`, `Quit`) intact below the divider.
+7. Refresh the launch-at-login item as Quickey already does today.
+
+This approach intentionally avoids persistent observation for this feature. The menu only needs to be correct when shown, so a cheap open-time snapshot is the simplest truthful solution.
+
+### Rebuild Rather Than Diff
+
+The shortcut section should be rebuilt wholesale instead of diffed in place.
+
+Reasons:
+
+- The menu is small.
+- Rebuild-on-open avoids index bookkeeping errors.
+- Full replacement makes repeated menu opens deterministic.
+- The logic is easier to test than partial mutation.
+
+## Error Handling And Fallbacks
+
+- If the app icon cannot be resolved for a bundle, use the generic application fallback icon.
+- If a running application snapshot has no bundle identifier, ignore it for running-state computation.
+- If no running instance exists for a shortcut bundle, omit the green dot and leave the row otherwise unchanged.
+- If the shortcut list is empty, show the placeholder row instead of omitting the entire section.
+- The dynamic rows should be disabled from interaction regardless of whether the represented shortcut itself is enabled.
+
+## Testing Strategy
+
+The primary tests should target deterministic model and menu-composition behavior rather than brittle visual snapshots.
+
+### Presentation Model Tests
+
+Add tests that prove:
+
+- shortcut order matches `ShortcutStore.shortcuts`
+- running bundles map to `isRunning == true`
+- disabled shortcuts remain present and marked correctly
+- empty shortcut input produces a placeholder row
+
+### Menu Composition Tests
+
+Add tests around `MenuBarController` (or extracted menu-composition helpers) that prove:
+
+- dynamic shortcut rows appear above the existing static items
+- the divider between dynamic rows and static items is present
+- repeated `menuWillOpen(_:)` calls do not duplicate rows
+- static item ordering remains stable after rebuilds
+
+### Fallback Tests
+
+Add targeted coverage for:
+
+- unresolved icon path fallback
+- empty running-app snapshot
+- mixed enabled/disabled shortcut sets
+
+## File-Level Plan Surface
+
+This design is expected to touch the following areas during implementation.
+
+### Existing Files To Modify
+
+- `Sources/Quickey/UI/MenuBarController.swift`
+- `Sources/Quickey/AppController.swift`
+- `Tests/QuickeyTests/MenuBarLaunchAtLoginPresentationTests.swift` or a new menu-bar-specific test file if the row model deserves dedicated coverage
+
+### New Files Likely To Add
+
+- a menu row presentation model file under `Sources/Quickey/UI/`
+- a custom menu row view file under `Sources/Quickey/UI/`
+- a dedicated test file for menu shortcut row modeling / menu rebuild behavior under `Tests/QuickeyTests/`
+
+## Validation Notes
+
+This feature is UI-facing but not deeply runtime-sensitive in the same sense as event taps or activation control. Still, the final behavior must be visually validated on macOS because AppKit menu row layout and icon rendering cannot be fully trusted from Linux-only inspection.
+
+At minimum, macOS validation for the eventual implementation should confirm:
+
+- dynamic shortcut rows render above the static menu items
+- enabled and disabled rows are visually distinct
+- the green dot appears only for currently running bundles
+- the menu remains stable across repeated opens
+- empty-state rendering looks intentional
+
+Until that validation runs on macOS, runtime/UI validation remains pending.


### PR DESCRIPTION
Fixes #180

## Summary
- render configured shortcuts as read-only custom rows at the top of the menu bar dropdown, including app icon, app name, shortcut text, running indicator, and disabled state
- rebuild the dynamic shortcut section from the shared `ShortcutStore` on install and `menuWillOpen(_:)`, preserving the saved shortcut order and keeping the existing static menu items below a separator
- add focused tests for shortcut presentation and menu rebuild behavior, including disabled-row styling, repeated rebuild safety, and disabled-but-running indicator coverage

## Testing
- [ ] `swift test`
- [ ] Additional validation noted below when needed

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Notes
- `swift` is not installed on this Linux host, so `swift test` was not run locally.
- Quickey targets macOS/AppKit; manual macOS validation is still needed for actual menu rendering and running-indicator behavior.
- `git diff --check origin/main..HEAD` passed locally.
