### PR TITLE
[codex] finish Wink rename follow-up

### DIFF
--- a/.github/scripts/sync-project-fields.mjs
+++ b/.github/scripts/sync-project-fields.mjs
@@ -12,7 +12,7 @@ import {
 } from './lib/project-automation.mjs';
 
 const apiVersion = '2022-11-28';
-const projectTitle = 'Quickey Backlog';
+const projectTitle = 'Wink Backlog';
 const statusFieldName = 'Status';
 const runtimeValidationFieldName = 'Runtime Validation';
 
@@ -32,7 +32,7 @@ async function graphqlRequest(query, variables = {}) {
       Accept: 'application/vnd.github+json',
       Authorization: `Bearer ${requiredEnv('PROJECT_AUTOMATION_TOKEN')}`,
       'Content-Type': 'application/json',
-      'User-Agent': 'quickey-project-sync',
+      'User-Agent': 'wink-project-sync',
       'X-GitHub-Api-Version': apiVersion,
     },
     body: JSON.stringify({ query, variables }),
@@ -52,7 +52,7 @@ async function restRequest(pathname) {
     headers: {
       Accept: 'application/vnd.github+json',
       Authorization: `Bearer ${requiredEnv('PROJECT_AUTOMATION_TOKEN')}`,
-      'User-Agent': 'quickey-project-sync',
+      'User-Agent': 'wink-project-sync',
       'X-GitHub-Api-Version': apiVersion,
     },
   });

--- a/.github/scripts/sync-project-fields.mjs
+++ b/.github/scripts/sync-project-fields.mjs
@@ -12,7 +12,7 @@ import {
 } from './lib/project-automation.mjs';
 
 const apiVersion = '2022-11-28';
-const projectTitle = 'Wink Backlog';
+const preferredProjectTitles = ['Wink Backlog', 'Quickey Backlog'];
 const statusFieldName = 'Status';
 const runtimeValidationFieldName = 'Runtime Validation';
 
