### PR TITLE
feat: surface shortcut status in settings list

### DIFF
--- a/Sources/Wink/Services/ShortcutStatusProvider.swift
+++ b/Sources/Wink/Services/ShortcutStatusProvider.swift
@@ -1,0 +1,140 @@
+import AppKit
+import Observation
+
+struct ShortcutRuntimeStatus: Equatable {
+    let isRunning: Bool
+    let isUnavailable: Bool
+
+    static let normal = ShortcutRuntimeStatus(isRunning: false, isUnavailable: false)
+}
+
+@MainActor
+@Observable
+final class ShortcutStatusProvider {
+    struct Client {
+        let applicationURL: (String) -> URL?
+        let runningBundleIdentifiers: () -> Set<String>
+    }
+
+    private struct ObservationToken {
+        let center: NotificationCenter
+        let token: NSObjectProtocol
+    }
+
+    private let client: Client
+    private let workspaceNotificationCenter: NotificationCenter
+    private let appNotificationCenter: NotificationCenter
+    private var trackedShortcuts: [AppShortcut] = []
+    private nonisolated(unsafe) var observationTokens: [ObservationToken] = []
+
+    private(set) var statusesByShortcutID: [UUID: ShortcutRuntimeStatus] = [:]
+
+    init(
+        client: Client = .live,
+        workspaceNotificationCenter: NotificationCenter = NSWorkspace.shared.notificationCenter,
+        appNotificationCenter: NotificationCenter = .default
+    ) {
+        self.client = client
+        self.workspaceNotificationCenter = workspaceNotificationCenter
+        self.appNotificationCenter = appNotificationCenter
+        observeNotifications()
+    }
+
+    deinit {
+        for observation in observationTokens {
+            observation.center.removeObserver(observation.token)
+        }
+    }
+
+    func track(_ shortcuts: [AppShortcut]) {
+        trackedShortcuts = shortcuts
+        refresh()
+    }
+
+    func refresh() {
+        statusesByShortcutID = makeStatuses(for: trackedShortcuts)
+    }
+
+    func status(for shortcut: AppShortcut) -> ShortcutRuntimeStatus {
+        statusesByShortcutID[shortcut.id]
+            ?? makeStatuses(for: [shortcut])[shortcut.id]
+            ?? .normal
+    }
+
+    private func observeNotifications() {
+        let workspaceNotifications: [Notification.Name] = [
+            NSWorkspace.didLaunchApplicationNotification,
+            NSWorkspace.didTerminateApplicationNotification
+        ]
+
+        for name in workspaceNotifications {
+            addObservation(for: name, center: workspaceNotificationCenter)
+        }
+
+        addObservation(
+            for: NSApplication.didBecomeActiveNotification,
+            center: appNotificationCenter
+        )
+    }
+
+    private func addObservation(
+        for name: Notification.Name,
+        center: NotificationCenter
+    ) {
+        let token = center.addObserver(
+            forName: name,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { [weak self] in
+                self?.refresh()
+            }
+        }
+
+        observationTokens.append(
+            ObservationToken(center: center, token: token)
+        )
+    }
+
+    private func makeStatuses(
+        for shortcuts: [AppShortcut]
+    ) -> [UUID: ShortcutRuntimeStatus] {
+        let runningBundleIdentifiers = client.runningBundleIdentifiers()
+        let uniqueBundleIdentifiers = Set(shortcuts.map(\.bundleIdentifier))
+        let availabilityByBundleIdentifier = Dictionary(
+            uniqueKeysWithValues: uniqueBundleIdentifiers.map { bundleIdentifier in
+                // A currently running app is still actionable even if LaunchServices
+                // cannot resolve it back to a bundle URL from its install location.
+                let isAvailable = runningBundleIdentifiers.contains(bundleIdentifier)
+                    || client.applicationURL(bundleIdentifier) != nil
+                return (bundleIdentifier, isAvailable)
+            }
+        )
+
+        return Dictionary(uniqueKeysWithValues: shortcuts.map { shortcut in
+            let isRunning = runningBundleIdentifiers.contains(shortcut.bundleIdentifier)
+            let isUnavailable = !(availabilityByBundleIdentifier[shortcut.bundleIdentifier] ?? false)
+            return (
+                shortcut.id,
+                ShortcutRuntimeStatus(
+                    isRunning: isRunning,
+                    isUnavailable: isUnavailable
+                )
+            )
+        })
+    }
+}
+
+extension ShortcutStatusProvider.Client {
+    @MainActor
+    static let live = ShortcutStatusProvider.Client(
+        applicationURL: { bundleIdentifier in
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+        },
+        runningBundleIdentifiers: {
+            Set(
+                NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier)
+            )
+        }
+    )
+}

