### PR TITLE
docs: link workflow harness repo from docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This directory maps the maintainer-facing docs for Wink.
 - [`pr-governance-rollout.md`](./pr-governance-rollout.md) — one-time rollout runbook for the review gate and `main` ruleset apply sequence
 - [`loop-prompt.md`](./loop-prompt.md) — reference and migration note; active automation is the `/babysit-prs` skill
 - [`loop-job-guide.md`](./loop-job-guide.md) — how to run and manage loop jobs with `/loop 30m /babysit-prs`
+- [`agent-workflow-harnesses`](https://github.com/xrf9268-hue/agent-workflow-harnesses) — external maintainer workflow harness repo for cross-session issue handoff, PR watch, and reusable automation templates across Wink and related repos
 
 ## Historical and Process Docs
 - [`archive/`](./archive/)


### PR DESCRIPTION
Fixes #213

## Summary
- add a maintainer-facing docs index entry for the external `agent-workflow-harnesses` repo
- keep the change limited to discoverability instead of moving workflow harness details back into Wink

## Testing
- [ ] `swift test`
- [x] Docs-only change; no code paths or runtime behavior changed

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Notes
- This PR only adds a lightweight maintainer docs entry under `docs/README.md`.
