### PR TITLE
Bound long UI lists to local scrollers

### DIFF
--- a/Sources/Wink/Services/ShortcutEditorState.swift
+++ b/Sources/Wink/Services/ShortcutEditorState.swift
@@ -163,18 +163,35 @@ final class ShortcutEditorState {
         onShortcutConfigurationChange()
     }
 
-    /// Moves the shortcut identified by `id` so that it occupies the slot currently
-    /// held by `target`. Used by drag-to-reorder in the Shortcuts tab, where drops
-    /// are resolved against the row under the cursor rather than an index between rows.
-    func reorderShortcut(draggedID id: UUID, onto target: UUID) {
-        guard id != target,
-              let fromIndex = shortcuts.firstIndex(where: { $0.id == id }),
-              let toIndex = shortcuts.firstIndex(where: { $0.id == target }),
-              fromIndex != toIndex else {
+    /// Moves the shortcut identified by `id` to an insertion offset in the
+    /// currently visible shortcut list.
+    func reorderShortcut(draggedID id: UUID, toVisibleOffset offset: Int, visibleShortcutIDs: [UUID]) {
+        guard let fromIndex = shortcuts.firstIndex(where: { $0.id == id }),
+              visibleShortcutIDs.contains(id) else {
             return
         }
 
-        let destination = toIndex > fromIndex ? toIndex + 1 : toIndex
+        let clampedOffset = min(max(offset, 0), visibleShortcutIDs.count)
+        let destination: Int
+        if clampedOffset == visibleShortcutIDs.count {
+            guard let lastVisibleID = visibleShortcutIDs.last,
+                  let lastVisibleIndex = shortcuts.firstIndex(where: { $0.id == lastVisibleID }) else {
+                return
+            }
+            destination = lastVisibleIndex + 1
+        } else {
+            let destinationID = visibleShortcutIDs[clampedOffset]
+            guard destinationID != id,
+                  let destinationIndex = shortcuts.firstIndex(where: { $0.id == destinationID }) else {
+                return
+            }
+            destination = destinationIndex
+        }
+
+        guard destination != fromIndex && destination != fromIndex + 1 else {
+            return
+        }
+
         moveShortcut(from: IndexSet([fromIndex]), to: destination)
     }
 

--- a/Sources/Wink/UI/InsightsTabView.swift
+++ b/Sources/Wink/UI/InsightsTabView.swift
@@ -26,54 +26,25 @@ struct InsightsTabView: View {
     @Bindable var viewModel: InsightsViewModel
 
     var body: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 14) {
-                header
+        VStack(alignment: .leading, spacing: 14) {
+            header
 
-                InsightsUnusedNudge(appNames: viewModel.unusedShortcutNames)
+            InsightsUnusedNudge(appNames: viewModel.unusedShortcutNames)
 
-                InsightsKpiSection(
-                    totalCount: viewModel.totalCount,
-                    previousPeriodTotal: viewModel.previousPeriodTotal,
-                    currentStreakDays: viewModel.currentStreakDays,
-                    sparklinePoints: viewModel.activationSparklinePoints
-                )
+            InsightsKpiSection(
+                totalCount: viewModel.totalCount,
+                previousPeriodTotal: viewModel.previousPeriodTotal,
+                currentStreakDays: viewModel.currentStreakDays,
+                sparklinePoints: viewModel.activationSparklinePoints
+            )
 
-                InsightsHourlyHeatmap(buckets: viewModel.heatmapBuckets)
+            InsightsHourlyHeatmap(buckets: viewModel.heatmapBuckets)
 
-                WinkCard(
-                    title: {
-                        Text(InsightsTabCopy.rankingSectionTitle)
-                    },
-                    accessory: {
-                        Text(InsightsTabCopy.rankingAccessoryText(totalCount: viewModel.totalCount, period: viewModel.period))
-                            .font(WinkType.labelSmall)
-                            .foregroundStyle(palette.textTertiary)
-                    }
-                ) {
-                    if viewModel.appRows.isEmpty {
-                        Text(InsightsTabCopy.emptyRankingText)
-                            .font(WinkType.bodyText)
-                            .foregroundStyle(palette.textSecondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, 14)
-                            .padding(.vertical, 18)
-                    } else {
-                        VStack(spacing: 0) {
-                            ForEach(Array(viewModel.appRows.enumerated()), id: \.element.id) { index, item in
-                                InsightsAppRow(
-                                    item: item,
-                                    showsDivider: index < viewModel.appRows.count - 1
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-            .padding(.horizontal, 22)
-            .padding(.vertical, 18)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
+            mostUsedCard
         }
+        .padding(.horizontal, 22)
+        .padding(.vertical, 18)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(palette.windowBg)
     }
 
@@ -99,5 +70,47 @@ struct InsightsTabView: View {
             .frame(width: 120)
             .labelsHidden()
         }
+    }
+
+    private var mostUsedCard: some View {
+        WinkCard(
+            title: {
+                Text(InsightsTabCopy.rankingSectionTitle)
+            },
+            accessory: {
+                Text(InsightsTabCopy.rankingAccessoryText(totalCount: viewModel.totalCount, period: viewModel.period))
+                    .font(WinkType.labelSmall)
+                    .foregroundStyle(palette.textTertiary)
+            }
+        ) {
+            if viewModel.appRows.isEmpty {
+                Text(InsightsTabCopy.emptyRankingText)
+                    .font(WinkType.bodyText)
+                    .foregroundStyle(palette.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(maxHeight: .infinity, alignment: .topLeading)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 18)
+            } else {
+                GeometryReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            ForEach(Array(viewModel.appRows.enumerated()), id: \.element.id) { index, item in
+                                InsightsAppRow(
+                                    item: item,
+                                    showsDivider: index < viewModel.appRows.count - 1
+                                )
+                            }
+                        }
+                        .frame(width: proxy.size.width, alignment: .leading)
+                        .frame(minHeight: proxy.size.height, alignment: .top)
+                    }
+                    .scrollIndicators(.automatic, axes: .vertical)
+                }
+                .frame(minHeight: 140, maxHeight: .infinity, alignment: .top)
+            }
+        }
+        .frame(maxHeight: .infinity, alignment: .topLeading)
+        .layoutPriority(1)
     }
 }

--- a/Sources/Wink/UI/InsightsTabView.swift
+++ b/Sources/Wink/UI/InsightsTabView.swift
@@ -102,7 +102,7 @@ struct InsightsTabView: View {
                                 )
                             }
                         }
-                        .frame(width: proxy.size.width, alignment: .leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                         .frame(minHeight: proxy.size.height, alignment: .top)
                     }
                     .scrollIndicators(.automatic, axes: .vertical)

--- a/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
+++ b/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
@@ -198,16 +198,15 @@ struct MenuBarPopoverView: View {
     @Bindable var model: MenuBarPopoverModel
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
-                header
-                search
-                todayCard
-                shortcutsCard
-                actionsCard
-            }
-            .padding(12)
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            search
+            todayCard
+            shortcutsCard
+            actionsCard
         }
