### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Sources/Wink/Resources/Info.plist
+++ b/Sources/Wink/Resources/Info.plist
@@ -11,8 +11,8 @@
   <key>CFBundleIconFile</key><string>AppIcon</string>
   <key>CFBundleIconName</key><string>AppIcon</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.3.0</string>
-  <key>CFBundleVersion</key><string>3</string>
+  <key>CFBundleShortVersionString</key><string>0.4.0</string>
+  <key>CFBundleVersion</key><string>4</string>
   <key>LSUIElement</key><true/>
   <key>LSMinimumSystemVersion</key><string>14.0</string>
   <key>NSHumanReadableCopyright</key><string>Copyright © 2026. All rights reserved.</string>


### PR DESCRIPTION
Fixes #247

## Summary
- bump `CFBundleShortVersionString` from `0.3.0` to `0.4.0` and `CFBundleVersion` from `3` to `4` in `Sources/Wink/Resources/Info.plist`
- reflect the cumulative work since 0.3.0: UI v2 migration (#207, #209, #210, #211), Sparkle auto-update pipeline (#197), shortcut recipe import/export (#196), drag-to-reorder (#179), menu bar shortcut overview (#201), Insights redesign (#199), DMG installer rebrand (#219, #234), and the Settings polish + docs wave (#216, #223, #225, #226, #232, #233, #236, #237, #239, #240, #243, #245)

## Testing
- [ ] `swift test`
- [x] Additional validation noted below when needed

Additional validation:
- `git diff Sources/Wink/Resources/Info.plist` shows only the version + build delta
- existing `Tests/WinkTests/SparkleUpdateServiceTests.swift`, `MenuBarPopoverViewTests.swift`, and `AppPreferencesTests.swift` use `0.3.0` as a fixed mock plist string (not asserting the running app version), so they intentionally stay unchanged
- runtime version surface (menu bar popover wordmark, About box) will show `v0.4.0` after the next packaged build; the manual packaged-app verification still needs to happen on hardware before tagging `v0.4.0`

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Pure version metadata change. Manual packaged-app validation (build, install DMG, confirm `v0.4.0` shows in menu bar popover and Sparkle "current version") still needs to happen before cutting the `v0.4.0` tag per `docs/signing-and-release.md`.
- The CI `Build and Test` failure observed on the first run is the pre-existing `InsightsViewModelTests.latestPeriodWinsWhenRefreshesOverlap()` async-flake also failing on `main` (runs 25030334768 for #245 and 24972799242 for #237). Unrelated to this version delta.