--- a/Sources/Wink/UI/SettingsView.swift
+++ b/Sources/Wink/UI/SettingsView.swift
@@ -27,6 +27,7 @@ struct SettingsView: View {
     var preferences: AppPreferences
     var insightsViewModel: InsightsViewModel
     var appListProvider: AppListProvider
+    var shortcutStatusProvider: ShortcutStatusProvider
     @State private var selectedTab: SettingsTab = .shortcuts
 
     private var lifecycleHandler: SettingsViewLifecycleHandler {
@@ -45,7 +46,12 @@ struct SettingsView: View {
             Group {
                 switch selectedTab {
                 case .shortcuts:
-                    ShortcutsTabView(editor: editor, preferences: preferences, appListProvider: appListProvider)
+                    ShortcutsTabView(
+                        editor: editor,
+                        preferences: preferences,
+                        appListProvider: appListProvider,
+                        shortcutStatusProvider: shortcutStatusProvider
+                    )
                 case .general:
                     GeneralTabView(preferences: preferences, editor: editor)
                 case .insights:

--- a/Sources/Wink/UI/SettingsWindowController.swift
+++ b/Sources/Wink/UI/SettingsWindowController.swift
@@ -8,6 +8,7 @@ final class SettingsWindowController {
     private let usageTracker: UsageTracker?
     private let hyperKeyService: HyperKeyService?
     private let updateService: UpdateServicing?
+    private let shortcutStatusProvider: ShortcutStatusProvider
     private var window: NSWindow?
 
     init(
@@ -15,13 +16,15 @@ final class SettingsWindowController {
         shortcutManager: ShortcutManager,
         usageTracker: UsageTracker? = nil,
         hyperKeyService: HyperKeyService? = nil,
-        updateService: UpdateServicing? = nil
+        updateService: UpdateServicing? = nil,
+        shortcutStatusProvider: ShortcutStatusProvider = ShortcutStatusProvider()
     ) {
         self.shortcutStore = shortcutStore
         self.shortcutManager = shortcutManager
         self.usageTracker = usageTracker
         self.hyperKeyService = hyperKeyService
         self.updateService = updateService
+        self.shortcutStatusProvider = shortcutStatusProvider
     }
 
     func show() {
@@ -45,7 +48,13 @@ final class SettingsWindowController {
         )
         let insightsViewModel = InsightsViewModel(usageTracker: usageTracker, shortcutStore: shortcutStore)
         let appListProvider = AppListProvider()
-        let contentView = SettingsView(editor: editor, preferences: preferences, insightsViewModel: insightsViewModel, appListProvider: appListProvider)
+        let contentView = SettingsView(
+            editor: editor,
+            preferences: preferences,
+            insightsViewModel: insightsViewModel,
+            appListProvider: appListProvider,
+            shortcutStatusProvider: shortcutStatusProvider
+        )
         let hostingController = NSHostingController(rootView: contentView)
 
         let window = NSWindow(contentViewController: hostingController)

--- a/Sources/Wink/UI/ShortcutsTabView.swift
+++ b/Sources/Wink/UI/ShortcutsTabView.swift
@@ -10,12 +10,16 @@ private enum ShortcutRowMetrics {
 struct ShortcutsListRowPresentation {
     let title: String
     let subtitle: String
-    let missingAppWarning: String?
+    let showsRunningIndicator: Bool
+    let unavailableHelpText: String?
 
-    init(shortcut: AppShortcut, usageCount: Int, targetInstalled: Bool) {
+    init(shortcut: AppShortcut, usageCount: Int, runtimeStatus: ShortcutRuntimeStatus) {
         title = shortcut.appName
         subtitle = "\(usageCount)× past 7 days"
-        missingAppWarning = targetInstalled ? nil : "App not currently installed"
+        showsRunningIndicator = runtimeStatus.isRunning
+        unavailableHelpText = runtimeStatus.isUnavailable
+            ? "Couldn't find this app. Rebind it to restore the shortcut."
+            : nil
     }
 }
 
@@ -23,7 +27,7 @@ struct ShortcutsTabView: View {
     @Bindable var editor: ShortcutEditorState
     var preferences: AppPreferences
     var appListProvider: AppListProvider
-    private let appBundleLocator = AppBundleLocator()
+    var shortcutStatusProvider: ShortcutStatusProvider
 
     @State private var showingAppPicker = false
 
@@ -169,17 +173,23 @@ struct ShortcutsTabView: View {
                 }
             }
         }
+        .onAppear {
+            shortcutStatusProvider.track(editor.shortcuts)
+        }
+        .onChange(of: editor.shortcuts) { _, newShortcuts in
+            shortcutStatusProvider.track(newShortcuts)
+        }
     }
 
     @ViewBuilder
     private func shortcutRow(_ shortcut: AppShortcut, index: Int) -> some View {
-        let targetInstalled = appBundleLocator.applicationURL(for: shortcut.bundleIdentifier) != nil
         let importPreviewActive = editor.pendingRecipeImport != nil
+        let runtimeStatus = shortcutStatusProvider.status(for: shortcut)
 
         ShortcutsListRow(
             shortcut: shortcut,
             usageCount: editor.usageCounts[shortcut.id, default: 0],
-            targetInstalled: targetInstalled,
+            runtimeStatus: runtimeStatus,
             importPreviewActive: importPreviewActive,
             index: index,
             onToggleEnabled: {
@@ -274,7 +284,7 @@ struct ShortcutsTabView: View {
 struct ShortcutsListRow: View {
     let shortcut: AppShortcut
     let usageCount: Int
-    let targetInstalled: Bool
+    let runtimeStatus: ShortcutRuntimeStatus
     let importPreviewActive: Bool
     let index: Int
     let onToggleEnabled: @MainActor () -> Void
@@ -284,28 +294,61 @@ struct ShortcutsListRow: View {
         ShortcutsListRowPresentation(
             shortcut: shortcut,
             usageCount: usageCount,
-            targetInstalled: targetInstalled
+            runtimeStatus: runtimeStatus
         )
+    }
+
+    private var rowOpacity: Double {
+        switch (shortcut.isEnabled, runtimeStatus.isUnavailable) {
+        case (false, true):
+            0.4
+        case (false, false):
+            0.5
+        case (true, true):
+            0.65
+        case (true, false):
+            1.0
+        }
     }
 
     var body: some View {
         HStack(spacing: ShortcutRowMetrics.spacing) {
-            AppIconView(
-                bundleIdentifier: shortcut.bundleIdentifier,
-                size: ShortcutRowMetrics.iconSize
-            )
+            ZStack(alignment: .bottomTrailing) {
+                AppIconView(
+                    bundleIdentifier: shortcut.bundleIdentifier,
+                    size: ShortcutRowMetrics.iconSize
+                )
+
+                if let unavailableHelpText = presentation.unavailableHelpText {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.orange)
+                        .background(
+                            Circle()
+                                .fill(Color(nsColor: .windowBackgroundColor))
+                                .frame(width: 14, height: 14)
+                        )
+                        .offset(x: 3, y: 3)
+                        .help(unavailableHelpText)
+                }
+            }
 
             VStack(alignment: .leading, spacing: ShortcutRowMetrics.textSpacing) {
-                Text(presentation.title)
-                    .font(.system(size: 13, weight: .medium))
+                HStack(spacing: 6) {
+                    Text(presentation.title)
+                        .font(.system(size: 13, weight: .medium))
+
+                    if presentation.showsRunningIndicator {
+                        Circle()
+                            .fill(.green)
+                            .frame(width: 8, height: 8)
+                            .help("App is currently running")
+                    }
+                }
+
                 Text(presentation.subtitle)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
-                if let missingAppWarning = presentation.missingAppWarning {
-                    Label(missingAppWarning, systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                }
             }
 
             Spacer()
@@ -332,6 +375,6 @@ struct ShortcutsListRow: View {
         .padding(.horizontal, 14)
         .padding(.vertical, ShortcutRowMetrics.verticalPadding)
         .alternatingRowBackground(index: index)
-        .opacity(shortcut.isEnabled ? (targetInstalled ? 1.0 : 0.7) : 0.5)
+        .opacity(rowOpacity)
     }
 }

--- a/Sources/Wink/UI/ShortcutsTabView.swift
+++ b/Sources/Wink/UI/ShortcutsTabView.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Combine
 import SwiftUI
 
 private enum ShortcutRowMetrics {
@@ -7,16 +9,48 @@ private enum ShortcutRowMetrics {
     static let verticalPadding: CGFloat = 10
 }
 
+struct ShortcutRowAccessibilityOptions: Equatable {
+    let differentiateWithoutColor: Bool
+    let reduceMotion: Bool
+
+    static let standard = ShortcutRowAccessibilityOptions(
+        differentiateWithoutColor: false,
+        reduceMotion: false
+    )
+
+    @MainActor
+    static var current: ShortcutRowAccessibilityOptions {
+        let workspace = NSWorkspace.shared
+        return ShortcutRowAccessibilityOptions(
+            differentiateWithoutColor: workspace.accessibilityDisplayShouldDifferentiateWithoutColor,
+            reduceMotion: workspace.accessibilityDisplayShouldReduceMotion
+        )
+    }
+}
+
 struct ShortcutsListRowPresentation {
     let title: String
     let subtitle: String
+    let contentOpacity: Double
     let showsRunningIndicator: Bool
+    let runningStatusText: String?
+    let unavailableStatusText: String?
     let unavailableHelpText: String?
 
-    init(shortcut: AppShortcut, usageCount: Int, runtimeStatus: ShortcutRuntimeStatus) {
+    init(
+        shortcut: AppShortcut,
+        usageCount: Int,
+        runtimeStatus: ShortcutRuntimeStatus,
+        accessibilityOptions: ShortcutRowAccessibilityOptions = .standard
+    ) {
         title = shortcut.appName
         subtitle = "\(usageCount)× past 7 days"
+        contentOpacity = shortcut.isEnabled ? 1.0 : 0.65
         showsRunningIndicator = runtimeStatus.isRunning
+        runningStatusText = runtimeStatus.isRunning && accessibilityOptions.differentiateWithoutColor
+            ? "Running"
+            : nil
+        unavailableStatusText = runtimeStatus.isUnavailable ? "App unavailable" : nil
         unavailableHelpText = runtimeStatus.isUnavailable
             ? "Couldn't find this app. Rebind it to restore the shortcut."
             : nil
@@ -30,6 +64,7 @@ struct ShortcutsTabView: View {
     var shortcutStatusProvider: ShortcutStatusProvider
 
     @State private var showingAppPicker = false
+    @State private var accessibilityOptions = ShortcutRowAccessibilityOptions.standard
 
     var body: some View {
         let importPreviewActive = editor.pendingRecipeImport != nil
@@ -174,10 +209,18 @@ struct ShortcutsTabView: View {
             }
         }
         .onAppear {
+            accessibilityOptions = .current
             shortcutStatusProvider.track(editor.shortcuts)
         }
         .onChange(of: editor.shortcuts) { _, newShortcuts in
             shortcutStatusProvider.track(newShortcuts)
+        }
+        .onReceive(
+            NSWorkspace.shared.notificationCenter.publisher(
+                for: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification
+            )
+        ) { _ in
+            accessibilityOptions = .current
         }
     }
 
@@ -190,6 +233,7 @@ struct ShortcutsTabView: View {
             shortcut: shortcut,
             usageCount: editor.usageCounts[shortcut.id, default: 0],
             runtimeStatus: runtimeStatus,
+            accessibilityOptions: accessibilityOptions,
             importPreviewActive: importPreviewActive,
             index: index,
             onToggleEnabled: {
@@ -285,6 +329,7 @@ struct ShortcutsListRow: View {
     let shortcut: AppShortcut
     let usageCount: Int
     let runtimeStatus: ShortcutRuntimeStatus
+    let accessibilityOptions: ShortcutRowAccessibilityOptions
     let importPreviewActive: Bool
     let index: Int
     let onToggleEnabled: @MainActor () -> Void
@@ -294,21 +339,24 @@ struct ShortcutsListRow: View {
         ShortcutsListRowPresentation(
             shortcut: shortcut,
             usageCount: usageCount,
-            runtimeStatus: runtimeStatus
+            runtimeStatus: runtimeStatus,
+            accessibilityOptions: accessibilityOptions
         )
     }
 
-    private var rowOpacity: Double {
-        switch (shortcut.isEnabled, runtimeStatus.isUnavailable) {
-        case (false, true):
-            0.4
-        case (false, false):
-            0.5
-        case (true, true):
-            0.65
-        case (true, false):
-            1.0
-        }
+    private var statusAnimationKey: ShortcutRowStatusAnimationKey {
+        ShortcutRowStatusAnimationKey(
+            isEnabled: shortcut.isEnabled,
+            isRunning: runtimeStatus.isRunning,
+            isUnavailable: runtimeStatus.isUnavailable,
+            differentiateWithoutColor: accessibilityOptions.differentiateWithoutColor
+        )
+    }
+
+    private var statusAnimation: Animation? {
+        accessibilityOptions.reduceMotion
+            ? nil
+            : .easeOut(duration: 0.16)
     }
 
     var body: some View {
@@ -322,7 +370,7 @@ struct ShortcutsListRow: View {
                 if let unavailableHelpText = presentation.unavailableHelpText {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(Color(nsColor: .systemOrange))
                         .background(
                             Circle()
                                 .fill(Color(nsColor: .windowBackgroundColor))
@@ -339,16 +387,31 @@ struct ShortcutsListRow: View {
                         .font(.system(size: 13, weight: .medium))
 
                     if presentation.showsRunningIndicator {
-                        Circle()
-                            .fill(.green)
-                            .frame(width: 8, height: 8)
-                            .help("App is currently running")
+                        HStack(spacing: 4) {
+                            Circle()
+                                .fill(Color(nsColor: .systemGreen))
+                                .frame(width: 8, height: 8)
+
+                            if let runningStatusText = presentation.runningStatusText {
+                                Text(runningStatusText)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        .help("App is currently running")
                     }
                 }
 
                 Text(presentation.subtitle)
                     .font(.caption)
                     .foregroundStyle(.tertiary)
+
+                if let unavailableStatusText = presentation.unavailableStatusText {
+                    Label(unavailableStatusText, systemImage: "exclamationmark.triangle.fill")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color(nsColor: .systemOrange))
+                        .help(presentation.unavailableHelpText ?? unavailableStatusText)
+                }
             }
 
             Spacer()
@@ -375,6 +438,14 @@ struct ShortcutsListRow: View {
         .padding(.horizontal, 14)
         .padding(.vertical, ShortcutRowMetrics.verticalPadding)
         .alternatingRowBackground(index: index)
-        .opacity(rowOpacity)
+        .opacity(presentation.contentOpacity)
+        .animation(statusAnimation, value: statusAnimationKey)
     }
+}
+
+private struct ShortcutRowStatusAnimationKey: Equatable {
+    let isEnabled: Bool
+    let isRunning: Bool
+    let isUnavailable: Bool
+    let differentiateWithoutColor: Bool
 }

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -74,15 +74,40 @@ struct LayoutRegressionTests {
         let presentation = ShortcutsListRowPresentation(
             shortcut: shortcut,
             usageCount: 732,
-            targetInstalled: false
+            runtimeStatus: ShortcutRuntimeStatus(
+                isRunning: false,
+                isUnavailable: true
+            )
         )
 
         #expect(presentation.title == "Missing App")
         #expect(presentation.subtitle == "732× past 7 days")
-        #expect(presentation.missingAppWarning == "App not currently installed")
+        #expect(presentation.showsRunningIndicator == false)
+        #expect(presentation.unavailableHelpText == "Couldn't find this app. Rebind it to restore the shortcut.")
         #expect(presentation.title != "com.example.MissingApp")
         #expect(presentation.subtitle != "com.example.MissingApp")
-        #expect(presentation.missingAppWarning != "com.example.MissingApp")
+        #expect(presentation.unavailableHelpText != "com.example.MissingApp")
+    }
+
+    @Test @MainActor
+    func shortcutsListRowPresentationShowsRunningIndicatorWhenAppIsActive() {
+        let shortcut = AppShortcut(
+            appName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            keyEquivalent: "s",
+            modifierFlags: ["command"]
+        )
+        let presentation = ShortcutsListRowPresentation(
+            shortcut: shortcut,
+            usageCount: 12,
+            runtimeStatus: ShortcutRuntimeStatus(
+                isRunning: true,
+                isUnavailable: false
+            )
+        )
+
+        #expect(presentation.showsRunningIndicator == true)
+        #expect(presentation.unavailableHelpText == nil)
     }
 }
 

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -82,10 +82,14 @@ struct LayoutRegressionTests {
 
         #expect(presentation.title == "Missing App")
         #expect(presentation.subtitle == "732× past 7 days")
+        #expect(presentation.contentOpacity == 1.0)
         #expect(presentation.showsRunningIndicator == false)
+        #expect(presentation.runningStatusText == nil)
+        #expect(presentation.unavailableStatusText == "App unavailable")
         #expect(presentation.unavailableHelpText == "Couldn't find this app. Rebind it to restore the shortcut.")
         #expect(presentation.title != "com.example.MissingApp")
         #expect(presentation.subtitle != "com.example.MissingApp")
+        #expect(presentation.unavailableStatusText != "com.example.MissingApp")
         #expect(presentation.unavailableHelpText != "com.example.MissingApp")
     }
 
@@ -107,7 +111,56 @@ struct LayoutRegressionTests {
         )
 
         #expect(presentation.showsRunningIndicator == true)
+        #expect(presentation.runningStatusText == nil)
         #expect(presentation.unavailableHelpText == nil)
+    }
+
+    @Test @MainActor
+    func shortcutsListRowPresentationAddsRunningLabelWhenDifferentiateWithoutColorIsEnabled() {
+        let shortcut = AppShortcut(
+            appName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            keyEquivalent: "s",
+            modifierFlags: ["command"]
+        )
+        let presentation = ShortcutsListRowPresentation(
+            shortcut: shortcut,
+            usageCount: 12,
+            runtimeStatus: ShortcutRuntimeStatus(
+                isRunning: true,
+                isUnavailable: false
+            ),
+            accessibilityOptions: ShortcutRowAccessibilityOptions(
+                differentiateWithoutColor: true,
+                reduceMotion: false
+            )
+        )
+
+        #expect(presentation.showsRunningIndicator == true)
+        #expect(presentation.runningStatusText == "Running")
+        #expect(presentation.unavailableStatusText == nil)
+    }
+
+    @Test @MainActor
+    func shortcutsListRowPresentationOnlyDimsDisabledRows() {
+        let shortcut = AppShortcut(
+            appName: "Terminal",
+            bundleIdentifier: "com.apple.Terminal",
+            keyEquivalent: "t",
+            modifierFlags: ["command"],
+            isEnabled: false
+        )
+        let presentation = ShortcutsListRowPresentation(
+            shortcut: shortcut,
+            usageCount: 4,
+            runtimeStatus: ShortcutRuntimeStatus(
+                isRunning: false,
+                isUnavailable: true
+            )
+        )
+
+        #expect(presentation.contentOpacity == 0.65)
+        #expect(presentation.unavailableStatusText == "App unavailable")
     }
 }
 

--- a/Tests/WinkTests/ShortcutStatusProviderTests.swift
+++ b/Tests/WinkTests/ShortcutStatusProviderTests.swift
@@ -1,0 +1,177 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Wink
+
+@Suite("Shortcut status provider")
+struct ShortcutStatusProviderTests {
+    @Test @MainActor
+    func trackBuildsRunningAndUnavailableStates() {
+        let state = ShortcutStatusProviderState(
+            applicationURLs: [
+                "com.apple.Safari": URL(fileURLWithPath: "/Applications/Safari.app")
+            ],
+            runningBundleIdentifiers: ["com.apple.Safari"]
+        )
+        let provider = makeProvider(state: state)
+        let safariShortcut = AppShortcut(
+            appName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            keyEquivalent: "s",
+            modifierFlags: ["command"]
+        )
+        let ghostShortcut = AppShortcut(
+            appName: "Ghostty",
+            bundleIdentifier: "com.mitchellh.ghostty",
+            keyEquivalent: "g",
+            modifierFlags: ["command"]
+        )
+
+        provider.track([safariShortcut, ghostShortcut])
+
+        #expect(
+            provider.status(for: safariShortcut)
+            == ShortcutRuntimeStatus(isRunning: true, isUnavailable: false)
+        )
+        #expect(
+            provider.status(for: ghostShortcut)
+            == ShortcutRuntimeStatus(isRunning: false, isUnavailable: true)
+        )
+    }
+
+    @Test @MainActor
+    func runningAppRemainsAvailableWhenLaunchServicesCannotResolveBundleURL() {
+        let state = ShortcutStatusProviderState(
+            applicationURLs: [:],
+            runningBundleIdentifiers: ["com.apple.Safari"]
+        )
+        let provider = makeProvider(state: state)
+        let safariShortcut = AppShortcut(
+            appName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            keyEquivalent: "s",
+            modifierFlags: ["command"]
+        )
+
+        provider.track([safariShortcut])
+
+        #expect(
+            provider.status(for: safariShortcut)
+            == ShortcutRuntimeStatus(isRunning: true, isUnavailable: false)
+        )
+    }
+
+    @Test @MainActor
+    func workspaceNotificationsRefreshRunningState() {
+        let state = ShortcutStatusProviderState(
+            applicationURLs: [
+                "com.apple.Safari": URL(fileURLWithPath: "/Applications/Safari.app")
+            ],
+            runningBundleIdentifiers: []
+        )
+        let workspaceNotificationCenter = NotificationCenter()
+        let provider = makeProvider(
+            state: state,
+            workspaceNotificationCenter: workspaceNotificationCenter
+        )
+        let safariShortcut = AppShortcut(
+            appName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            keyEquivalent: "s",
+            modifierFlags: ["command"]
+        )
+
+        provider.track([safariShortcut])
+        #expect(provider.status(for: safariShortcut).isRunning == false)
+
+        state.runningBundleIdentifiers = ["com.apple.Safari"]
+        workspaceNotificationCenter.post(
+            name: NSWorkspace.didLaunchApplicationNotification,
+            object: nil
+        )
+        drainMainRunLoop()
+
+        #expect(provider.status(for: safariShortcut).isRunning == true)
+
+        state.runningBundleIdentifiers = []
+        workspaceNotificationCenter.post(
+            name: NSWorkspace.didTerminateApplicationNotification,
+            object: nil
+        )
+        drainMainRunLoop()
+
+        #expect(provider.status(for: safariShortcut).isRunning == false)
+    }
+
+    @Test @MainActor
+    func appActivationRefreshesAvailabilityState() {
+        let state = ShortcutStatusProviderState(
+            applicationURLs: [
+                "com.apple.Safari": URL(fileURLWithPath: "/Applications/Safari.app")
+            ],
+            runningBundleIdentifiers: []
+        )
+        let appNotificationCenter = NotificationCenter()
+        let provider = makeProvider(
+            state: state,
+            appNotificationCenter: appNotificationCenter
+        )
+        let safariShortcut = AppShortcut(
+            appName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            keyEquivalent: "s",
+            modifierFlags: ["command"]
+        )
+
+        provider.track([safariShortcut])
+        #expect(provider.status(for: safariShortcut).isUnavailable == false)
+
+        state.applicationURLs["com.apple.Safari"] = nil
+        appNotificationCenter.post(
+            name: NSApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        drainMainRunLoop()
+
+        #expect(provider.status(for: safariShortcut).isUnavailable == true)
+    }
+}
+
+@MainActor
+private func makeProvider(
+    state: ShortcutStatusProviderState,
+    workspaceNotificationCenter: NotificationCenter = NotificationCenter(),
+    appNotificationCenter: NotificationCenter = NotificationCenter()
+) -> ShortcutStatusProvider {
+    ShortcutStatusProvider(
+        client: .init(
+            applicationURL: { bundleIdentifier in
+                state.applicationURLs[bundleIdentifier]
+            },
+            runningBundleIdentifiers: {
+                state.runningBundleIdentifiers
+            }
+        ),
+        workspaceNotificationCenter: workspaceNotificationCenter,
+        appNotificationCenter: appNotificationCenter
+    )
+}
+
+@MainActor
+private func drainMainRunLoop() {
+    RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+}
+
+@MainActor
+private final class ShortcutStatusProviderState {
+    var applicationURLs: [String: URL]
+    var runningBundleIdentifiers: Set<String>
+
+    init(
+        applicationURLs: [String: URL],
+        runningBundleIdentifiers: Set<String>
+    ) {
+        self.applicationURLs = applicationURLs
+        self.runningBundleIdentifiers = runningBundleIdentifiers
+    }
+}


### PR DESCRIPTION
Fixes #178

## Summary
- add shared shortcut runtime status tracking for Settings > Shortcuts so rows can reflect running and unavailable apps
- refine row presentation so disabled shortcuts are only lightly de-emphasized, unavailable apps show a persistent warning label, and running state gains an explicit label when macOS asks to differentiate without color
- add regression coverage for the new presentation rules and keep the provider behavior verified when LaunchServices cannot resolve a currently running app

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Notes
- Manually validated `/Users/yvan/developer/Wink/build/Wink.app` on macOS in `Settings > Shortcuts` with a reversible fixture covering `running`, `disabled`, and `unavailable` row states plus screenshot review.