+        .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(palette.windowBg)
         .onAppear {
             model.refresh()
@@ -286,17 +285,25 @@ struct MenuBarPopoverView: View {
                     .padding(.top, 14)
                     .padding(.bottom, 10)
             } else {
-                VStack(spacing: 0) {
-                    ForEach(Array(filteredRows.enumerated()), id: \.element.id) { index, row in
-                        MenuBarShortcutRow(row: row)
+                GeometryReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 0) {
+                            ForEach(Array(filteredRows.enumerated()), id: \.element.id) { index, row in
+                                MenuBarShortcutRow(row: row)
 
-                        if index < filteredRows.count - 1 {
-                            Divider()
-                                .overlay(palette.hairline)
-                                .padding(.leading, 48)
+                                if index < filteredRows.count - 1 {
+                                    Divider()
+                                        .overlay(palette.hairline)
+                                        .padding(.leading, 48)
+                                }
+                            }
                         }
+                        .frame(width: proxy.size.width, alignment: .leading)
+                        .frame(minHeight: proxy.size.height, alignment: .top)
                     }
+                    .scrollIndicators(.automatic, axes: .vertical)
                 }
+                .frame(minHeight: 120, maxHeight: .infinity, alignment: .top)
             }
 
             Divider().overlay(palette.hairline)
@@ -314,6 +321,8 @@ struct MenuBarPopoverView: View {
             }
             .buttonStyle(.plain)
         }
+        .frame(maxHeight: .infinity, alignment: .topLeading)
+        .layoutPriority(1)
     }
 
     private var actionsCard: some View {

--- a/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
+++ b/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
@@ -298,7 +298,7 @@ struct MenuBarPopoverView: View {
                                 }
                             }
                         }
-                        .frame(width: proxy.size.width, alignment: .leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                         .frame(minHeight: proxy.size.height, alignment: .top)
                     }
                     .scrollIndicators(.automatic, axes: .vertical)

--- a/Sources/Wink/UI/SettingsView.swift
+++ b/Sources/Wink/UI/SettingsView.swift
@@ -34,11 +34,19 @@ struct SettingsView: View {
 
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
-            List(SettingsTab.allCases, id: \.self, selection: $settingsLauncher.selectedTab) { tab in
-                Label(tab.title, systemImage: tab.systemImage)
-                    .font(WinkType.bodyMedium)
-                    .padding(.leading, SettingsSidebarMetrics.rowContentLeadingAdjustment)
-                    .tag(tab)
+            List(selection: $settingsLauncher.selectedTab) {
+                Color.clear
+                    .frame(height: SettingsSidebarMetrics.topContentPadding)
+                    .listRowInsets(EdgeInsets())
+                    .listRowBackground(palette.sidebarBg)
+                    .accessibilityHidden(true)
+
+                ForEach(SettingsTab.allCases, id: \.self) { tab in
+                    Label(tab.title, systemImage: tab.systemImage)
+                        .font(WinkType.bodyMedium)
+                        .padding(.leading, SettingsSidebarMetrics.rowContentLeadingAdjustment)
+                        .tag(tab)
+                }
             }
             .listStyle(.sidebar)
             .scrollContentBackground(.hidden)
@@ -105,7 +113,8 @@ struct SettingsView: View {
     }
 }
 
-private enum SettingsSidebarMetrics {
+enum SettingsSidebarMetrics {
     static let width: CGFloat = 150
+    static let topContentPadding: CGFloat = 8
     static let rowContentLeadingAdjustment: CGFloat = -2
 }

--- a/Sources/Wink/UI/ShortcutsTabView.swift
+++ b/Sources/Wink/UI/ShortcutsTabView.swift
@@ -459,6 +459,7 @@ struct ShortcutsTabView: View {
                         .frame(width: proxy.size.width, alignment: .leading)
                         .frame(minHeight: proxy.size.height, alignment: .top)
                     }
+                    .scrollIndicators(.automatic, axes: .vertical)
                 }
                 .frame(
                     minHeight: ShortcutRowMetrics.minimumListHeight,
@@ -592,6 +593,7 @@ struct ShortcutsTabView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .scrollIndicators(.automatic, axes: .vertical)
             .frame(maxHeight: ShortcutImportPreviewMetrics.detailsMaxHeight)
         }
     }

--- a/Sources/Wink/UI/ShortcutsTabView.swift
+++ b/Sources/Wink/UI/ShortcutsTabView.swift
@@ -22,6 +22,49 @@ private enum ShortcutRowMetrics {
     }
 }
 
+private enum ShortcutListCoordinateSpace {
+    static let name = "WinkShortcutListCoordinateSpace"
+}
+
+private struct ShortcutRowFramePreferenceKey: PreferenceKey {
+    static let defaultValue: [UUID: CGRect] = [:]
+
+    static func reduce(value: inout [UUID: CGRect], nextValue: () -> [UUID: CGRect]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, new in new })
+    }
+}
+
+struct ShortcutRowReorderHandlers {
+    let onChanged: (DragGesture.Value) -> Void
+    let onEnded: (DragGesture.Value) -> Void
+}
+
+enum ShortcutReorderPlanner {
+    static func visibleDropOffset(
+        for shortcutID: UUID,
+        translationY: CGFloat,
+        visibleShortcutIDs: [UUID],
+        rowFrames: [UUID: CGRect]
+    ) -> Int? {
+        guard let sourceFrame = rowFrames[shortcutID],
+              let sourceVisibleOffset = visibleShortcutIDs.firstIndex(of: shortcutID) else {
+            return nil
+        }
+
+        let projectedMidY = sourceFrame.midY + translationY
+        let rowsAbove = visibleShortcutIDs
+            .filter { $0 != shortcutID }
+            .compactMap { rowFrames[$0] }
+            .filter { projectedMidY > $0.midY }
+            .count
+
+        if rowsAbove >= sourceVisibleOffset {
+            return rowsAbove + 1
+        }
+        return rowsAbove
+    }
+}
+
 private enum ShortcutImportPreviewMetrics {
     static let detailsMaxHeight: CGFloat = 128
 }
@@ -178,6 +221,9 @@ struct ShortcutsTabView: View {
     @State private var showingAppPicker = false
     @State private var filterText = ""
     @State private var accessibilityOptions = ShortcutRowAccessibilityOptions.standard
+    @State private var shortcutRowFrames: [UUID: CGRect] = [:]
+    @State private var draggingShortcutID: UUID?
+    @State private var dragTranslationY: CGFloat = 0
 
     private var filteredShortcuts: [AppShortcut] {
         let query = filterText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -456,8 +502,12 @@ struct ShortcutsTabView: View {
                                 }
                             }
                         }
-                        .frame(width: proxy.size.width, alignment: .leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                         .frame(minHeight: proxy.size.height, alignment: .top)
+                    }
+                    .coordinateSpace(name: ShortcutListCoordinateSpace.name)
+                    .onPreferenceChange(ShortcutRowFramePreferenceKey.self) { frames in
+                        shortcutRowFrames = frames
                     }
                     .scrollIndicators(.automatic, axes: .vertical)
                 }
@@ -472,29 +522,74 @@ struct ShortcutsTabView: View {
         .layoutPriority(1)
     }
 
