### PR TITLE
Polish Settings titlebar chrome baseline

### DIFF
--- a/Sources/Wink/Services/DiagnosticLogWriter.swift
+++ b/Sources/Wink/Services/DiagnosticLogWriter.swift
@@ -81,7 +81,12 @@ final class DiagnosticLogWriter: @unchecked Sendable {
             FileManager.default.createFile(atPath: logPath, contents: nil)
         }
         guard let newHandle = FileHandle(forWritingAtPath: logPath) else { return nil }
-        try? newHandle.seekToEnd()
+        do {
+            _ = try newHandle.seekToEnd()
+        } catch {
+            try? newHandle.close()
+            return nil
+        }
         handle = newHandle
         return newHandle
     }

--- a/Sources/Wink/UI/SettingsView.swift
+++ b/Sources/Wink/UI/SettingsView.swift
@@ -26,24 +26,27 @@ struct SettingsView: View {
     var shortcutStatusProvider: ShortcutStatusProvider
     @Bindable var settingsLauncher: SettingsLauncher
 
+    @State private var columnVisibility: NavigationSplitViewVisibility = .all
+
     private var lifecycleHandler: SettingsViewLifecycleHandler {
         SettingsViewLifecycleHandler(preferences: preferences)
     }
 
     var body: some View {
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
             List(SettingsTab.allCases, id: \.self, selection: $settingsLauncher.selectedTab) { tab in
                 Label(tab.title, systemImage: tab.systemImage)
                     .font(WinkType.bodyMedium)
+                    .padding(.leading, SettingsSidebarMetrics.rowContentLeadingAdjustment)
                     .tag(tab)
             }
+            .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
             .navigationSplitViewColumnWidth(
                 min: SettingsSidebarMetrics.width,
                 ideal: SettingsSidebarMetrics.width,
                 max: SettingsSidebarMetrics.width
             )
-            .listStyle(.sidebar)
-            .scrollContentBackground(.hidden)
             .background(palette.sidebarBg)
         } detail: {
             GeometryReader { proxy in
@@ -59,6 +62,11 @@ struct SettingsView: View {
         }
         .navigationSplitViewStyle(.balanced)
         .background(palette.windowBg)
+        .onReceive(NotificationCenter.default.publisher(for: .settingsSidebarToggleRequested)) { _ in
+            withAnimation(.easeInOut(duration: 0.2)) {
+                toggleSidebar()
+            }
+        }
         .onChange(of: settingsLauncher.selectedTab) { _, newTab in
             if newTab == .insights {
                 insightsViewModel.scheduleRefresh()
@@ -73,6 +81,10 @@ struct SettingsView: View {
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             lifecycleHandler.handleAppDidBecomeActive()
         }
+    }
+
+    private func toggleSidebar() {
+        columnVisibility = columnVisibility == .all ? .detailOnly : .all
     }
 
     @ViewBuilder
@@ -94,5 +106,6 @@ struct SettingsView: View {
 }
 
 private enum SettingsSidebarMetrics {
-    static let width: CGFloat = 180
+    static let width: CGFloat = 150
+    static let rowContentLeadingAdjustment: CGFloat = -2
 }

--- a/Sources/Wink/WinkApp.swift
+++ b/Sources/Wink/WinkApp.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 enum SettingsWindowMetrics {
@@ -47,11 +48,441 @@ struct WinkApp: App {
                 width: SettingsWindowMetrics.width,
                 height: SettingsWindowMetrics.height
             )
+            .toolbar(removing: .title)
+            .toolbar(removing: .sidebarToggle)
+            .background(SettingsWindowChromeConfigurator())
             .winkChromeRoot()
         }
         .commands {
             SettingsCommands(settingsLauncher: appDelegate.settingsLauncher)
         }
+    }
+}
+
+/// Layout constants taken verbatim from the Wink design source
+/// `docs/design/reference/chrome.jsx` and `primitives.jsx`. Anything that
+/// touches the titlebar/chrome region must use these — do not re-derive.
+enum SettingsTitlebarLayout {
+    /// chrome.jsx: outer flex row `height: 36`.
+    static let height: CGFloat = 36
+
+    /// primitives.jsx TrafficLights: `padding: 0 16px`.
+    static let trafficLightContainerHorizontalPadding: CGFloat = 16
+    /// primitives.jsx TrafficLights: each dot `width: 12; height: 12`.
+    static let trafficLightDotSize: CGFloat = 12
+    /// primitives.jsx TrafficLights: flex `gap: 8` between dots.
+    static let trafficLightDotGap: CGFloat = 8
+
+    /// chrome.jsx title overlay: `fontSize: 13; fontWeight: 500`.
+    static let titleFontSize: CGFloat = 13
+    /// CSS `font-weight: 500` ≈ AppKit/SwiftUI `.medium`.
+    static let titleFontWeight: NSFont.Weight = .medium
+
+    /// Chrome browser reference titlebar puts the sidebar toggle ~24pt right
+    /// of the zoom button's right edge, sharing the traffic-light baseline.
+    /// We treat that as the "natural" gap between the lights cluster and the
+    /// next titlebar control.
+    static let toggleGapFromTrafficLights: CGFloat = 8
+
+    /// SF Symbol `sidebar.leading` rendered at this point size matches the
+    /// visual weight of the Chrome/Codex toggle icon at this scale.
+    static let toggleIconPointSize: CGFloat = 14
+    static let toggleHitSize = NSSize(width: 24, height: 24)
+
+    /// chrome.jsx `borderBottom: 0.5px solid chromeBorder`.
+    static let hairlineThickness: CGFloat = 0.5
+
+    /// On macOS 15's compact SwiftUI Settings titlebar, `contentLayoutRect`
+    /// starts 28pt below the window top. A bottom titlebar accessory with this
+    /// height grows the native titlebar area to the CSS row height of 36pt.
+    static let titlebarAccessoryHeight: CGFloat = 8
+
+    static let backgroundIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarBackground")
+    static let hairlineIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarHairline")
+    static let sidebarToggleIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarSidebarToggle")
+    static let titleIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarTitle")
+    static let accessoryIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarAccessory")
+
+    /// Right edge of the traffic-light container (= where the toggle starts
+    /// counting its leading gap from). 16 + 12 + 8 + 12 + 8 + 12 + 16 = 84.
+    static var trafficLightContainerWidth: CGFloat {
+        2 * trafficLightContainerHorizontalPadding
+            + 3 * trafficLightDotSize
+            + 2 * trafficLightDotGap
+    }
+
+    /// Window-coords top of each dot (CSS `align-items: center` in 36pt row
+    /// with 12pt dot ⇒ top inset = (36 − 12) / 2 = 12).
+    static var trafficLightDotTopY: CGFloat {
+        (height - trafficLightDotSize) / 2
+    }
+
+    /// Vertical center y shared by traffic lights, toggle and title.
+    static var baselineCenterY: CGFloat {
+        height / 2
+    }
+
+    /// Window-coords leading x for each of the three dots, in order.
+    static var trafficLightDotLeadingXs: [CGFloat] {
+        let firstX = trafficLightContainerHorizontalPadding
+        return (0..<3).map { i in
+            firstX + CGFloat(i) * (trafficLightDotSize + trafficLightDotGap)
+        }
+    }
+
+    /// Window-coords leading x for the sidebar toggle hit area.
+    static var toggleLeadingX: CGFloat {
+        trafficLightContainerWidth + toggleGapFromTrafficLights
+    }
+
+    /// Window-coords top y for the sidebar-toggle hit target.
+    static var toggleTopY: CGFloat {
+        baselineCenterY - toggleHitSize.height / 2
+    }
+}
+
+/// Minimal NSWindow surgery for the SwiftUI `Settings` scene:
+///   1. Hide the system-rendered title — `NSSplitViewItem` would otherwise
+///      center it in the detail half of the titlebar rather than across the
+///      whole window. AppKit draws the visible replacement title instead.
+///   2. `titlebarAppearsTransparent = true` + `.fullSizeContentView` so the
+///      custom titlebar background can draw underneath the system titlebar and
+///      so clicks on custom controls in that area pass through
+///      (per the AppKit SDK header: "the titlebar doesn't draw its
+///      background, allowing all buttons to show through, and 'click through'
+///      to happen").
+///   3. Add an 8pt bottom `NSTitlebarAccessoryViewController` so the Settings
+///      content starts below the design's 36pt chrome row instead of below the
+///      native 28pt titlebar safe area.
+///   4. Reposition the three native `standardWindowButton`s so their colored
+///      dots land at the design coordinates from `chrome.jsx` /
+///      `primitives.jsx` (close dot top-left = (16, 12) etc). This is *not*
+///      a stylistic offset; it is the exact placement the design CSS
+///      `align-items: center` produces inside a 36pt row.
+private struct SettingsWindowChromeConfigurator: NSViewRepresentable {
+    func makeCoordinator() -> SettingsWindowChromeCoordinator {
+        SettingsWindowChromeCoordinator()
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        view.isHidden = true
+        scheduleConfiguration(for: view, coordinator: context.coordinator)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        scheduleConfiguration(for: nsView, coordinator: context.coordinator)
+    }
+
+    private func scheduleConfiguration(for view: NSView, coordinator: SettingsWindowChromeCoordinator) {
+        DispatchQueue.main.async {
+            guard let window = view.window else { return }
+            coordinator.attach(to: window)
+        }
+    }
+}
+
+extension Notification.Name {
+    static let settingsSidebarToggleRequested = Notification.Name("WinkSettingsSidebarToggleRequested")
+}
+
+@MainActor
+final class SettingsWindowChromeCoordinator: NSObject {
+    private weak var window: NSWindow?
+    private var observers: [NSObjectProtocol] = []
+
+    func attach(to window: NSWindow) {
+        guard self.window !== window else {
+            applyAll()
+            return
+        }
+        for observer in observers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        observers.removeAll()
+
+        self.window = window
+        applyOnce()
+
+        // AppKit re-asserts titlebar layout on internal updates (key state,
+        // content attachment, titlebar accessory changes, resize). Re-apply so
+        // the CSS-derived coordinates stay pinned.
+        let nc = NotificationCenter.default
+        for name in [NSWindow.didUpdateNotification,
+                     NSWindow.didBecomeKeyNotification,
+                     NSWindow.didResignKeyNotification,
+                     NSWindow.didExposeNotification,
+                     NSWindow.didResizeNotification] {
+            let token = nc.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
+                MainActor.assumeIsolated { self?.applyAll() }
+            }
+            observers.append(token)
+        }
+    }
+
+    private func applyOnce() {
+        guard let window else { return }
+        window.title = "Wink"
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.styleMask.insert(.fullSizeContentView)
+        window.titlebarSeparatorStyle = .none
+        window.toolbarStyle = .unifiedCompact
+        window.toolbar = nil
+        window.isMovableByWindowBackground = true
+        applyAll()
+    }
+
+    fileprivate func applyAll() {
+        guard let window else { return }
+        installTitlebarAccessory(in: window)
+        window.layoutIfNeeded()
+        guard let titlebarView = positionTrafficLights(in: window) else { return }
+        installOrUpdateTitlebarChrome(in: titlebarView)
+    }
+
+    private func installTitlebarAccessory(in window: NSWindow) {
+        if let accessory = window.titlebarAccessoryViewControllers.first(where: {
+            $0.view.identifier == SettingsTitlebarLayout.accessoryIdentifier
+        }) {
+            accessory.layoutAttribute = .bottom
+            accessory.automaticallyAdjustsSize = false
+            accessory.view.setFrameSize(NSSize(
+                width: accessory.view.frame.width,
+                height: SettingsTitlebarLayout.titlebarAccessoryHeight
+            ))
+            return
+        }
+
+        let accessoryView = SettingsTitlebarPassthroughView(frame: NSRect(
+            x: 0,
+            y: 0,
+            width: 0,
+            height: SettingsTitlebarLayout.titlebarAccessoryHeight
+        ))
+        accessoryView.identifier = SettingsTitlebarLayout.accessoryIdentifier
+
+        let accessory = NSTitlebarAccessoryViewController()
+        accessory.layoutAttribute = .bottom
+        accessory.automaticallyAdjustsSize = false
+        accessory.fullScreenMinHeight = SettingsTitlebarLayout.titlebarAccessoryHeight
+        accessory.view = accessoryView
+        window.addTitlebarAccessoryViewController(accessory)
+    }
+
+    @discardableResult
+    private func positionTrafficLights(in window: NSWindow) -> NSView? {
+        let buttonTypes: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
+        let buttons = buttonTypes.compactMap { window.standardWindowButton($0) }
+        guard let titlebarView = buttons.first?.superview else { return nil }
+
+        // Release constraints anchoring the standard buttons. Without this,
+        // `setFrameOrigin` is overwritten on the next layout pass.
+        for button in buttons {
+            button.translatesAutoresizingMaskIntoConstraints = true
+        }
+        var node: NSView? = titlebarView
+        while let view = node {
+            let related = view.constraints.filter { constraint in
+                buttons.contains {
+                    ((constraint.firstItem as AnyObject?) === $0)
+                        || ((constraint.secondItem as AnyObject?) === $0)
+                }
+            }
+            NSLayoutConstraint.deactivate(related)
+            node = view.superview
+        }
+
+        let dotTopY = SettingsTitlebarLayout.trafficLightDotTopY      // 12
+        let dotSize = SettingsTitlebarLayout.trafficLightDotSize      // 12
+        let dotXs = SettingsTitlebarLayout.trafficLightDotLeadingXs   // [16, 36, 56]
+
+        for (button, dotX) in zip(buttons, dotXs) {
+            let buttonSize = button.frame.size
+            let buttonTopY = dotTopY - (buttonSize.height - dotSize) / 2
+            let buttonLeadingX = dotX - (buttonSize.width - dotSize) / 2
+            let yFromBottom = titlebarView.bounds.height - buttonTopY - buttonSize.height
+            button.setFrameOrigin(NSPoint(x: buttonLeadingX, y: yFromBottom))
+        }
+
+        return titlebarView
+    }
+
+    private func installOrUpdateTitlebarChrome(in titlebarView: NSView) {
+        let background = titlebarView.subviews.first {
+            $0.identifier == SettingsTitlebarLayout.backgroundIdentifier
+        } as? SettingsTitlebarPassthroughView ?? {
+            let view = SettingsTitlebarPassthroughView(frame: titlebarView.bounds)
+            view.identifier = SettingsTitlebarLayout.backgroundIdentifier
+            titlebarView.addSubview(view, positioned: .below, relativeTo: nil)
+            return view
+        }()
+        background.frame = titlebarView.bounds
+        background.autoresizingMask = [.width, .height]
+        background.updateBackgroundColor()
+
+        let hairline = titlebarView.subviews.first {
+            $0.identifier == SettingsTitlebarLayout.hairlineIdentifier
+        } as? SettingsTitlebarHairlineView ?? {
+            let view = SettingsTitlebarHairlineView(frame: .zero)
+            view.identifier = SettingsTitlebarLayout.hairlineIdentifier
+            titlebarView.addSubview(view)
+            return view
+        }()
+        hairline.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: titlebarView.bounds.width,
+            height: SettingsTitlebarLayout.hairlineThickness
+        )
+        hairline.autoresizingMask = [.width, .maxYMargin]
+        hairline.updateBackgroundColor()
+
+        let toggle = titlebarView.subviews.first {
+            $0.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier
+        } as? NSButton ?? {
+            let button = NSButton(frame: .zero)
+            button.identifier = SettingsTitlebarLayout.sidebarToggleIdentifier
+            button.image = NSImage(systemSymbolName: "sidebar.leading", accessibilityDescription: "Toggle Sidebar")
+            button.imagePosition = .imageOnly
+            button.imageScaling = .scaleProportionallyDown
+            button.isBordered = false
+            button.bezelStyle = .regularSquare
+            button.setButtonType(.momentaryChange)
+            button.toolTip = "Toggle Sidebar"
+            button.target = self
+            button.action = #selector(toggleSidebar(_:))
+            titlebarView.addSubview(button)
+            return button
+        }()
+        toggle.target = self
+        toggle.action = #selector(toggleSidebar(_:))
+        toggle.contentTintColor = SettingsTitlebarColors.textSecondary(for: titlebarView.effectiveAppearance)
+        toggle.frame = frameFromTopLeft(
+            x: SettingsTitlebarLayout.toggleLeadingX,
+            y: SettingsTitlebarLayout.toggleTopY,
+            size: SettingsTitlebarLayout.toggleHitSize,
+            in: titlebarView
+        )
+
+        let title = titlebarView.subviews.first {
+            $0.identifier == SettingsTitlebarLayout.titleIdentifier
+        } as? NSTextField ?? {
+            let label = NSTextField(labelWithString: "Wink")
+            label.identifier = SettingsTitlebarLayout.titleIdentifier
+            label.alignment = .center
+            label.isBezeled = false
+            label.isBordered = false
+            label.drawsBackground = false
+            label.isEditable = false
+            label.isSelectable = false
+            label.allowsDefaultTighteningForTruncation = false
+            label.lineBreakMode = .byClipping
+            titlebarView.addSubview(label)
+            return label
+        }()
+        title.stringValue = "Wink"
+        title.font = .systemFont(
+            ofSize: SettingsTitlebarLayout.titleFontSize,
+            weight: SettingsTitlebarLayout.titleFontWeight
+        )
+        title.textColor = SettingsTitlebarColors.textPrimary(for: titlebarView.effectiveAppearance)
+        title.sizeToFit()
+        let titleSize = title.intrinsicContentSize
+        title.frame = NSRect(
+            x: (titlebarView.bounds.width - titleSize.width) / 2,
+            y: titlebarView.bounds.height - SettingsTitlebarLayout.baselineCenterY - titleSize.height / 2,
+            width: titleSize.width,
+            height: titleSize.height
+        ).integral
+    }
+
+    private func frameFromTopLeft(x: CGFloat, y: CGFloat, size: NSSize, in container: NSView) -> NSRect {
+        NSRect(
+            x: x,
+            y: container.bounds.height - y - size.height,
+            width: size.width,
+            height: size.height
+        )
+    }
+
+    @objc private func toggleSidebar(_ sender: Any?) {
+        NotificationCenter.default.post(name: .settingsSidebarToggleRequested, object: window)
+    }
+}
+
+private class SettingsTitlebarPassthroughView: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        updateBackgroundColor()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        wantsLayer = true
+        updateBackgroundColor()
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateBackgroundColor()
+    }
+
+    func updateBackgroundColor() {
+        layer?.backgroundColor = SettingsTitlebarColors.chromeBackground(for: effectiveAppearance).cgColor
+    }
+}
+
+private final class SettingsTitlebarHairlineView: SettingsTitlebarPassthroughView {
+    override func updateBackgroundColor() {
+        layer?.backgroundColor = SettingsTitlebarColors.hairline(for: effectiveAppearance).cgColor
+    }
+}
+
+private enum SettingsTitlebarColors {
+    static func chromeBackground(for appearance: NSAppearance) -> NSColor {
+        isDark(appearance)
+            ? NSColor(srgbRed: 0x2C, green: 0x2C, blue: 0x2E)
+            : NSColor(srgbRed: 0xEC, green: 0xEC, blue: 0xEC)
+    }
+
+    static func hairline(for appearance: NSAppearance) -> NSColor {
+        isDark(appearance)
+            ? NSColor(srgbRed: 1.0, green: 1.0, blue: 1.0, alpha: 0.08)
+            : NSColor(srgbRed: 0.0, green: 0.0, blue: 0.0, alpha: 0.08)
+    }
+
+    static func textPrimary(for appearance: NSAppearance) -> NSColor {
+        isDark(appearance)
+            ? NSColor(srgbRed: 1.0, green: 1.0, blue: 1.0, alpha: 0.92)
+            : NSColor(srgbRed: 0.0, green: 0.0, blue: 0.0, alpha: 0.88)
+    }
+
+    static func textSecondary(for appearance: NSAppearance) -> NSColor {
+        isDark(appearance)
+            ? NSColor(srgbRed: 1.0, green: 1.0, blue: 1.0, alpha: 0.55)
+            : NSColor(srgbRed: 0.0, green: 0.0, blue: 0.0, alpha: 0.55)
+    }
+
+    private static func isDark(_ appearance: NSAppearance) -> Bool {
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+    }
+}
+
+private extension NSColor {
+    convenience init(srgbRed red: Int, green: Int, blue: Int, alpha: CGFloat = 1) {
+        self.init(
+            srgbRed: CGFloat(red) / 255.0,
+            green: CGFloat(green) / 255.0,
+            blue: CGFloat(blue) / 255.0,
+            alpha: alpha
+        )
     }
 }
 