@@ -66,6 +66,7 @@ async function restRequest(pathname) {
 }
 
 async function resolveProject(owner, repo) {
+  const projectQuery = preferredProjectTitles.join(' ');
   const data = await graphqlRequest(
     `
       query ResolveProject($owner: String!, $repo: String!, $projectQuery: String!) {
@@ -93,14 +94,18 @@ async function resolveProject(owner, repo) {
         }
       }
     `,
-    { owner, repo, projectQuery: projectTitle },
+    { owner, repo, projectQuery },
   );
 
   const projects = data.repository.owner.projectsV2.nodes;
-  const project = projects.find((candidate) => candidate.title === projectTitle);
+  const project = preferredProjectTitles
+    .map((title) => projects.find((candidate) => candidate.title === title))
+    .find(Boolean);
 
   if (!project) {
-    throw new Error(`Project "${projectTitle}" was not found for ${owner}.`);
+    throw new Error(
+      `Project "${preferredProjectTitles.join('" or "')}" was not found for ${owner}.`,
+    );
   }
 
   return project;

--- a/.github/scripts/tests/main-ruleset.test.mjs
+++ b/.github/scripts/tests/main-ruleset.test.mjs
@@ -31,7 +31,7 @@ test('main ruleset requires pull requests and review freshness', () => {
   assert.deepEqual(pullRequestRule.parameters.allowed_merge_methods, ['merge', 'squash', 'rebase']);
 });
 
-test('main ruleset requires the deterministic Quickey checks', () => {
+test('main ruleset requires the deterministic Wink checks', () => {
   const statusChecksRule = findRule('required_status_checks');
   const contexts = statusChecksRule.parameters.required_status_checks.map(
     (check) => check.context,

--- a/.github/scripts/tests/project-automation.test.mjs
+++ b/.github/scripts/tests/project-automation.test.mjs
@@ -14,13 +14,13 @@ import {
 test('extractClosingIssueNumbers finds closing keywords for local issues', () => {
   const body = `
 Fixes #135
-Resolves xrf9268-hue/Quickey#140
+Resolves xrf9268-hue/Wink#140
 
 Refs #141
 `;
 
   assert.deepEqual(
-    extractClosingIssueNumbers(body, { owner: 'xrf9268-hue', repo: 'Quickey' }),
+    extractClosingIssueNumbers(body, { owner: 'xrf9268-hue', repo: 'Wink' }),
     [135, 140],
   );
 });

--- a/.github/scripts/tests/review-state.test.mjs
+++ b/.github/scripts/tests/review-state.test.mjs
@@ -30,7 +30,7 @@ test('evaluateReviewState fails on unresolved non-outdated inline threads', () =
         isOutdated: false,
         path: 'Sources/Wink/AppController.swift',
         line: 88,
-        reviewer: 'quickey-review-bot',
+        reviewer: 'wink-review-bot',
         bodyText: 'Guard the no-window path before marking activation stable.',
       },
     ],
@@ -118,7 +118,7 @@ test('firstLine trims blank lines and collapses whitespace', () => {
 });
 
 test('validate-review-state writes a step summary and exits non-zero for blocking threads', async () => {
-  const tempDir = await mkdtemp(join(tmpdir(), 'quickey-review-gate-'));
+  const tempDir = await mkdtemp(join(tmpdir(), 'wink-review-gate-'));
   const eventPath = join(tempDir, 'event.json');
   const summaryPath = join(tempDir, 'summary.md');
 
@@ -145,7 +145,7 @@ test('validate-review-state writes a step summary and exits non-zero for blockin
             isOutdated: false,
             path: 'Sources/Wink/AppController.swift',
             line: 88,
-            reviewer: 'quickey-review-bot',
+            reviewer: 'wink-review-bot',
             bodyText: 'Guard the no-window path before marking activation stable.',
           },
         ],

--- a/.github/scripts/validate-pr-metadata.mjs
+++ b/.github/scripts/validate-pr-metadata.mjs
@@ -13,7 +13,7 @@ async function githubRequest(pathname) {
     headers: {
       Accept: 'application/vnd.github+json',
       Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
-      'User-Agent': 'quickey-pr-metadata-validator',
+      'User-Agent': 'wink-pr-metadata-validator',
       'X-GitHub-Api-Version': apiVersion,
     },
   });

--- a/.github/scripts/validate-review-state.mjs
+++ b/.github/scripts/validate-review-state.mjs
@@ -20,7 +20,7 @@ async function graphqlRequest(query, variables) {
       Accept: 'application/vnd.github+json',
       Authorization: `Bearer ${requiredEnv('GITHUB_TOKEN')}`,
       'Content-Type': 'application/json',
-      'User-Agent': 'quickey-review-gate',
+      'User-Agent': 'wink-review-gate',
       'X-GitHub-Api-Version': apiVersion,
     },
     body: JSON.stringify({ query, variables }),

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   sync:
-    name: Reconcile Quickey Backlog
+    name: Reconcile Wink Backlog
     runs-on: ubuntu-latest
     steps:
       - name: Require project automation token

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 Wink is a macOS menu bar app that binds global shortcuts to target apps, with Thor-like toggle behavior, fast activation, and lightweight usage insights.
 
+## Why "Wink"?
+The rename from `Quickey` to `Wink` came out of [issue #183](https://github.com/xrf9268-hue/Wink/issues/183): the old name explained the mechanism ("quick keys"), while the new name tries to capture the feeling. The goal is app switching that happens "in the wink of an eye" rather than a tool name that only describes hotkeys.
+
+- It emphasizes the experience: fast, almost instant switching
+- It keeps the product short, lightweight, and a little more human than a purely functional utility name
+- It mirrors the same naming instinct that inspired tools like [Shun](https://blog.sorrycc.com/release-shun): name the sensation, not just the implementation
+
 ## Highlights
 - Global shortcuts that launch or toggle target apps with a single keystroke
 - Thor-like semantics that activate, re-activate hidden apps, or directly hide the frontmost target depending on state
@@ -48,7 +55,7 @@ swift test
 
 `Launch at Login` should be validated from a packaged app installed in `/Applications` or `~/Applications`. Running `build/Wink.app` directly from the repo can surface an install-location warning instead of a real login-item configuration state.
 
-Tagged releases use `v<CFBundleShortVersionString>` and publish `Wink-<version>.dmg` through the release workflow described in [`docs/signing-and-release.md`](./docs/signing-and-release.md). Notarized releases are not yet available; the current [internal prerelease](https://github.com/xrf9268-hue/Quickey/releases/tag/internal-downloads) is unsigned, so macOS may warn on first launch.
+Tagged releases use `v<CFBundleShortVersionString>` and publish `Wink-<version>.dmg` through the release workflow described in [`docs/signing-and-release.md`](./docs/signing-and-release.md). Notarized releases are not yet available; the current [internal prerelease](https://github.com/xrf9268-hue/Wink/releases/tag/internal-downloads) is unsigned, so macOS may warn on first launch.
 
 ## Documentation
 - [`docs/README.md`](./docs/README.md)
@@ -57,4 +64,4 @@ Tagged releases use `v<CFBundleShortVersionString>` and publish `Wink-<version>.
 - [`docs/signing-and-release.md`](./docs/signing-and-release.md)
 
 ## Repository Automation
-GitHub Actions now enforce PR issue linkage (`Fixes #...`) and keep the `Quickey Backlog` project's `Status` / `Runtime Validation` fields synchronized. See [`docs/github-automation.md`](./docs/github-automation.md) for the required `PROJECT_AUTOMATION_TOKEN` secret and the recommended branch-protection check.
+GitHub Actions now enforce PR issue linkage (`Fixes #...`) and keep the `Wink Backlog` project's `Status` / `Runtime Validation` fields synchronized. See [`docs/github-automation.md`](./docs/github-automation.md) for the required `PROJECT_AUTOMATION_TOKEN` secret and the recommended branch-protection check.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This directory maps the maintainer-facing docs for Wink.
 
 ## Core Docs
 - [`architecture.md`](./architecture.md)
-- [`github-automation.md`](./github-automation.md) — PR metadata enforcement, deterministic review gating, the checked-in `main` ruleset artifact, Quickey Backlog project reconciliation, runtime-validation field sync, and required repository secrets
+- [`github-automation.md`](./github-automation.md) — PR metadata enforcement, deterministic review gating, the checked-in `main` ruleset artifact, Wink Backlog project reconciliation, runtime-validation field sync, and required repository secrets
 - [`signing-and-release.md`](./signing-and-release.md) — local DMG packaging, internal-package artifacts, signing, notarization, release secrets, and tag-driven GitHub Release flow
 
 ## Maintainer Notes

--- a/docs/github-automation.md
+++ b/docs/github-automation.md
@@ -17,8 +17,8 @@ Wink now uses repository-native GitHub Actions and a checked-in ruleset artifact
    - Refreshes on PR, review, and review-comment activity; GitHub Actions does not currently expose a dedicated review-thread resolved/unresolved workflow trigger, so a pure thread-resolution change may need a manual rerun or another PR activity before the check turns green again
 
 3. **Project reconciliation** (`.github/workflows/project-sync.yml`)
-   - Adds the event issue or linked issue into the `Quickey Backlog` Project V2 if it is missing
-   - Scheduled and manual reconciliation runs backfill any repository issues that are still missing from `Quickey Backlog`
+   - Adds the event issue or linked issue into the `Wink Backlog` Project V2 if it is missing
+   - Scheduled and manual reconciliation runs backfill any repository issues that are still missing from `Wink Backlog`
    - Syncs `Status` to `Ready`, `In Progress`, or `Done`
    - Syncs `Runtime Validation` to `None`, `macOS pending`, or `macOS complete`
    - Re-runs every 6 hours so transient event failures do not leave the project permanently stale

--- a/docs/loop-job-guide.md
+++ b/docs/loop-job-guide.md
@@ -1,11 +1,11 @@
 # Loop Job Guide
 
-How to run automated Claude Code sessions for recurring project work using `/loop`. See also [Wiki: Loop Job Configuration](https://github.com/xrf9268-hue/Quickey/wiki/Loop-Job-Configuration).
+How to run automated Claude Code sessions for recurring project work using `/loop`. See also [Wiki: Loop Job Configuration](https://github.com/xrf9268-hue/Wink/wiki/Loop-Job-Configuration).
 
 Repository-native state sync is now handled separately by GitHub Actions:
 - `.github/workflows/pr-metadata.yml` enforces PR issue linkage and validation-state metadata
 - `.github/workflows/review-gate.yml` turns unresolved actionable review state into a deterministic required check
-- `.github/workflows/project-sync.yml` keeps `Quickey Backlog` `Status` and `Runtime Validation` aligned with issue/PR state
+- `.github/workflows/project-sync.yml` keeps `Wink Backlog` `Status` and `Runtime Validation` aligned with issue/PR state
 - [`github-automation.md`](./github-automation.md) documents the required `PROJECT_AUTOMATION_TOKEN` secret, checked-in ruleset artifact, and governance rollout order
 
 ## Quick Start

--- a/docs/loop-prompt.md
+++ b/docs/loop-prompt.md
@@ -5,7 +5,7 @@ This file is retained for reference. The active loop automation is now delivered
 Core repository state sync now lives in GitHub Actions:
 - `.github/workflows/pr-metadata.yml` enforces `Fixes #...` and `Validation Status`
 - `.github/workflows/review-gate.yml` enforces deterministic review-state blocking
-- `.github/workflows/project-sync.yml` reconciles `Quickey Backlog` issue/project state
+- `.github/workflows/project-sync.yml` reconciles `Wink Backlog` issue/project state
 
 ## Usage
 

--- a/docs/pr-governance-rollout.md
+++ b/docs/pr-governance-rollout.md
@@ -60,7 +60,7 @@ The summary bullets above are already suitable for the PR body. If you want a sh
 tmpdir="$(mktemp -d)"
 cat > "$tmpdir/event.json" <<'JSON'
 {
-  "repository": { "owner": { "login": "xrf9268-hue" }, "name": "Quickey" },
+  "repository": { "owner": { "login": "xrf9268-hue" }, "name": "Wink" },
   "pull_request": { "number": 170 }
 }
 JSON
@@ -80,7 +80,7 @@ node .github/scripts/validate-review-state.mjs
 Inspect existing rulesets:
 
 ```bash
-gh api repos/xrf9268-hue/Quickey/rulesets \
+gh api repos/xrf9268-hue/Wink/rulesets \
   -H "Accept: application/vnd.github+json" \
   --jq '.[] | {id, name, target, enforcement}'
 ```
@@ -88,7 +88,7 @@ gh api repos/xrf9268-hue/Quickey/rulesets \
 Create the ruleset if it does not exist:
 
 ```bash
-gh api repos/xrf9268-hue/Quickey/rulesets \
+gh api repos/xrf9268-hue/Wink/rulesets \
   --method POST \
   -H "Accept: application/vnd.github+json" \
   --input .github/governance/main-ruleset.json
@@ -97,8 +97,8 @@ gh api repos/xrf9268-hue/Quickey/rulesets \
 Update the ruleset if it already exists:
 
 ```bash
-RULESET_ID="$(gh api repos/xrf9268-hue/Quickey/rulesets --jq '.[] | select(.name=="main merge governance") | .id')"
-gh api "repos/xrf9268-hue/Quickey/rulesets/$RULESET_ID" \
+RULESET_ID="$(gh api repos/xrf9268-hue/Wink/rulesets --jq '.[] | select(.name=="main merge governance") | .id')"
+gh api "repos/xrf9268-hue/Wink/rulesets/$RULESET_ID" \
   --method PUT \
   -H "Accept: application/vnd.github+json" \
   --input .github/governance/main-ruleset.json
@@ -107,7 +107,7 @@ gh api "repos/xrf9268-hue/Quickey/rulesets/$RULESET_ID" \
 Verify the live ruleset after apply:
 
 ```bash
-gh api repos/xrf9268-hue/Quickey/rulesets \
+gh api repos/xrf9268-hue/Wink/rulesets \
   -H "Accept: application/vnd.github+json" \
   --jq '.[] | select(.name=="main merge governance")'
 ```

--- a/docs/signing-and-release.md
+++ b/docs/signing-and-release.md
@@ -77,7 +77,7 @@ Release-mode app signing is driven through environment variables passed to `scri
 - `ENABLE_TIMESTAMP=1`
 - `REQUIRE_SIGN_IDENTITY=1`
 
-The checked-in [entitlements.plist](/Users/yvan/developer/Quickey/entitlements.plist) is the canonical release entitlement file.
+The checked-in [entitlements.plist](../entitlements.plist) is the canonical release entitlement file.
 
 Wink's current entitlement set is intentionally minimal:
 
@@ -96,7 +96,7 @@ Accessibility and Input Monitoring are still user-granted runtime permissions, n
 
 ## GitHub Release Workflow
 
-The release workflow lives at [release.yml](/Users/yvan/developer/Quickey/.github/workflows/release.yml).
+The release workflow lives at [release.yml](../.github/workflows/release.yml).
 
 ### Trigger
 
@@ -134,7 +134,7 @@ When secrets are absent, the workflow reports the missing secrets and skips publ
 
 ## Internal Package Workflow
 
-For teams that do not yet have a `Developer ID Application` certificate, Wink also defines [internal-package.yml](/Users/yvan/developer/Quickey/.github/workflows/internal-package.yml).
+For teams that do not yet have a `Developer ID Application` certificate, Wink also defines [internal-package.yml](../.github/workflows/internal-package.yml).
 
 ### Trigger
 
@@ -156,11 +156,11 @@ The prerelease notes are written for testers, not maintainers: they explain who 
 
 Stable internal prerelease URL:
 
-- [internal-downloads](https://github.com/xrf9268-hue/Quickey/releases/tag/internal-downloads)
+- [internal-downloads](https://github.com/xrf9268-hue/Wink/releases/tag/internal-downloads)
 
 ## Manual Release Checklist
 
-1. Update `CFBundleShortVersionString` and `CFBundleVersion` in [Info.plist](/Users/yvan/developer/Quickey/Sources/Wink/Resources/Info.plist)
+1. Update `CFBundleShortVersionString` and `CFBundleVersion` in [Info.plist](../Sources/Wink/Resources/Info.plist)
 2. Run `swift test`
 3. Run `./scripts/package-app.sh`
 4. Run `./scripts/package-dmg.sh`
@@ -222,9 +222,9 @@ macOS ties Accessibility and Input Monitoring permissions to the app signature. 
 
 ## CI Integration
 
-- [ci.yml](/Users/yvan/developer/Quickey/.github/workflows/ci.yml)
+- [ci.yml](../.github/workflows/ci.yml)
   Builds, tests, packages the app, packages the DMG, and verifies artifacts without Apple credentials
-- [release.yml](/Users/yvan/developer/Quickey/.github/workflows/release.yml)
+- [release.yml](../.github/workflows/release.yml)
   Handles tag-driven signing, notarization, stapling, validation, and GitHub Release publication
 
 ## Validation Limits

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -750,9 +750,9 @@ const html = `<!DOCTYPE html>
       <kbd>Hyper</kbd> = Caps Lock remapped via <strong>Wink</strong> &nbsp;|&nbsp;
       Available: <kbd>E</kbd> <kbd>J</kbd> <kbd>L</kbd> <kbd>Q</kbd> <kbd>U</kbd> <kbd>Y</kbd>
     </p>
-    <a class="repo-link" href="https://github.com/xrf9268-hue/Quickey" target="_blank" rel="noopener noreferrer" aria-label="View on GitHub">
+    <a class="repo-link" href="https://github.com/xrf9268-hue/Wink" target="_blank" rel="noopener noreferrer" aria-label="View on GitHub">
       <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
-      <span>xrf9268-hue/Quickey</span>
+      <span>xrf9268-hue/Wink</span>
     </a>
   </div>
 

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -1,8 +1,8 @@
 {
-  "name": "quickey-cheatsheet",
+  "name": "wink-cheatsheet",
   "main": "src/index.ts",
   "compatibility_date": "2024-12-01",
   "routes": [
-    { "pattern": "quickey.aixie.de", "custom_domain": true }
+    { "pattern": "wink.aixie.de", "custom_domain": true }
   ]
 }


### PR DESCRIPTION
Fixes #183

## Summary
- finish the post-rename follow-up by renaming `Quickey Backlog` references to `Wink Backlog` across GitHub automation, workflow labels, and maintainer docs
- switch the cheat sheet worker config from `quickey-cheatsheet` / `quickey.aixie.de` to `wink-cheatsheet` / `wink.aixie.de`, and align the remaining docs and links with the renamed repo
- record the user-facing naming rationale in `README.md` and keep the GitHub/Cloudflare entrypoints consistent with the current Wink identity

## Impact
- project-sync automation now targets the renamed GitHub Project V2 title
- the cheat sheet worker now serves from `wink.aixie.de`, and the legacy `quickey-cheatsheet` worker/service path is retired
- maintainer-facing docs no longer send people to stale repo URLs or old project names

## Testing
- [x] `node --test .github/scripts/tests/*.mjs`
- [x] `git diff --check`
- [x] `npx wrangler deploy --dry-run`
- [x] `npx wrangler deploy`
- [x] `curl -I https://wink.aixie.de`

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Notes
- Applied the GitHub Project rename to `Wink Backlog` and updated the repository homepage to `https://wink.aixie.de`.
- Deployed `wink-cheatsheet`, detached the old `quickey.aixie.de` custom domain, and deleted the legacy `quickey-cheatsheet` worker.
- `Sync GitHub Project` currently runs from `pull_request_target` against `main`, so this PR is the bootstrap change that updates the project title lookup from `Quickey Backlog` to `Wink Backlog`.