-    // Drag-to-reorder lives on the row via `.draggable` + `.dropDestination`. We gate
-    // it on `canReorder` so filtering or an active import preview cannot produce a
+    // Drag-to-reorder is local to the visible shortcut list. We gate it on
+    // `canReorder` so filtering or an active import preview cannot produce a
     // silently-wrong reorder against the full shortcut list.
     @ViewBuilder
     private func reorderableRow(_ shortcut: AppShortcut, index: Int, canReorder: Bool) -> some View {
         if canReorder {
-            shortcutRow(shortcut, index: index)
-                .draggable(shortcut.id.uuidString)
-                .dropDestination(for: String.self) { items, _ in
-                    guard let idString = items.first,
-                          let draggedID = UUID(uuidString: idString) else {
-                        return false
+            shortcutRow(
+                shortcut,
+                index: index,
+                reorderHandlers: ShortcutRowReorderHandlers(
+                    onChanged: { value in
+                        draggingShortcutID = shortcut.id
+                        dragTranslationY = value.translation.height
+                    },
+                    onEnded: { value in
+                        completeReorderDrag(shortcutID: shortcut.id, translationY: value.translation.height)
                     }
-                    editor.reorderShortcut(draggedID: draggedID, onto: shortcut.id)
-                    return true
-                }
+                )
+            )
+                .background(rowFrameReader(for: shortcut.id))
+                .offset(y: draggingShortcutID == shortcut.id ? dragTranslationY : 0)
+                .zIndex(draggingShortcutID == shortcut.id ? 1 : 0)
         } else {
             shortcutRow(shortcut, index: index)
         }
     }
 
+    private func rowFrameReader(for shortcutID: UUID) -> some View {
+        GeometryReader { proxy in
+            Color.clear.preference(
+                key: ShortcutRowFramePreferenceKey.self,
+                value: [shortcutID: proxy.frame(in: .named(ShortcutListCoordinateSpace.name))]
+            )
+        }
+    }
+
+    private func completeReorderDrag(shortcutID: UUID, translationY: CGFloat) {
+        defer {
+            draggingShortcutID = nil
+            dragTranslationY = 0
+        }
+
+        guard let offset = visibleDropOffset(for: shortcutID, translationY: translationY) else {
+            return
+        }
+
+        editor.reorderShortcut(
+            draggedID: shortcutID,
+            toVisibleOffset: offset,
+            visibleShortcutIDs: filteredShortcuts.map(\.id)
+        )
+    }
+
+    private func visibleDropOffset(for shortcutID: UUID, translationY: CGFloat) -> Int? {
+        ShortcutReorderPlanner.visibleDropOffset(
+            for: shortcutID,
+            translationY: translationY,
+            visibleShortcutIDs: filteredShortcuts.map(\.id),
+            rowFrames: shortcutRowFrames
+        )
+    }
+
     @ViewBuilder
-    private func shortcutRow(_ shortcut: AppShortcut, index: Int) -> some View {
+    private func shortcutRow(
+        _ shortcut: AppShortcut,
+        index: Int,
+        reorderHandlers: ShortcutRowReorderHandlers? = nil
+    ) -> some View {
         let importPreviewActive = editor.pendingRecipeImport != nil
         let runtimeStatus = shortcutStatusProvider.status(for: shortcut)
 
@@ -511,7 +606,8 @@ struct ShortcutsTabView: View {
             },
             onRemove: {
                 editor.removeShortcut(id: shortcut.id)
-            }
+            },
+            reorderHandlers: reorderHandlers
         )
     }
 