--- a/Sources/Wink/WinkApp.swift
+++ b/Sources/Wink/WinkApp.swift
@@ -187,18 +187,34 @@ extension Notification.Name {
     static let settingsSidebarToggleRequested = Notification.Name("WinkSettingsSidebarToggleRequested")
 }
 
+private final class NotificationObserverBag {
+    private var tokens: [NSObjectProtocol] = []
+
+    func removeAll() {
+        for token in tokens {
+            NotificationCenter.default.removeObserver(token)
+        }
+        tokens.removeAll()
+    }
+
+    func append(_ token: NSObjectProtocol) {
+        tokens.append(token)
+    }
+
+    deinit {
+        removeAll()
+    }
+}
+
 @MainActor
 final class SettingsWindowChromeCoordinator: NSObject {
     private weak var window: NSWindow?
-    private var observers: [NSObjectProtocol] = []
+    private let observers = NotificationObserverBag()
 
     func attach(to window: NSWindow) {
         guard self.window !== window else {
             applyAll()
             return
-        }
-        for observer in observers {
-            NotificationCenter.default.removeObserver(observer)
         }
         observers.removeAll()
 

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -510,7 +510,7 @@ struct LayoutRegressionTests {
     }
 
     @Test @MainActor
-    func settingsViewUsesDesignSidebarColumnWidth() throws {
+    func settingsViewUsesCompactSidebarColumnWidth() throws {
         let context = SettingsViewLayoutContext()
         defer { context.harness.cleanup() }
 
@@ -531,9 +531,46 @@ struct LayoutRegressionTests {
         let splitView = try #require(splitViews.first)
         let sidebarWidth = splitView.arrangedSubviews.first?.frame.width ?? 0
 
-        #expect(abs(sidebarWidth - 180) < 1)
+        #expect(abs(sidebarWidth - 150) < 1)
         #expect(splitView.frame.minY >= -1)
         #expect(splitView.frame.height <= hostingView.bounds.height + 1)
+    }
+
+    @Test @MainActor
+    func settingsWindowChromeConfiguratorGrowsTitlebarToDesignHeight() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: SettingsWindowMetrics.width, height: SettingsWindowMetrics.height),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let coordinator = SettingsWindowChromeCoordinator()
+
+        coordinator.attach(to: window)
+        window.layoutIfNeeded()
+
+        let topInset = window.frame.height - window.contentLayoutRect.maxY
+        let accessory = try #require(window.titlebarAccessoryViewControllers.first)
+        let closeButton = try #require(window.standardWindowButton(.closeButton))
+        let titlebarView = try #require(closeButton.superview)
+        let sidebarToggle = try #require(titlebarView.subviews.first {
+            $0.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier
+        })
+        let customTitle = try #require(titlebarView.subviews.first {
+            $0.identifier == SettingsTitlebarLayout.titleIdentifier
+        })
+        let toggleCenterYFromTop = titlebarView.bounds.height - sidebarToggle.frame.midY
+        let titleCenterYFromTop = titlebarView.bounds.height - customTitle.frame.midY
+
+        #expect(abs(topInset - SettingsTitlebarLayout.height) < 0.5)
+        #expect(abs(titlebarView.bounds.height - SettingsTitlebarLayout.height) < 0.5)
+        #expect(accessory.layoutAttribute == .bottom)
+        #expect(accessory.automaticallyAdjustsSize == false)
+        #expect(abs(accessory.view.frame.height - SettingsTitlebarLayout.titlebarAccessoryHeight) < 0.5)
+        #expect(abs(sidebarToggle.frame.minX - SettingsTitlebarLayout.toggleLeadingX) < 0.5)
+        #expect(abs(toggleCenterYFromTop - SettingsTitlebarLayout.baselineCenterY) < 0.5)
+        #expect(abs(customTitle.frame.midX - titlebarView.bounds.midX) < 0.5)
+        #expect(abs(titleCenterYFromTop - SettingsTitlebarLayout.baselineCenterY) < 0.5)
     }
 }
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -751,3 +751,37 @@ A two-layer mitigation is in place:
 1. Skill-level circuit breaker in Iteration Guard reads `logs/loop-circuit-breaker.json` and skips iterations during cooldown (exponential backoff up to 4 hours)
 2. Stop hook (`.claude/hooks/rate-limit-detector.sh`) detects rate-limit signals in the session transcript and writes cooldown state for the next iteration
 This handles soft limits and post-recovery transitions. Full quota exhaustion still causes empty fires — this is a `/loop` infrastructure limitation that requires upstream improvement.
