### PR TITLE
fix: sync settings shortcut state after startup

### DIFF
--- a/Sources/Wink/Services/ShortcutEditorState.swift
+++ b/Sources/Wink/Services/ShortcutEditorState.swift
@@ -108,6 +108,7 @@ final class ShortcutEditorState {
         self.appBundleLocator = appBundleLocator
         self.onShortcutConfigurationChange = onShortcutConfigurationChange
         self.shortcuts = shortcutStore.shortcuts
+        observeShortcutStore()
         Task { await refreshUsageCounts() }
     }
 
@@ -292,6 +293,24 @@ final class ShortcutEditorState {
     func refreshUsageCounts() async {
         guard let usageTracker else { return }
         usageCounts = await usageTracker.usageCounts(days: 7)
+    }
+
+    private func observeShortcutStore() {
+        withObservationTracking {
+            _ = shortcutStore.shortcuts
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+
+                let latestShortcuts = self.shortcutStore.shortcuts
+                if self.shortcuts != latestShortcuts {
+                    self.shortcuts = latestShortcuts
+                    await self.refreshUsageCounts()
+                }
+
+                self.observeShortcutStore()
+            }
+        }
     }
 
     private func resetDraft() {

--- a/Sources/Wink/Services/ShortcutStore.swift
+++ b/Sources/Wink/Services/ShortcutStore.swift
@@ -1,6 +1,8 @@
 import Foundation
+import Observation
 
 @MainActor
+@Observable
 final class ShortcutStore {
     private(set) var shortcuts: [AppShortcut] = []
 

--- a/Tests/WinkTests/ShortcutEditorStateTests.swift
+++ b/Tests/WinkTests/ShortcutEditorStateTests.swift
@@ -40,6 +40,39 @@ func savingShortcutChangesInvokesConfigurationChangeHandler() {
 }
 
 @Test @MainActor
+func editorSynchronizesWhenShortcutStoreChangesExternally() async {
+    let context = makeEditorContext()
+    defer { context.harness.cleanup() }
+
+    let safari = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "s",
+        modifierFlags: ["command", "shift"]
+    )
+
+    context.shortcutStore.replaceAll(with: [safari])
+
+    await waitUntil("editor syncs loaded shortcuts from store") {
+        context.editor.shortcuts.map(\.id) == [safari.id]
+    }
+
+    #expect(context.editor.shortcuts.map(\.id) == [safari.id])
+    #expect(context.editor.allEnabled == true)
+
+    var disabledSafari = safari
+    disabledSafari.isEnabled = false
+    context.shortcutStore.replaceAll(with: [disabledSafari])
+
+    await waitUntil("editor syncs enabled state from store") {
+        context.editor.shortcuts.first?.isEnabled == false
+    }
+
+    #expect(context.editor.shortcuts.first?.isEnabled == false)
+    #expect(context.editor.allEnabled == false)
+}
+
+@Test @MainActor
 func movingShortcutPersistsOrderAndInvokesConfigurationChangeHandler() throws {
     let shortcutStore = ShortcutStore()
     let safari = AppShortcut(
@@ -464,6 +497,24 @@ private final class ImportScanRecorder: @unchecked Sendable {
 
     init(now: Date) {
         self.now = now
+    }
+}
+
+@MainActor
+private func waitUntil(
+    _ description: String,
+    timeout: Duration = .seconds(2),
+    pollInterval: Duration = .milliseconds(20),
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let clock = ContinuousClock()
+    let deadline = clock.now + timeout
+    while !condition() {
+        if clock.now >= deadline {
+            Issue.record("Timed out waiting for: \(description)")
+            return
+        }
+        try? await Task.sleep(for: pollInterval)
     }
 }
 


### PR DESCRIPTION
Fixes #215

## Summary
- keep the Settings shortcut list and master switch synchronized with the live shortcut store after packaged-app startup
- make `ShortcutStore` observable and resubscribe `ShortcutEditorState` so startup restoration no longer leaves Settings with a stale empty snapshot

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed
- `bash scripts/package-app.sh`
- `bash scripts/e2e-full-test.sh`
- Packaged macOS runtime validation on `/Users/yvan/developer/Wink/build/Wink.app`
- Verified Settings > Shortcuts shows `Your Shortcuts · 4`
- Verified Settings > General shows `Enable All Shortcuts` as `on`

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Notes
- The first post-fix full-screen captures were invalid because they grabbed the wrong desktop content; the final local evidence was re-captured directly from the `Wink Settings` window.
