### PR TITLE
fix: deterministically await Insights refresh in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ scripts/cgevent-helper
 .worktrees/
 logs/
 worker/.wrangler/
+.env
+.env.*
+!.env.example

--- a/Sources/Wink/UI/InsightsViewModel.swift
+++ b/Sources/Wink/UI/InsightsViewModel.swift
@@ -98,6 +98,10 @@ final class InsightsViewModel {
         await doRefresh(for: period, generation: refreshGeneration)
     }
 
+    func waitForRefreshForTesting() async {
+        await refreshTask?.value
+    }
+
     private func doRefresh(for period: InsightsPeriod, generation: UInt64) async {
         let now = nowProvider()
 

--- a/Tests/WinkTests/InsightsViewModelTests.swift
+++ b/Tests/WinkTests/InsightsViewModelTests.swift
@@ -142,11 +142,7 @@ func latestPeriodWinsWhenRefreshesOverlap() async {
     viewModel.period = .month
     viewModel.period = .day
 
-    await waitForRefreshResult {
-        viewModel.totalCount == 1 &&
-        viewModel.ranking.first?.id == shortcutId &&
-        viewModel.ranking.first?.count == 1
-    }
+    await viewModel.waitForRefreshForTesting()
 
     #expect(viewModel.period == .day)
     #expect(viewModel.totalCount == 1)
@@ -243,20 +239,3 @@ private func timeZoneDistinctFromCurrent(relativeTo now: Date) -> TimeZone {
     }) ?? TimeZone(secondsFromGMT: 0)!
 }
 
-@MainActor
-private func waitForRefreshResult(
-    timeout: Duration = .seconds(5),
-    pollInterval: Duration = .milliseconds(10),
-    condition: @escaping @MainActor () -> Bool
-) async {
-    let clock = ContinuousClock()
-    let deadline = clock.now.advanced(by: timeout)
-
-    while clock.now < deadline {
-        if condition() {
-            return
-        }
-
-        try? await Task.sleep(for: pollInterval)
-    }
-}


### PR DESCRIPTION
Fixes #248

## Summary
- Replace the 5-second wall-clock polling helper (\`waitForRefreshResult\`) in \`latestPeriodWinsWhenRefreshesOverlap\` with a deterministic \`await viewModel.waitForRefreshForTesting()\`, matching the \`AppListProvider.waitForRefreshForTesting()\` pattern already used in this codebase
- Add \`.env\` / \`.env.*\` to \`.gitignore\` (with \`.env.example\` allow-listed) so local secrets are never staged accidentally

## Why Apple's docs back this approach
- **Swift concurrency docs**: \`Task.value\` is the documented way to wait for an unstructured \`Task\` to finish. Cancelled tasks still complete, so \`await refreshTask?.value\` waits exactly as long as the refresh actually takes — no clock-based ceiling.
- **Swift Testing migration guide**: explicitly recommends moving away from wall-clock waits and toward \`Confirmation\` / \`await\` whenever the production code can surface an awaitable handle. Polling with a timeout is the legacy XCTest \`expectation(...)\` shape; it should be the last resort.
- **Project convention**: \`Sources/Wink/Services/AppListProvider.swift:67\` already exposes the exact same \`waitForRefreshForTesting()\` accessor pattern and is used by \`AppListProviderTests\`. The new code mirrors that convention.

## Why the old test was flaky
The InsightsViewModel uses two complementary mechanisms (cancel the previous \`refreshTask\`, plus a generation counter) to make sure the latest \`period\` write wins. Both are correct.

The flake came from the **test side**: \`waitForRefreshResult\` polled with a 5-second deadline. Swift Testing runs tests in parallel; every \`@MainActor\` test serializes on the same executor. When the suite is busy, Task B's \`doRefresh\` body — which has 9 \`async let\` calls into a serial actor and then has to hop back to MainActor to publish state — can take longer than 5 seconds before \`totalCount\` is observed, even though the view model itself is correct. When that happens the polling loop times out with view-model state still at its initial \`(totalCount=0, ranking=[])\`, which matches the failure shape we kept seeing on CI (run \`25030334768\` on \`main\`, run \`25030848134\` post-merge for #246, etc.).

Awaiting \`refreshTask?.value\` removes the deadline entirely. Local repro:
- 5/5 isolated runs of the test passed in ~12ms
- Full \`swift test\` (366 tests) green; the same test runs in ~2.5s under parallel pressure — i.e. exactly the contention window the old 5s deadline could lose to

## Diff shape
- \`Sources/Wink/UI/InsightsViewModel.swift\`: add \`func waitForRefreshForTesting() async { await refreshTask?.value }\`
- \`Tests/WinkTests/InsightsViewModelTests.swift\`: replace polling helper with the new awaitable accessor; delete now-unused \`waitForRefreshResult\` helper
- \`.gitignore\`: add \`.env\`, \`.env.*\`, allow-list \`.env.example\`

## Testing
- [x] \`swift test\`
- [x] Additional validation noted below when needed

Additional validation:
- 5x repeated \`swift test --filter latestPeriodWinsWhenRefreshesOverlap\`, all pass ~12ms each
- Full \`swift test\` passes (366 tests, ~2.5s for the previously flaky case under parallel load)
- Verified \`.env\` is no longer tracked; \`git status\` shows it as untracked, ignored after the gitignore update

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant \`AGENTS.md\` and \`docs/architecture.md\` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to \`docs/archive/\` as a current source of truth.

## Notes
- Test-only + gitignore change. Production refresh logic is untouched; the new \`waitForRefreshForTesting()\` accessor is a thin wrapper over the existing private \`refreshTask\` and only matters in test builds.