+
+## Settings Titlebar Polish Requires Treating Design CSS As Source-Of-Truth
+
+**Issue**
+The macOS Settings titlebar UI was iterated through ~17 rejected screenshots over a single session before landing the right approach. The recurring failure mode was inventing values (top inset 14, container height 44, etc.) instead of reading the existing design source verbatim.
+
+**Cause**
+- `docs/design/reference/chrome.jsx` already specified `height: 36`, `align-items: center`, `border-bottom: 0.5px solid chromeBorder` and `primitives.jsx` already specified `padding: 0 16px; gap: 8` with `12x12` dots. Every position is exactly determined by those values.
+- The implementer kept proposing native macOS defaults (28pt titlebar, traffic lights at default inset) instead of the design's 36pt row with traffic-light dots at top-left (16, 12). "Native default" was the wrong baseline because the design intentionally diverges from it.
+- Earlier iterations also conflated "don't move traffic lights unnaturally" (user's actual complaint) with "never call `setFrameOrigin` on traffic lights at all". When the design dictates a 36pt row, traffic lights *must* be repositioned to land at design coordinates — that is alignment, not stylistic offset.
+
+**Practical guidance**
+- For any chrome polish work, **read the JSX/CSS in `docs/design/reference/` first** and translate values verbatim. Do not start from "what does macOS do by default" — start from "what does the design say".
+- SwiftUI's layout primitives have direct CSS-flex equivalents — `HStack(spacing:)` for `gap`, `.padding(.horizontal:)` for `padding: 0 X`, `.frame(maxWidth: .infinity)` + `.overlay { ... }` for `position: absolute; inset: 0; justify-content: center`. Prefer SwiftUI translations over hand-positioned `NSTextField` / `NSButton` for anything that is purely visual.
+- Reserve NSWindow-level customization for things SwiftUI cannot do: `titlebarAppearsTransparent`, `.fullSizeContentView`, `titlebarSeparatorStyle`, and repositioning the three native `standardWindowButton`s. Prefer SwiftUI for purely visual chrome only after verifying it is actually in the window's top 36pt coordinate space; SwiftUI Settings scenes may still respect the titlebar safe area and render the row below native chrome.
+- When the design specifies a non-native chrome height (36pt vs native ~28pt), the native `titlebarSeparatorStyle = .line` will draw at the wrong y. Set `.none` and draw the hairline yourself in SwiftUI at the design's y.
+- Reference apps screenshots (Chrome / Codex) are useful for **adjacent-control patterns** like the gap between traffic lights and a sidebar toggle — measure with PIL/numpy and follow the gap, not the absolute coords (their windows have different chrome heights).
+- Validation must be evidence-driven: `swift /Users/yvan/.codex/skills/macos-runtime-validation/scripts/capture_window_screenshot.swift` to capture, then a Python+PIL pixel measurement that asserts dot center coords, hairline y, and title center x against the spec. "Looks right" is not acceptable; the user has rejected ~17 "looks right" passes in this category.
+
+## SwiftUI Settings Safe Area Can Hide a Correct-Looking Chrome Row Below the Titlebar
+
+**Issue**
+After the traffic-light dots were correctly repositioned to the design coordinates, the SwiftUI `SettingsTitlebarChrome` row still rendered below the native titlebar. The screenshot looked close at a glance, but the sidebar toggle landed around y=41-53 and collided with the detail heading instead of sharing the traffic-light baseline at y=18.
+
+**Cause**
+- `.fullSizeContentView` makes the AppKit content view span the full window, but the SwiftUI `Settings` scene can still apply the window titlebar safe-area/content-layout inset to the SwiftUI root. A top `VStack` chrome row therefore starts below the native titlebar instead of at window y=0.
+- `.ignoresSafeArea(.container, edges: .top)` and `safeAreaInset(edge: .top)` are risky in this Settings scene: earlier attempts stopped the Settings window from appearing at all.
+- On macOS 15, a compact SwiftUI Settings titlebar starts with a 28pt `contentLayoutRect` top inset. Adding an 8pt bottom `NSTitlebarAccessoryViewController` with `layoutAttribute = .bottom` grows the titlebar/content inset to the design's 36pt row using documented AppKit API.
+
+**Practical guidance**
+- Treat `NSTitlebarAccessoryViewController` as the first tool for making a native Settings titlebar a precise non-default height. Set `.layoutAttribute = .bottom`, `.automaticallyAdjustsSize = false`, and give the accessory view the exact extra height needed to reach the design row.
+- If the title/sidebar-toggle must share a baseline with native traffic lights, place them in the `titlebarView` as AppKit controls after the accessory has grown the titlebar view to the target height. A SwiftUI row below the safe area cannot share y=18 with controls living in the native titlebar.
+- Keep the `NavigationSplitView` content out of the fake chrome row. Once the titlebar accessory makes `contentLayoutRect` start at y=36, the sidebar first row naturally begins below the hairline instead of needing a compensating top spacer.
+- Validate with pixels, not assumptions: assert the traffic-light bboxes, sidebar-toggle y centroid, hairline y, and sidebar first-row icon x alignment from the saved packaged-app screenshot.


### PR DESCRIPTION
Fixes #235

## Summary
- align the Settings chrome row to the design CSS by growing the native titlebar to 36pt with a bottom `NSTitlebarAccessoryViewController`
- move the sidebar toggle and centered `Wink` title into the AppKit titlebar view so they share the traffic-light baseline at y=18
- keep the 0.5pt hairline at y=36 and align the first sidebar icon with the close-dot left edge
- record the SwiftUI Settings safe-area/titlebar accessory lesson for future chrome work

## Testing
- [x] `swift test`
- [x] `swift test --filter LayoutRegressionTests`
- [x] `swift build`
- [x] `./scripts/package-app.sh`
- [x] `codesign --verify --deep --strict --verbose=2 build/Wink.app`
- [x] Packaged-app Settings screenshot capture plus PIL pixel assertions against `build/validation/settings-layout-2026-04-26-2026-04-26/screenshots/28-settings-titlebar-final-review-pass.png`

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- macOS runtime validation scope is Settings titlebar UI layout only: screenshot/pixel validation of traffic-light bboxes, sidebar-toggle baseline, centered title, hairline y=36, and sidebar first-icon alignment.
- Shortcut capture E2E was not claimed. The fresh ad-hoc build snapshot remains TCC not-ready (`ax=false im=false carbon=false eventTap=false`), and no Accessibility/Input Monitoring rows or TCC state were changed.
