### PR TITLE
[codex] fix project sync title compatibility

### DIFF
--- a/.github/scripts/sync-project-fields.mjs
+++ b/.github/scripts/sync-project-fields.mjs
@@ -348,7 +348,7 @@ function currentSingleSelectName(item, fieldName) {
   return fieldValue?.name ?? null;
 }
 
-async function ensureIssuesInProject(owner, repo, projectId, snapshotItems, event) {
+async function ensureIssuesInProject(owner, repo, projectId, chosenProjectTitle, snapshotItems, event) {
   const knownIssueNumbers = new Set(
     snapshotItems
       .map((item) => item.content)
@@ -376,7 +376,7 @@ async function ensureIssuesInProject(owner, repo, projectId, snapshotItems, even
 
     const issueNodeId = await fetchIssueNodeId(owner, repo, issueNumber);
     await addIssueToProject(projectId, issueNodeId);
-    console.log(`Added issue #${issueNumber} to project "${projectTitle}".`);
+    console.log(`Added issue #${issueNumber} to project "${chosenProjectTitle}".`);
   }
 }
 
@@ -434,7 +434,7 @@ async function main() {
   const project = await resolveProject(owner, repo);
 
   let snapshot = await loadProjectSnapshot(project.id);
-  await ensureIssuesInProject(owner, repo, project.id, snapshot.items, event);
+  await ensureIssuesInProject(owner, repo, project.id, project.title, snapshot.items, event);
   snapshot = await loadProjectSnapshot(project.id);
 
   const { statusField, runtimeField } = buildFieldMaps(snapshot.fields);
@@ -483,7 +483,7 @@ async function main() {
     }
   }
 
-  console.log(`Project sync complete for "${projectTitle}" with ${updates} field update(s).`);
+  console.log(`Project sync complete for "${project.title}" with ${updates} field update(s).`);
 }
 
 main().catch((error) => {

--- a/.github/scripts/tests/sync-project-fields.test.mjs
+++ b/.github/scripts/tests/sync-project-fields.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('sync-project-fields does not use stale projectTitle logging references', async () => {
+  const source = await readFile(
+    new URL('../sync-project-fields.mjs', import.meta.url),
+    'utf8',
+  );
+
+  assert.equal(
+    source.includes('Added issue #${issueNumber} to project "${projectTitle}".'),
+    false,
+    'sync-project-fields.mjs still uses stale add-item projectTitle logging',
+  );
+  assert.equal(
+    source.includes('Project sync complete for "${projectTitle}" with ${updates} field update(s).'),
+    false,
+    'sync-project-fields.mjs still uses stale completion projectTitle logging',
+  );
+});


### PR DESCRIPTION
Fixes #183

## Summary
- remove the stale `projectTitle` logging references left behind in `.github/scripts/sync-project-fields.mjs`
- keep the backlog-title compatibility logic added in #192, but make the script consistently use the resolved project title at runtime
- add a regression test so future title-rename refactors do not reintroduce the same `ReferenceError`

## Root Cause
After #192 merged, `Sync GitHub Project` worked again for `pull_request_target`, but a manual `workflow_dispatch` run against `main` exposed two remaining log statements that still referenced the removed `projectTitle` constant. The script had already switched to `preferredProjectTitles`, so those code paths now threw `ReferenceError: projectTitle is not defined`.

## Testing
- [x] `node --test .github/scripts/tests/sync-project-fields.test.mjs`
- [x] `node --test .github/scripts/tests/*.mjs`
- [x] `git diff --check`

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Notes
- I already restored the live GitHub Project title to `Wink Backlog` after #192 merged.
- This follow-up PR exists because the post-merge manual `Sync GitHub Project` run on `main` revealed the stale log references.