@@ -623,6 +719,7 @@ struct ShortcutsListRow: View {
     let index: Int
     let onToggleEnabled: @MainActor () -> Void
     let onRemove: @MainActor () -> Void
+    let reorderHandlers: ShortcutRowReorderHandlers?
 
     private var presentation: ShortcutsListRowPresentation {
         ShortcutsListRowPresentation(
@@ -651,9 +748,7 @@ struct ShortcutsListRow: View {
 
     var body: some View {
         HStack(spacing: ShortcutRowMetrics.spacing) {
-            WinkIcon.grip.image(size: 11, weight: .semibold)
-                .foregroundStyle(palette.textTertiary)
-                .frame(width: ShortcutRowMetrics.gripColumnWidth)
+            gripHandle
 
             ZStack(alignment: .bottomTrailing) {
                 AppIconView(
@@ -723,6 +818,25 @@ struct ShortcutsListRow: View {
         .alternatingRowBackground(index: index)
         .opacity(presentation.contentOpacity)
         .animation(statusAnimation, value: statusAnimationKey)
+    }
+
+    @ViewBuilder
+    private var gripHandle: some View {
+        let icon = WinkIcon.grip.image(size: 11, weight: .semibold)
+            .foregroundStyle(palette.textTertiary)
+            .frame(width: ShortcutRowMetrics.gripColumnWidth)
+            .contentShape(Rectangle())
+            .help("Drag to reorder")
+
+        if let reorderHandlers {
+            icon.gesture(
+                DragGesture(minimumDistance: 3)
+                    .onChanged(reorderHandlers.onChanged)
+                    .onEnded(reorderHandlers.onEnded)
+            )
+        } else {
+            icon
+        }
     }
 
     private var shortcutAccessoryGroup: some View {

--- a/Sources/Wink/WinkApp.swift
+++ b/Sources/Wink/WinkApp.swift
@@ -88,6 +88,8 @@ enum SettingsTitlebarLayout {
     /// visual weight of the Chrome/Codex toggle icon at this scale.
     static let toggleIconPointSize: CGFloat = 14
     static let toggleHitSize = NSSize(width: 24, height: 24)
+    static let sidebarToggleSymbolName = "rectangle.leadinghalf.inset.filled"
+    static let sidebarToggleFallbackSymbolName = "sidebar.leading"
 
     /// chrome.jsx `borderBottom: 0.5px solid chromeBorder`.
     static let hairlineThickness: CGFloat = 0.5
@@ -209,6 +211,7 @@ private final class NotificationObserverBag {
 @MainActor
 final class SettingsWindowChromeCoordinator: NSObject {
     private weak var window: NSWindow?
+    private weak var chromeHostView: NSView?
     private let observers = NotificationObserverBag()
 
     func attach(to window: NSWindow) {
@@ -239,19 +242,26 @@ final class SettingsWindowChromeCoordinator: NSObject {
 
     private func applyOnce() {
         guard let window else { return }
+        applyWindowChromeOptions(to: window)
+        applyAll()
+    }
+
+    private func applyWindowChromeOptions(to window: NSWindow) {
         window.title = "Wink"
         window.titleVisibility = .hidden
         window.titlebarAppearsTransparent = true
         window.styleMask.insert(.fullSizeContentView)
         window.titlebarSeparatorStyle = .none
         window.toolbarStyle = .unifiedCompact
-        window.toolbar = nil
+        if window.toolbar != nil {
+            window.toolbar = nil
+        }
         window.isMovableByWindowBackground = true
-        applyAll()
     }
 
     fileprivate func applyAll() {
         guard let window else { return }
+        applyWindowChromeOptions(to: window)
         installTitlebarAccessory(in: window)
         window.layoutIfNeeded()
         guard let titlebarView = positionTrafficLights(in: window) else { return }
@@ -326,6 +336,13 @@ final class SettingsWindowChromeCoordinator: NSObject {
     }
 
     private func installOrUpdateTitlebarChrome(in titlebarView: NSView) {
+        if chromeHostView !== titlebarView {
+            if let chromeHostView {
+                removeInstalledChrome(from: chromeHostView)
+            }
+            chromeHostView = titlebarView
+        }
+
         let background = titlebarView.subviews.first {
             $0.identifier == SettingsTitlebarLayout.backgroundIdentifier
         } as? SettingsTitlebarPassthroughView ?? {
@@ -360,7 +377,7 @@ final class SettingsWindowChromeCoordinator: NSObject {
         } as? NSButton ?? {
             let button = NSButton(frame: .zero)
             button.identifier = SettingsTitlebarLayout.sidebarToggleIdentifier
-            button.image = NSImage(systemSymbolName: "sidebar.leading", accessibilityDescription: "Toggle Sidebar")
+            button.image = Self.sidebarToggleImage()
             button.imagePosition = .imageOnly
             button.imageScaling = .scaleProportionallyDown
             button.isBordered = false
@@ -381,6 +398,7 @@ final class SettingsWindowChromeCoordinator: NSObject {
             size: SettingsTitlebarLayout.toggleHitSize,
             in: titlebarView
         )
+        hideUnownedSidebarToggleButtons(in: titlebarView, keeping: toggle)
 
         let title = titlebarView.subviews.first {
             $0.identifier == SettingsTitlebarLayout.titleIdentifier
@@ -412,6 +430,73 @@ final class SettingsWindowChromeCoordinator: NSObject {
             width: titleSize.width,
             height: titleSize.height
         ).integral
+    }
+
+    private func removeInstalledChrome(from hostView: NSView) {
+        let identifiers = [
+            SettingsTitlebarLayout.backgroundIdentifier,
+            SettingsTitlebarLayout.hairlineIdentifier,
+            SettingsTitlebarLayout.sidebarToggleIdentifier,
+            SettingsTitlebarLayout.titleIdentifier,
+        ]
+        for subview in hostView.subviews where subview.identifier.map(identifiers.contains) == true {
+            subview.removeFromSuperview()
+        }
+    }
+
+    private func hideUnownedSidebarToggleButtons(in titlebarView: NSView, keeping customToggle: NSButton) {
+        let customFrame = customToggle.frame.insetBy(dx: -10, dy: -8)
+        for button in descendantButtons(in: titlebarView) where button !== customToggle {
+            guard isSidebarToggleCandidate(button, in: titlebarView, near: customFrame) else {
+                continue
+            }
+            button.isHidden = true
+            button.isEnabled = false
+        }
+    }
+
+    private func isSidebarToggleCandidate(_ button: NSButton, in titlebarView: NSView, near customFrame: NSRect) -> Bool {
+        if button.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier {
+            return false
+        }
+
+        let searchableText = [
+            button.identifier?.rawValue,
+            button.toolTip,
+            button.accessibilityLabel(),
+            button.accessibilityTitle(),
+            button.cell?.accessibilityLabel(),
+            button.cell?.accessibilityTitle(),
+        ]
+        if searchableText.contains(where: { $0?.localizedCaseInsensitiveContains("sidebar") == true }) {
+            return true
+        }
+
+        let frameInTitlebar = button.superview?.convert(button.frame, to: titlebarView) ?? button.frame
+        return button.frame.width <= SettingsTitlebarLayout.toggleHitSize.width + 12
+            && button.frame.height <= SettingsTitlebarLayout.toggleHitSize.height + 12
+            && frameInTitlebar.intersects(customFrame)
+    }
+
+    private static func sidebarToggleImage() -> NSImage? {
+        NSImage(
+            systemSymbolName: SettingsTitlebarLayout.sidebarToggleSymbolName,
+            accessibilityDescription: "Toggle Sidebar"
+        ) ?? NSImage(
+            systemSymbolName: SettingsTitlebarLayout.sidebarToggleFallbackSymbolName,
+            accessibilityDescription: "Toggle Sidebar"
+        )
+    }
+
+    private func descendantButtons(in view: NSView) -> [NSButton] {
+        var result: [NSButton] = []
+        for subview in view.subviews {
+            if let button = subview as? NSButton {
+                result.append(button)
+            }
+            result.append(contentsOf: descendantButtons(in: subview))
+        }
+        return result
     }
 
     private func frameFromTopLeft(x: CGFloat, y: CGFloat, size: NSSize, in container: NSView) -> NSRect {

--- a/Sources/Wink/WinkApp.swift
+++ b/Sources/Wink/WinkApp.swift
@@ -78,11 +78,11 @@ enum SettingsTitlebarLayout {
     /// CSS `font-weight: 500` ≈ AppKit/SwiftUI `.medium`.
     static let titleFontWeight: NSFont.Weight = .medium
 
-    /// Chrome browser reference titlebar puts the sidebar toggle ~24pt right
-    /// of the zoom button's right edge, sharing the traffic-light baseline.
-    /// We treat that as the "natural" gap between the lights cluster and the
-    /// next titlebar control.
-    static let toggleGapFromTrafficLights: CGFloat = 8
+    /// Chrome browser reference titlebar puts the sidebar toggle about 24pt to
+    /// the trailing side of the zoom button, sharing the traffic-light baseline.
+    /// AppKit owns the traffic-light positions; Wink only places its own toggle
+    /// relative to the current system button frames.
+    static let toggleGapFromZoomButton: CGFloat = 24
 
     /// SF Symbol `sidebar.leading` rendered at this point size matches the
     /// visual weight of the Chrome/Codex toggle icon at this scale.
@@ -105,41 +105,9 @@ enum SettingsTitlebarLayout {
     static let titleIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarTitle")
     static let accessoryIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarAccessory")
 
-    /// Right edge of the traffic-light container (= where the toggle starts
-    /// counting its leading gap from). 16 + 12 + 8 + 12 + 8 + 12 + 16 = 84.
-    static var trafficLightContainerWidth: CGFloat {
-        2 * trafficLightContainerHorizontalPadding
-            + 3 * trafficLightDotSize
-            + 2 * trafficLightDotGap
-    }
-
-    /// Window-coords top of each dot (CSS `align-items: center` in 36pt row
-    /// with 12pt dot ⇒ top inset = (36 − 12) / 2 = 12).
-    static var trafficLightDotTopY: CGFloat {
-        (height - trafficLightDotSize) / 2
-    }
-
     /// Vertical center y shared by traffic lights, toggle and title.
     static var baselineCenterY: CGFloat {
         height / 2
-    }
-
-    /// Window-coords leading x for each of the three dots, in order.
-    static var trafficLightDotLeadingXs: [CGFloat] {
-        let firstX = trafficLightContainerHorizontalPadding
-        return (0..<3).map { i in
-            firstX + CGFloat(i) * (trafficLightDotSize + trafficLightDotGap)
-        }
-    }
-
-    /// Window-coords leading x for the sidebar toggle hit area.
-    static var toggleLeadingX: CGFloat {
-        trafficLightContainerWidth + toggleGapFromTrafficLights
-    }
-
-    /// Window-coords top y for the sidebar-toggle hit target.
-    static var toggleTopY: CGFloat {
-        baselineCenterY - toggleHitSize.height / 2
     }
 }
 
@@ -156,11 +124,9 @@ enum SettingsTitlebarLayout {
 ///   3. Add an 8pt bottom `NSTitlebarAccessoryViewController` so the Settings
 ///      content starts below the design's 36pt chrome row instead of below the
 ///      native 28pt titlebar safe area.
-///   4. Reposition the three native `standardWindowButton`s so their colored
-///      dots land at the design coordinates from `chrome.jsx` /
-///      `primitives.jsx` (close dot top-left = (16, 12) etc). This is *not*
-///      a stylistic offset; it is the exact placement the design CSS
-///      `align-items: center` produces inside a 36pt row.
+///   4. Add Wink's own sidebar toggle beside the system traffic lights without
+///      rewriting the native button frames. AppKit remains the owner of the
+///      standard close/minimize/zoom placement during titlebar updates.
 private struct SettingsWindowChromeConfigurator: NSViewRepresentable {
     func makeCoordinator() -> SettingsWindowChromeCoordinator {
         SettingsWindowChromeCoordinator()
@@ -264,7 +230,7 @@ final class SettingsWindowChromeCoordinator: NSObject {
         applyWindowChromeOptions(to: window)
         installTitlebarAccessory(in: window)
         window.layoutIfNeeded()
-        guard let titlebarView = positionTrafficLights(in: window) else { return }
+        guard let titlebarView = titlebarHostView(in: window) else { return }
         installOrUpdateTitlebarChrome(in: titlebarView)
     }
 
@@ -297,42 +263,8 @@ final class SettingsWindowChromeCoordinator: NSObject {
         window.addTitlebarAccessoryViewController(accessory)
     }
 
-    @discardableResult
-    private func positionTrafficLights(in window: NSWindow) -> NSView? {
-        let buttonTypes: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
-        let buttons = buttonTypes.compactMap { window.standardWindowButton($0) }
-        guard let titlebarView = buttons.first?.superview else { return nil }
-
-        // Release constraints anchoring the standard buttons. Without this,
-        // `setFrameOrigin` is overwritten on the next layout pass.
-        for button in buttons {
-            button.translatesAutoresizingMaskIntoConstraints = true
-        }
-        var node: NSView? = titlebarView
-        while let view = node {
-            let related = view.constraints.filter { constraint in
-                buttons.contains {
-                    ((constraint.firstItem as AnyObject?) === $0)
-                        || ((constraint.secondItem as AnyObject?) === $0)
-                }
-            }
-            NSLayoutConstraint.deactivate(related)
-            node = view.superview
-        }
-
-        let dotTopY = SettingsTitlebarLayout.trafficLightDotTopY      // 12
-        let dotSize = SettingsTitlebarLayout.trafficLightDotSize      // 12
-        let dotXs = SettingsTitlebarLayout.trafficLightDotLeadingXs   // [16, 36, 56]
-
-        for (button, dotX) in zip(buttons, dotXs) {
-            let buttonSize = button.frame.size
-            let buttonTopY = dotTopY - (buttonSize.height - dotSize) / 2
-            let buttonLeadingX = dotX - (buttonSize.width - dotSize) / 2
-            let yFromBottom = titlebarView.bounds.height - buttonTopY - buttonSize.height
-            button.setFrameOrigin(NSPoint(x: buttonLeadingX, y: yFromBottom))
-        }
-
-        return titlebarView
+    private func titlebarHostView(in window: NSWindow) -> NSView? {
+        window.standardWindowButton(.closeButton)?.superview
     }
 
     private func installOrUpdateTitlebarChrome(in titlebarView: NSView) {
@@ -392,12 +324,7 @@ final class SettingsWindowChromeCoordinator: NSObject {
         toggle.target = self
         toggle.action = #selector(toggleSidebar(_:))
         toggle.contentTintColor = SettingsTitlebarColors.textSecondary(for: titlebarView.effectiveAppearance)
-        toggle.frame = frameFromTopLeft(
-            x: SettingsTitlebarLayout.toggleLeadingX,
-            y: SettingsTitlebarLayout.toggleTopY,
-            size: SettingsTitlebarLayout.toggleHitSize,
-            in: titlebarView
-        )
+        toggle.frame = sidebarToggleFrame(in: titlebarView)
         hideUnownedSidebarToggleButtons(in: titlebarView, keeping: toggle)
 
         let title = titlebarView.subviews.first {
@@ -488,6 +415,33 @@ final class SettingsWindowChromeCoordinator: NSObject {
         )
     }
 
+    private func sidebarToggleFrame(in titlebarView: NSView) -> NSRect {
+        let size = SettingsTitlebarLayout.toggleHitSize
+        let isRightToLeft = window?.windowTitlebarLayoutDirection == .rightToLeft
+
+        let x: CGFloat
+        if isRightToLeft,
+           let closeButton = window?.standardWindowButton(.closeButton) {
+            x = closeButton.frame.minX - SettingsTitlebarLayout.toggleGapFromZoomButton - size.width
+        } else if let zoomButton = window?.standardWindowButton(.zoomButton) {
+            x = zoomButton.frame.maxX + SettingsTitlebarLayout.toggleGapFromZoomButton
+        } else {
+            x = SettingsTitlebarLayout.trafficLightContainerHorizontalPadding
+                + 3 * SettingsTitlebarLayout.trafficLightDotSize
+                + 2 * SettingsTitlebarLayout.trafficLightDotGap
+                + SettingsTitlebarLayout.toggleGapFromZoomButton
+        }
+
+        let centerY = window?.standardWindowButton(.zoomButton)?.frame.midY
+            ?? titlebarView.bounds.midY
+        return NSRect(
+            x: x,
+            y: centerY - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+    }
+
     private func descendantButtons(in view: NSView) -> [NSButton] {
         var result: [NSButton] = []
         for subview in view.subviews {
@@ -497,15 +451,6 @@ final class SettingsWindowChromeCoordinator: NSObject {
             result.append(contentsOf: descendantButtons(in: subview))
         }
         return result
-    }
-
-    private func frameFromTopLeft(x: CGFloat, y: CGFloat, size: NSSize, in container: NSView) -> NSRect {
-        NSRect(
-            x: x,
-            y: container.bounds.height - y - size.height,
-            width: size.width,
-            height: size.height
-        )
     }
 
     @objc private func toggleSidebar(_ sender: Any?) {

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -35,6 +35,49 @@ struct LayoutRegressionTests {
     }
 
     @Test @MainActor
+    func menuBarPopoverShortcutsRegionOwnsVerticalScroller() throws {
+        let context = MenuBarPopoverLayoutContext(shortcutCount: 18)
+        defer { context.harness.cleanup() }
+
+        let hostingView = makeHostingView(
+            MenuBarPopoverView(model: context.model).winkChromeRoot(),
+            size: NSSize(width: 356, height: 520)
+        )
+
+        let scrollViews = verticalScrollViews(in: hostingView)
+        let scroller = try #require(scrollViews.first)
+
+        #expect(scrollViews.count == 1)
+        #expect(scroller.frame.height < hostingView.bounds.height - 120)
+        #expect(scroller.frame.height > 80)
+    }
+
+    @Test @MainActor
+    func insightsMostUsedRegionOwnsVerticalScroller() async throws {
+        let store = ShortcutStore()
+        let shortcuts = makeInsightShortcuts(count: 20)
+        store.replaceAll(with: shortcuts)
+
+        let viewModel = InsightsViewModel(
+            usageTracker: MultiShortcutUsageTracker(shortcuts: shortcuts),
+            shortcutStore: store
+        )
+        await viewModel.refresh(for: .week)
+
+        let hostingView = makeHostingView(
+            InsightsTabView(viewModel: viewModel),
+            size: NSSize(width: 700, height: 640)
+        )
+
+        let scrollViews = verticalScrollViews(in: hostingView)
+        let scroller = try #require(scrollViews.first)
+
+        #expect(scrollViews.count == 1)
+        #expect(scroller.frame.height < hostingView.bounds.height - 180)
+        #expect(scroller.frame.height > 120)
+    }
+
+    @Test @MainActor
     func insightsCardUsesUpdatedSectionTitleCopy() {
         #expect(InsightsTabCopy.rankingSectionTitle == "Most used")
         #expect(InsightsTabCopy.rankingAccessoryText(totalCount: 112, period: .week) == "112 activations · 7 days")
@@ -439,7 +482,7 @@ struct LayoutRegressionTests {
     }
 
     @Test @MainActor
-    func insightsTabExposesSinglePageScroller() async {
+    func insightsMostUsedExposesSingleVerticalScroller() async {
         let shortcutId = UUID()
         let store = ShortcutStore()
         store.replaceAll(with: [
@@ -463,9 +506,7 @@ struct LayoutRegressionTests {
             size: NSSize(width: 700, height: 430)
         )
 
-        let scrollViewsWithVerticalScrollers = descendants(in: hostingView)
-            .compactMap { $0 as? NSScrollView }
-            .filter(\.hasVerticalScroller)
+        let scrollViewsWithVerticalScrollers = verticalScrollViews(in: hostingView)
 
         #expect(scrollViewsWithVerticalScrollers.count == 1)
     }
@@ -618,6 +659,68 @@ private actor StaticUsageTracker: UsageTracking {
     }
 }
 
+private actor MultiShortcutUsageTracker: UsageTracking {
+    private let counts: [UUID: Int]
+    private let dailyCountsByShortcut: [String: [(date: String, count: Int)]]
+    private let hourlyBuckets: [HourlyUsageBucket]
+
+    init(shortcuts: [AppShortcut]) {
+        counts = Dictionary(
+            uniqueKeysWithValues: shortcuts.enumerated().map { index, shortcut in
+                (shortcut.id, shortcuts.count - index)
+            }
+        )
+        dailyCountsByShortcut = Dictionary(
+            uniqueKeysWithValues: shortcuts.enumerated().map { index, shortcut in
+                (
+                    shortcut.id.uuidString,
+                    [
+                        (date: "2026-04-20", count: 1),
+                        (date: "2026-04-21", count: shortcuts.count - index),
+                    ]
+                )
+            }
+        )
+        hourlyBuckets = (0..<7).flatMap { day in
+            (0..<24).map { hour in
+                HourlyUsageBucket(
+                    date: "2026-04-\(String(format: "%02d", 20 + day))",
+                    hour: hour,
+                    count: (day + hour) % 4
+                )
+            }
+        }
+    }
+
+    func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] {
+        counts
+    }
+
+    func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] {
+        dailyCountsByShortcut
+    }
+
+    func totalSwitches(days: Int, relativeTo now: Date) async -> Int {
+        counts.values.reduce(0, +)
+    }
+
+    func hourlyCounts(days: Int, relativeTo now: Date) async -> [HourlyUsageBucket] {
+        hourlyBuckets
+    }
+
+    func previousPeriodTotal(days: Int, relativeTo now: Date) async -> Int {
+        0
+    }
+
+    func streakDays(relativeTo now: Date) async -> Int {
+        7
+    }
+
+    func usageTimeZone() async -> TimeZone {
+        .current
+    }
+}
+
 private struct CardWidthProbeView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -633,6 +736,17 @@ private struct CardWidthProbeView: View {
     }
 }
 
+private func makeInsightShortcuts(count: Int) -> [AppShortcut] {
+    (0..<count).map { index in
+        AppShortcut(
+            appName: "Insight App \(index + 1)",
+            bundleIdentifier: "com.example.insight\(index + 1)",
+            keyEquivalent: String(UnicodeScalar(97 + (index % 26))!),
+            modifierFlags: ["command", "option"]
+        )
+    }
+}
+
 private func makeHeatmapBuckets() -> [HourlyUsageBucket] {
     (0..<7).flatMap { day in
         (0..<24).map { hour in
@@ -642,6 +756,65 @@ private func makeHeatmapBuckets() -> [HourlyUsageBucket] {
                 count: (day + hour) % 5
             )
         }
+    }
+}
+
+@MainActor
+private final class MenuBarPopoverLayoutContext {
+    let harness = TestPersistenceHarness()
+    let model: MenuBarPopoverModel
+
+    init(shortcutCount: Int) {
+        let shortcutStore = ShortcutStore()
+        let shortcuts = (0..<shortcutCount).map { index in
+            AppShortcut(
+                appName: "Menu App \(index + 1)",
+                bundleIdentifier: "com.example.menu\(index + 1)",
+                keyEquivalent: String(UnicodeScalar(97 + (index % 26))!),
+                modifierFlags: ["command", "option", "control", "shift"]
+            )
+        }
+        shortcutStore.replaceAll(with: shortcuts)
+
+        let manager = ShortcutManager(
+            shortcutStore: shortcutStore,
+            persistenceService: harness.makePersistenceService(),
+            appSwitcher: LayoutFakeAppSwitcher(),
+            captureCoordinator: ShortcutCaptureCoordinator(
+                standardProvider: LayoutFakeCaptureProvider(),
+                hyperProvider: LayoutFakeHyperCaptureProvider()
+            ),
+            permissionService: LayoutFakePermissionService(),
+            diagnosticClient: .live
+        )
+
+        let preferences = AppPreferences(
+            shortcutManager: manager,
+            launchAtLoginService: LaunchAtLoginService(client: .init(
+                status: { .notRegistered },
+                register: {},
+                unregister: {},
+                openSystemSettingsLoginItems: {}
+            ))
+        )
+        let statusProvider = ShortcutStatusProvider(
+            client: .init(
+                applicationURL: { _ in URL(fileURLWithPath: "/Applications/Fake.app") },
+                runningBundleIdentifiers: { [] }
+            ),
+            workspaceNotificationCenter: NotificationCenter(),
+            appNotificationCenter: NotificationCenter()
+        )
+        model = MenuBarPopoverModel(
+            shortcutStore: shortcutStore,
+            preferences: preferences,
+            shortcutStatusProvider: statusProvider,
+            usageTracker: StaticUsageTracker(shortcutId: shortcuts.first?.id ?? UUID()),
+            workspaceNotificationCenter: NotificationCenter(),
+            appNotificationCenter: NotificationCenter(),
+            openSettings: { _ in },
+            quit: {}
+        )
     }
 }
 
@@ -859,6 +1032,13 @@ private func makeHostingView<Content: View>(_ rootView: Content, size: NSSize) -
     RunLoop.current.run(until: Date().addingTimeInterval(0.05))
     hostingView.layoutSubtreeIfNeeded()
     return hostingView
+}
+
+@MainActor
+private func verticalScrollViews(in view: NSView) -> [NSScrollView] {
+    descendants(in: view)
+        .compactMap { $0 as? NSScrollView }
+        .filter(\.hasVerticalScroller)
 }
 
 @MainActor

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -50,6 +50,7 @@ struct LayoutRegressionTests {
         #expect(scrollViews.count == 1)
         #expect(scroller.frame.height < hostingView.bounds.height - 120)
         #expect(scroller.frame.height > 80)
+        #expect((scroller.documentView?.frame.width ?? 0) <= scroller.contentView.bounds.width + 1)
     }
 
     @Test @MainActor
@@ -75,6 +76,7 @@ struct LayoutRegressionTests {
         #expect(scrollViews.count == 1)
         #expect(scroller.frame.height < hostingView.bounds.height - 180)
         #expect(scroller.frame.height > 120)
+        #expect((scroller.documentView?.frame.width ?? 0) <= scroller.contentView.bounds.width + 1)
     }
 
     @Test @MainActor
@@ -424,8 +426,10 @@ struct LayoutRegressionTests {
         let scrollViewsWithVerticalScrollers = descendants(in: hostingView)
             .compactMap { $0 as? NSScrollView }
             .filter(\.hasVerticalScroller)
+        let scroller = scrollViewsWithVerticalScrollers.first
 
         #expect(scrollViewsWithVerticalScrollers.count == 1)
+        #expect((scroller?.documentView?.frame.width ?? 0) <= (scroller?.contentView.bounds.width ?? 0) + 1)
     }
 
     @Test @MainActor
@@ -594,6 +598,7 @@ struct LayoutRegressionTests {
         let topInset = window.frame.height - window.contentLayoutRect.maxY
         let accessory = try #require(window.titlebarAccessoryViewControllers.first)
         let closeButton = try #require(window.standardWindowButton(.closeButton))
+        let zoomButton = try #require(window.standardWindowButton(.zoomButton))
         let titlebarView = try #require(closeButton.superview)
         let sidebarToggle = try #require(titlebarView.subviews.first {
             $0.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier
@@ -603,14 +608,16 @@ struct LayoutRegressionTests {
         })
         let toggleCenterYFromTop = titlebarView.bounds.height - sidebarToggle.frame.midY
         let titleCenterYFromTop = titlebarView.bounds.height - customTitle.frame.midY
+        let expectedToggleLeadingX = zoomButton.frame.maxX + SettingsTitlebarLayout.toggleGapFromZoomButton
 
         #expect(abs(topInset - SettingsTitlebarLayout.height) < 0.5)
         #expect(abs(titlebarView.bounds.height - SettingsTitlebarLayout.height) < 0.5)
         #expect(accessory.layoutAttribute == .bottom)
         #expect(accessory.automaticallyAdjustsSize == false)
         #expect(abs(accessory.view.frame.height - SettingsTitlebarLayout.titlebarAccessoryHeight) < 0.5)
-        #expect(abs(sidebarToggle.frame.minX - SettingsTitlebarLayout.toggleLeadingX) < 0.5)
-        #expect(abs(toggleCenterYFromTop - SettingsTitlebarLayout.baselineCenterY) < 0.5)
+        #expect(abs(sidebarToggle.frame.minX - expectedToggleLeadingX) < 0.5)
+        #expect(abs(sidebarToggle.frame.midY - zoomButton.frame.midY) < 0.5)
+        #expect(abs(toggleCenterYFromTop - (titlebarView.bounds.height - zoomButton.frame.midY)) < 0.5)
         #expect(abs(customTitle.frame.midX - titlebarView.bounds.midX) < 0.5)
         #expect(abs(titleCenterYFromTop - SettingsTitlebarLayout.baselineCenterY) < 0.5)
     }
@@ -665,6 +672,48 @@ struct LayoutRegressionTests {
             $0.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier
         }
         #expect(ownedToggles.count == 1)
+    }
+
+    @Test @MainActor
+    func settingsWindowChromeDoesNotReapplyTrafficLightFrames() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: SettingsWindowMetrics.width, height: SettingsWindowMetrics.height),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let coordinator = SettingsWindowChromeCoordinator()
+
+        coordinator.attach(to: window)
+        let closeButton = try #require(window.standardWindowButton(.closeButton))
+        let minimizeButton = try #require(window.standardWindowButton(.miniaturizeButton))
+        let zoomButton = try #require(window.standardWindowButton(.zoomButton))
+        let appKitOwnedOrigins = [
+            closeButton: closeButton.frame.origin.offsetBy(dx: -8, dy: -4),
+            minimizeButton: minimizeButton.frame.origin.offsetBy(dx: -8, dy: -4),
+            zoomButton: zoomButton.frame.origin.offsetBy(dx: -8, dy: -4),
+        ]
+
+        for (button, origin) in appKitOwnedOrigins {
+            button.setFrameOrigin(origin)
+        }
+
+        coordinator.attach(to: window)
+
+        #expect(closeButton.frame.origin.isWithinHalfPoint(of: appKitOwnedOrigins[closeButton]))
+        #expect(minimizeButton.frame.origin.isWithinHalfPoint(of: appKitOwnedOrigins[minimizeButton]))
+        #expect(zoomButton.frame.origin.isWithinHalfPoint(of: appKitOwnedOrigins[zoomButton]))
+    }
+}
+
+private extension NSPoint {
+    func offsetBy(dx: CGFloat, dy: CGFloat) -> NSPoint {
+        NSPoint(x: x + dx, y: y + dy)
+    }
+
+    func isWithinHalfPoint(of other: NSPoint?) -> Bool {
+        guard let other else { return false }
+        return abs(x - other.x) < 0.5 && abs(y - other.y) < 0.5
     }
 }
 

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -573,6 +573,7 @@ struct LayoutRegressionTests {
         let sidebarWidth = splitView.arrangedSubviews.first?.frame.width ?? 0
 
         #expect(abs(sidebarWidth - 150) < 1)
+        #expect(SettingsSidebarMetrics.topContentPadding == 8)
         #expect(splitView.frame.minY >= -1)
         #expect(splitView.frame.height <= hostingView.bounds.height + 1)
     }
@@ -612,6 +613,58 @@ struct LayoutRegressionTests {
         #expect(abs(toggleCenterYFromTop - SettingsTitlebarLayout.baselineCenterY) < 0.5)
         #expect(abs(customTitle.frame.midX - titlebarView.bounds.midX) < 0.5)
         #expect(abs(titleCenterYFromTop - SettingsTitlebarLayout.baselineCenterY) < 0.5)
+    }
+
+    @Test @MainActor
+    func settingsWindowChromeReappliesToolbarAndSeparatorSuppression() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: SettingsWindowMetrics.width, height: SettingsWindowMetrics.height),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let coordinator = SettingsWindowChromeCoordinator()
+
+        coordinator.attach(to: window)
+        window.toolbar = NSToolbar(identifier: "InjectedToolbar")
+        window.titlebarSeparatorStyle = .line
+
+        coordinator.attach(to: window)
+
+        #expect(window.toolbar == nil)
+        #expect(window.titlebarSeparatorStyle == .none)
+    }
+
+    @Test @MainActor
+    func settingsWindowChromeHidesDuplicateSidebarToggleButtons() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: SettingsWindowMetrics.width, height: SettingsWindowMetrics.height),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let coordinator = SettingsWindowChromeCoordinator()
+
+        coordinator.attach(to: window)
+        let closeButton = try #require(window.standardWindowButton(.closeButton))
+        let titlebarView = try #require(closeButton.superview)
+        let sidebarToggle = try #require(titlebarView.subviews.first {
+            $0.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier
+        })
+        let duplicateToggle = NSButton(frame: sidebarToggle.frame.offsetBy(dx: 2, dy: 0))
+        duplicateToggle.image = NSImage(systemSymbolName: "sidebar.leading", accessibilityDescription: "Toggle Sidebar")
+        duplicateToggle.imagePosition = .imageOnly
+        duplicateToggle.toolTip = "Toggle Sidebar"
+        titlebarView.addSubview(duplicateToggle)
+
+        coordinator.attach(to: window)
+
+        #expect(duplicateToggle.isHidden)
+        #expect(duplicateToggle.isEnabled == false)
+        let ownedToggles = titlebarView.subviews.filter {
+            $0.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier
+        }
+        #expect(ownedToggles.count == 1)
     }
 }
 

--- a/Tests/WinkTests/ShortcutEditorStateTests.swift
+++ b/Tests/WinkTests/ShortcutEditorStateTests.swift
@@ -174,6 +174,78 @@ func movingShortcutTowardEndAdjustsDestinationAfterRemoval() throws {
 }
 
 @Test @MainActor
+func reorderingShortcutToVisibleDropOffsetPersistsOrder() throws {
+    let safari = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "s",
+        modifierFlags: ["command", "shift"]
+    )
+    let terminal = AppShortcut(
+        appName: "Terminal",
+        bundleIdentifier: "com.apple.Terminal",
+        keyEquivalent: "t",
+        modifierFlags: ["command", "shift"]
+    )
+    let notes = AppShortcut(
+        appName: "Notes",
+        bundleIdentifier: "com.apple.Notes",
+        keyEquivalent: "n",
+        modifierFlags: ["command", "shift"]
+    )
+    let chrome = AppShortcut(
+        appName: "Chrome",
+        bundleIdentifier: "com.google.Chrome",
+        keyEquivalent: "c",
+        modifierFlags: ["command", "shift"]
+    )
+    let context = makeEditorContext(existingShortcuts: [safari, terminal, notes, chrome])
+    defer { context.harness.cleanup() }
+
+    context.editor.reorderShortcut(
+        draggedID: safari.id,
+        toVisibleOffset: 3,
+        visibleShortcutIDs: [safari.id, terminal.id, notes.id, chrome.id]
+    )
+
+    #expect(context.editor.shortcuts.map(\.id) == [terminal.id, notes.id, safari.id, chrome.id])
+    #expect(context.callbackCount.value == 1)
+
+    let persisted = try context.harness.makePersistenceService().load()
+    #expect(persisted.map(\.id) == [terminal.id, notes.id, safari.id, chrome.id])
+}
+
+@Test
+func reorderPlannerMapsDownwardDragToVisibleInsertionOffset() {
+    let ids = (0..<4).map { _ in UUID() }
+    let rowFrames = rowFrames(for: ids)
+
+    let offset = ShortcutReorderPlanner.visibleDropOffset(
+        for: ids[0],
+        translationY: 110,
+        visibleShortcutIDs: ids,
+        rowFrames: rowFrames
+    )
+
+    #expect(offset == 3)
+}
+
+@Test
+func reorderPlannerMapsUpwardDragToVisibleInsertionOffset() {
+    let ids = (0..<4).map { _ in UUID() }
+    let rowFrames = rowFrames(for: ids)
+
+    let offset = ShortcutReorderPlanner.visibleDropOffset(
+        for: ids[3],
+        translationY: -110,
+        visibleShortcutIDs: ids,
+        rowFrames: rowFrames
+    )
+
+    #expect(offset == 1)
+}
+
+@Test @MainActor
 func beginImportBuildsPreviewWithoutPersistingChanges() throws {
     let context = makeEditorContext()
     defer { context.harness.cleanup() }
@@ -206,6 +278,21 @@ func beginImportBuildsPreviewWithoutPersistingChanges() throws {
     #expect(context.editor.pendingRecipeImport?.entries.count == 1)
     #expect(persisted.isEmpty)
     #expect(context.callbackCount.value == 0)
+}
+
+private func rowFrames(for ids: [UUID]) -> [UUID: CGRect] {
+    let rowHeight: CGFloat = 50
+    return Dictionary(uniqueKeysWithValues: ids.enumerated().map { index, id in
+        (
+            id,
+            CGRect(
+                x: 0,
+                y: CGFloat(index) * rowHeight,
+                width: 400,
+                height: rowHeight
+            )
+        )
+    })
 }
 
 @Test @MainActor


### PR DESCRIPTION
Fixes #238

## Summary
- keep the menu bar popover shortcut list anchored to the local scroll clip width so always-visible macOS scroll bars do not clip trailing shortcut UI
- keep the Insights Most used rows anchored to the local scroll clip width for the same always-visible scroll bar case
- stop manually repositioning the native titlebar traffic lights so Settings sidebar toggling no longer causes the close/minimize/zoom controls to visibly jump
- replace the broken system drop-target reorder path in `Your Shortcuts` with grip-only local drag reordering backed by visible-row frame mapping and persisted ordering updates
- add focused regression coverage for local scroller width containment, titlebar chrome stability, and shortcut reorder mapping/persistence

## Testing
- [x] `swift test --filter LayoutRegressionTests`
- [x] `swift test --filter ShortcutEditorStateTests`
- [x] `swift test`
- [x] `git diff --check`
- [x] `./scripts/package-app.sh`
- [x] `codesign --verify --deep --strict --verbose=2 build/Wink.app`
- [x] Packaged Settings screenshot capture: `build/validation/settings-dnd-titlebar-2026-04-27/screenshots/03-settings-window-final-package.png`
- [x] Packaged Settings DnD screenshot capture: `build/validation/settings-dnd-titlebar-2026-04-27/screenshots/05-settings-dnd-after-grip-computer-use.png`

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] No toggle / activation / event tap / persistence architecture docs drift was introduced; `AGENTS.md` and `docs/architecture.md` remain current for this PR scope.
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Local code review found no blocking issues.
- Runtime validation covered Settings titlebar stability plus `Your Shortcuts` drag-to-reorder in the rebuilt packaged app.
- The final DnD validation moved `Ghostty` from row 1 to after `Finder` via Computer Use, confirmed both in UI and in `~/Library/Application Support/Wink/shortcuts.json`, then restored the original shortcuts order.
- Full shortcut capture, TCC, login item, and activation-path E2E were not rerun because this PR only changes Settings UI chrome and local list interaction behavior.