### PR TITLE
Refine README Wink meaning copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Wink is a macOS menu bar app for opening, focusing, and hiding apps with global shortcuts. It keeps the interaction deliberately small: press a shortcut once to bring an app forward, press it again to get it out of the way.
 
 ## Why "Wink"?
-The name comes from the rename discussion in [issue #183](https://github.com/xrf9268-hue/Wink/issues/183). The old name described quick keys; Wink describes the experience: app switching that happens in the wink of an eye.
+Wink suggests a quick, subtle signal: something that happens almost instantly and then gets out of the way. That is the feeling Wink aims for when switching apps.
 
 ## Highlights
 - Bind letters, function keys, arrows, or Space to target apps.


### PR DESCRIPTION
Fixes #244

## Summary
- replace the “Why Wink?” paragraph with direct product meaning copy
- remove issue/history wording from the README introduction

## Testing
- [ ] `swift test`
- [x] Additional validation noted below when needed

Additional validation:
- `git diff --check`
- reviewed the rendered README excerpt locally

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Docs-only follow-up to #243.