### PR TITLE
fix: suppress automatic permission prompts in packaged e2e

### DIFF
--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -39,6 +39,7 @@ final class AppController {
         appSwitcher: appSwitcher,
         usageTracker: usageTracker,
         appBundleLocator: appBundleLocator,
+        automaticPermissionPromptingEnabled: ShortcutManager.defaultAutomaticPermissionPromptingEnabled(),
         diagnosticClient: .live
     )
     private lazy var appPreferences = AppPreferences(

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -4,9 +4,18 @@ import UserNotifications
 import os.log
 
 private let logger = Logger(subsystem: DiagnosticLog.subsystem, category: "ShortcutManager")
+private let shortcutManagerSuppressAutomaticPermissionPromptsArgument = "--suppress-automatic-permission-prompts"
+
+private func shortcutManagerAutomaticPermissionPromptingEnabled(
+    processInfo: ProcessInfo = .processInfo
+) -> Bool {
+    !processInfo.arguments.contains(shortcutManagerSuppressAutomaticPermissionPromptsArgument)
+}
 
 @MainActor
 final class ShortcutManager {
+    static let suppressAutomaticPermissionPromptsArgument = shortcutManagerSuppressAutomaticPermissionPromptsArgument
+
     struct DiagnosticClient {
         let log: @Sendable (String) -> Void
     }
@@ -19,6 +28,7 @@ final class ShortcutManager {
     private let usageTracker: UsageTracker?
     private let appBundleLocator: AppBundleLocator
     private let diagnosticClient: DiagnosticClient
+    private let automaticPermissionPromptingEnabled: Bool
     private let keyMatcher = KeyMatcher()
     private var triggerIndex: [ShortcutTrigger: AppShortcut] = [:]
     private var permissionTimer: Timer?
@@ -38,6 +48,7 @@ final class ShortcutManager {
         permissionService: any PermissionServicing = AccessibilityPermissionService(),
         usageTracker: UsageTracker? = nil,
         appBundleLocator: AppBundleLocator = AppBundleLocator(),
+        automaticPermissionPromptingEnabled: Bool = shortcutManagerAutomaticPermissionPromptingEnabled(),
         diagnosticClient: DiagnosticClient
     ) {
         self.shortcutStore = shortcutStore
@@ -48,6 +59,7 @@ final class ShortcutManager {
         self.usageTracker = usageTracker
         self.appBundleLocator = appBundleLocator
         self.diagnosticClient = diagnosticClient
+        self.automaticPermissionPromptingEnabled = automaticPermissionPromptingEnabled
     }
 
     func start() {
@@ -60,9 +72,12 @@ final class ShortcutManager {
             let shouldRequestInputMonitoring = inputMonitoringRequired
                 && permissionService.isAccessibilityTrusted()
             ready = permissionService.requestIfNeeded(
-                prompt: true,
+                prompt: automaticPermissionPromptingEnabled,
                 inputMonitoringRequired: shouldRequestInputMonitoring
             )
+        }
+        if !automaticPermissionPromptingEnabled {
+            diagnosticClient.log("Automatic permission prompts suppressed for this launch")
         }
         logger.info(
             "start(): ready=\(ready), ax=\(self.permissionService.isAccessibilityTrusted()), im=\(self.permissionService.isInputMonitoringTrusted()), inputMonitoringRequired=\(inputMonitoringRequired), paused=\(self.shortcutsPaused)"
@@ -144,7 +159,7 @@ final class ShortcutManager {
         let shouldRequestInputMonitoring = captureCoordinator.inputMonitoringRequired
             && permissionService.isAccessibilityTrusted()
         _ = permissionService.requestIfNeeded(
-            prompt: true,
+            prompt: automaticPermissionPromptingEnabled,
             inputMonitoringRequired: shouldRequestInputMonitoring
         )
         attemptStartIfPermitted()
@@ -238,7 +253,7 @@ final class ShortcutManager {
             && !imGranted
         {
             _ = permissionService.requestIfNeeded(
-                prompt: true,
+                prompt: automaticPermissionPromptingEnabled,
                 inputMonitoringRequired: true
             )
             let refreshedInputMonitoring = permissionService.isInputMonitoringTrusted()
@@ -337,7 +352,7 @@ final class ShortcutManager {
             && permissionService.isAccessibilityTrusted()
         {
             _ = permissionService.requestIfNeeded(
-                prompt: true,
+                prompt: automaticPermissionPromptingEnabled,
                 inputMonitoringRequired: true
             )
         }
@@ -475,6 +490,12 @@ final class ShortcutManager {
 
     private func quoted(_ value: String) -> String {
         "\"\(value.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "\"", with: "\\\""))\""
+    }
+
+    static func defaultAutomaticPermissionPromptingEnabled(
+        processInfo: ProcessInfo = .processInfo
+    ) -> Bool {
+        shortcutManagerAutomaticPermissionPromptingEnabled(processInfo: processInfo)
     }
 }
 

--- a/Sources/Wink/UI/ShortcutsTabView.swift
+++ b/Sources/Wink/UI/ShortcutsTabView.swift
@@ -321,7 +321,7 @@ struct ShortcutsTabView: View {
         case let .warning(title, message, showsAction):
             WinkBanner(kind: .warn, title: title, message: message) {
                 if showsAction {
-                    WinkButton("Open Settings", variant: .primary) {
+                    WinkButton(permissionActionTitle, variant: .primary) {
                         preferences.requestShortcutPermissions()
                     }
                 } else {
@@ -331,6 +331,17 @@ struct ShortcutsTabView: View {
                 }
             }
         }
+    }
+
+    private var permissionActionTitle: String {
+        let status = preferences.shortcutCaptureStatus
+        if !status.accessibilityGranted {
+            return "Request Accessibility"
+        }
+        if status.inputMonitoringRequired && !status.inputMonitoringGranted && !status.hyperShortcutsReady {
+            return "Request Input Monitoring"
+        }
+        return "Request Access"
     }
 
     @ViewBuilder

--- a/Tests/WinkTests/ShortcutManagerStatusTests.swift
+++ b/Tests/WinkTests/ShortcutManagerStatusTests.swift
@@ -29,6 +29,7 @@ private final class MutablePermissionService: @unchecked Sendable, PermissionSer
     var ax: Bool
     var input: Bool
     var requestCallCount = 0
+    var requestedPromptFlags: [Bool] = []
     var requestedInputMonitoringFlags: [Bool] = []
     var grantInputMonitoringOnPrompt = false
 
@@ -52,6 +53,7 @@ private final class MutablePermissionService: @unchecked Sendable, PermissionSer
     @discardableResult
     func requestIfNeeded(prompt: Bool, inputMonitoringRequired: Bool) -> Bool {
         requestCallCount += 1
+        requestedPromptFlags.append(prompt)
         requestedInputMonitoringFlags.append(inputMonitoringRequired)
         if prompt && inputMonitoringRequired && grantInputMonitoringOnPrompt && ax {
             input = true
@@ -190,6 +192,7 @@ private func makeShortcutManager(
     hyperProvider: FakeHyperCaptureProvider = FakeHyperCaptureProvider(),
     persistenceHarness: TestPersistenceHarness = TestPersistenceHarness(),
     appBundleLocator: AppBundleLocator = defaultShortcutManagerAppBundleLocator(),
+    automaticPermissionPromptingEnabled: Bool = true,
     diagnosticSink: @escaping @Sendable (String) -> Void = { _ in }
 ) -> (manager: ShortcutManager, standardProvider: FakeCaptureProvider, hyperProvider: FakeHyperCaptureProvider, persistenceHarness: TestPersistenceHarness) {
     let coordinator = ShortcutCaptureCoordinator(
@@ -203,6 +206,7 @@ private func makeShortcutManager(
         captureCoordinator: coordinator,
         permissionService: permissionService,
         appBundleLocator: appBundleLocator,
+        automaticPermissionPromptingEnabled: automaticPermissionPromptingEnabled,
         diagnosticClient: .init(log: diagnosticSink)
     )
     return (manager, standardProvider, hyperProvider, persistenceHarness)
@@ -469,6 +473,7 @@ func startDoesNotRequestInputMonitoringWhenCurrentConfigurationIsStandardOnly() 
     manager.start()
 
     #expect(permissionService.requestCallCount == 1)
+    #expect(permissionService.requestedPromptFlags == [true])
     #expect(permissionService.requestedInputMonitoringFlags == [false])
     #expect(standardProvider.startCallCount == 1)
     #expect(hyperProvider.startCallCount == 0)
@@ -489,6 +494,7 @@ func startRequestsInputMonitoringWhenCurrentConfigurationNeedsHyperTransport() {
     let status = manager.shortcutCaptureStatus()
 
     #expect(permissionService.requestCallCount == 1)
+    #expect(permissionService.requestedPromptFlags == [true])
     #expect(permissionService.requestedInputMonitoringFlags == [true])
     #expect(status.inputMonitoringGranted == true)
     #expect(status.inputMonitoringRequired == true)
@@ -510,6 +516,7 @@ func startDefersInputMonitoringPromptUntilAccessibilityIsGrantedForHyperConfigur
 
     manager.start()
 
+    #expect(permissionService.requestedPromptFlags == [true])
     #expect(permissionService.requestedInputMonitoringFlags == [false])
     #expect(permissionService.input == false)
     #expect(standardProvider.isRunning == false)
@@ -520,6 +527,7 @@ func startDefersInputMonitoringPromptUntilAccessibilityIsGrantedForHyperConfigur
 
     let status = manager.shortcutCaptureStatus()
 
+    #expect(permissionService.requestedPromptFlags == [true, true])
     #expect(permissionService.requestedInputMonitoringFlags == [false, true])
     #expect(status.accessibilityGranted == true)
     #expect(status.inputMonitoringGranted == true)
@@ -543,6 +551,7 @@ func mixedConfigurationKeepsStandardShortcutsReadyWhileHyperWaitsForInputMonitor
 
     let status = manager.shortcutCaptureStatus()
 
+    #expect(permissionService.requestedPromptFlags == [true])
     #expect(permissionService.requestedInputMonitoringFlags == [true])
     #expect(status.inputMonitoringGranted == false)
     #expect(status.inputMonitoringRequired == true)
@@ -562,6 +571,7 @@ func enablingHyperAtRuntimeRequestsInputMonitoringAndResyncsCapture() {
     manager.save(shortcuts: [hyperShortcut()])
     manager.start()
 
+    #expect(permissionService.requestedPromptFlags == [true])
     #expect(permissionService.requestedInputMonitoringFlags == [false])
     #expect(standardProvider.isRunning == true)
     #expect(hyperProvider.isRunning == false)
@@ -570,6 +580,7 @@ func enablingHyperAtRuntimeRequestsInputMonitoringAndResyncsCapture() {
 
     let status = manager.shortcutCaptureStatus()
 
+    #expect(permissionService.requestedPromptFlags == [true, true])
     #expect(permissionService.requestedInputMonitoringFlags == [false, true])
     #expect(status.inputMonitoringGranted == true)
     #expect(status.inputMonitoringRequired == true)
@@ -591,6 +602,7 @@ func grantingAccessibilityAfterHyperBecomesRequiredRequestsInputMonitoring() {
     manager.start()
     manager.setHyperKeyEnabled(true)
 
+    #expect(permissionService.requestedPromptFlags == [true])
     #expect(permissionService.requestedInputMonitoringFlags == [false])
     #expect(standardProvider.isRunning == false)
     #expect(hyperProvider.isRunning == false)
@@ -600,6 +612,7 @@ func grantingAccessibilityAfterHyperBecomesRequiredRequestsInputMonitoring() {
 
     let status = manager.shortcutCaptureStatus()
 
+    #expect(permissionService.requestedPromptFlags == [true, true])
     #expect(permissionService.requestedInputMonitoringFlags == [false, true])
     #expect(status.accessibilityGranted == true)
     #expect(status.inputMonitoringGranted == true)
@@ -654,6 +667,52 @@ func unchangedPermissionsDoNotResyncCaptureRepeatedly() {
 
     #expect(standardProvider.startCallCount == standardStartsAfterLaunch)
     #expect(hyperProvider.startCallCount == hyperStartsAfterLaunch)
+}
+
+@Test @MainActor
+func startSuppressesAutomaticPermissionPromptsWhenDisabledForThisLaunch() {
+    let permissionService = MutablePermissionService(ax: true, input: false)
+    let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
+        permissionService: permissionService,
+        automaticPermissionPromptingEnabled: false
+    )
+    manager.save(shortcuts: [hyperShortcut()])
+    manager.setHyperKeyEnabled(true)
+
+    manager.start()
+
+    let status = manager.shortcutCaptureStatus()
+
+    #expect(permissionService.requestCallCount == 1)
+    #expect(permissionService.requestedPromptFlags == [false])
+    #expect(permissionService.requestedInputMonitoringFlags == [true])
+    #expect(status.inputMonitoringGranted == false)
+    #expect(status.hyperShortcutsReady == false)
+    #expect(standardProvider.startCallCount == 0)
+    #expect(hyperProvider.startCallCount == 0)
+}
+
+@Test @MainActor
+func explicitPermissionRequestStillPromptsWhenAutomaticPromptsAreDisabled() {
+    let permissionService = MutablePermissionService(ax: true, input: false)
+    permissionService.grantInputMonitoringOnPrompt = true
+    let (manager, _, hyperProvider, _) = makeShortcutManager(
+        permissionService: permissionService,
+        automaticPermissionPromptingEnabled: false
+    )
+    manager.save(shortcuts: [hyperShortcut()])
+    manager.setHyperKeyEnabled(true)
+
+    manager.start()
+    manager.requestPermissions()
+
+    let status = manager.shortcutCaptureStatus()
+
+    #expect(permissionService.requestedPromptFlags == [false, true])
+    #expect(permissionService.requestedInputMonitoringFlags == [true, true])
+    #expect(status.inputMonitoringGranted == true)
+    #expect(status.hyperShortcutsReady == true)
+    #expect(hyperProvider.isRunning == true)
 }
 
 @Test @MainActor

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -110,6 +110,42 @@ The macOS 15 SDK contract for `CGPreflightListenEventAccess()` / `CGRequestListe
 **Practical guidance**
 When investigating Hyper capture, trust the live runtime signals first: `CGPreflightListenEventAccess()`, the Wink Settings banner, `Event tap started`, and an actual Hyper end-to-end pass. Treat the System Settings pane as helpful but non-authoritative UI that may lag behind live access. Signature churn and launch-path mismatches still matter, so validate with `open Wink.app` and remember that rebuilding or re-signing can change the TCC identity that System Settings associates with the app.
 
+## Suppress Automatic Permission Prompts During E2E Harness Launches
+
+**Issue**
+Repeated packaged-app reruns during local runtime validation can stack duplicate macOS permission sheets if each cold start immediately calls the startup prompt path before the previous sheet is resolved.
+
+**Cause**
+The product's normal startup path may intentionally use the Accessibility/Input Monitoring prompt APIs, but the E2E harness is a rerun-heavy workflow. When a validation run fails for local TCC reasons and the operator relaunches repeatedly, each fresh launch can enqueue another system sheet instead of producing a clean fail-fast result.
+
+**Practical guidance**
+Keep normal product behavior unchanged, but let the repository E2E harness launch Wink with a dedicated `--suppress-automatic-permission-prompts` argument. In that mode, startup still checks live permission state, but it must not call the automatic prompt path; explicit user actions in Settings can still request access when needed. This keeps rerun-heavy validation from creating multiple overlapping system dialogs while preserving truthful readiness failures in the harness.
+
+## A Suppressed Harness Launch Can Still Fail Cleanly On TCC
+
+**Issue**
+After adding `--suppress-automatic-permission-prompts`, a freshly rebuilt packaged app may still start with `ax=false im=false carbon=false eventTap=false` and the harness may fail in startup readiness.
+
+**Cause**
+The launch argument only suppresses the automatic startup prompt path. It does not change TCC identity matching, and it does not grant permissions by itself. After an ad-hoc rebuild, the first rerun can fail cleanly because the current bundle no longer matches the previous TCC record.
+
+**Practical guidance**
+Do not treat that first clean failure as proof that the suppress flag is broken. Treat it as a better diagnostic result: the harness is reporting the local TCC blocker without piling on more permission sheets. Re-grant the exact current packaged bundle, then rerun the suite.
+
+## Duplicate Permission Sheets After Suppression Usually Mean Another Launch Path Exists
+
+**Issue**
+You still see repeated macOS permission dialogs even though the E2E harness now launches Wink with `--suppress-automatic-permission-prompts`.
+
+**Cause**
+Another launch path is still active. Typical causes are:
+- a second `Wink.app` copy launched from another worktree or path
+- a system-driven `Quit and Reopen` relaunch that reopened the wrong bundle
+- an explicit in-app permission request action, which should still be allowed to prompt
+
+**Practical guidance**
+When repeated permission sheets still appear, do not immediately remove the suppression behavior. First verify the running executable path with `pgrep -fal`, inspect the debug log for multiple `Wink starting` lines, and confirm whether the prompt came from an explicit permission request rather than the startup path. Fix the duplicate launch path or wrong bundle relaunch first, then rerun validation.
+
 ## Ad-hoc Signing and TCC
 
 **Issue**

--- a/scripts/e2e-lib.bats
+++ b/scripts/e2e-lib.bats
@@ -133,6 +133,27 @@ LOG
   [ "$status" -eq 0 ]
 }
 
+@test "e2e_launch_app suppresses automatic permission prompts for validation launches" {
+  local app_dir="$BATS_TEST_TMPDIR/Wink.app"
+  local log_file="$BATS_TEST_TMPDIR/debug.log"
+  mkdir -p "$app_dir"
+
+  run bash -lc "
+    export E2E_APP_PATH='$app_dir'
+    export E2E_LOG_FILE='$log_file'
+    source '$BATS_TEST_DIRNAME/e2e-lib.sh'
+    pkill() { :; }
+    open() { printf '%s\n' \"\$*\"; }
+    detect_capture_requirement() { echo none; }
+    wait_for_capture_requirement() { return 0; }
+    hyper_key_enabled_flag() { echo 0; }
+    e2e_launch_app
+  "
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-a $app_dir --args --suppress-automatic-permission-prompts"* ]]
+}
+
 @test "bundle_has_configured_shortcut matches a configured standard shortcut" {
   local shortcuts="$BATS_TEST_TMPDIR/shortcuts.json"
   cat >"$shortcuts" <<'JSON'

--- a/scripts/e2e-lib.sh
+++ b/scripts/e2e-lib.sh
@@ -698,7 +698,7 @@ e2e_launch_app() {
     mkdir -p "$(dirname "$LOG_FILE")"
     : > "$LOG_FILE"
 
-    open "$APP_PATH"
+    open -a "$APP_PATH" --args --suppress-automatic-permission-prompts
 
     requirement=$(detect_capture_requirement "$SHORTCUTS_FILE" "$(hyper_key_enabled_flag)")
 


### PR DESCRIPTION
Fixes #217

## Summary
- suppress automatic startup permission prompts for packaged E2E harness launches while keeping explicit in-app permission requests intact
- update the Shortcuts warning CTA copy so it matches the real permission-request behavior instead of implying a pure settings deep link
- add regression coverage for the new launch argument path and document the runtime-validation lessons from the packaged macOS rerun flow

## Testing
- [x] `swift test`
- [x] `bats scripts/e2e-lib.bats`
- [x] `bash scripts/package-app.sh`
- [x] `bash scripts/e2e-full-test.sh`

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Notes
- Keep exactly one `Validation Status` checkbox selected.
- If the PR touches runtime-sensitive files, the PR metadata workflow will reject `Not runtime-sensitive`.
