### PR TITLE
fix: resolve menu bar resource bundle for packaged .app

### DIFF
--- a/Sources/Wink/Resources/Info.plist
+++ b/Sources/Wink/Resources/Info.plist
@@ -11,8 +11,8 @@
   <key>CFBundleIconFile</key><string>AppIcon</string>
   <key>CFBundleIconName</key><string>AppIcon</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>0.4.0</string>
-  <key>CFBundleVersion</key><string>4</string>
+  <key>CFBundleShortVersionString</key><string>0.4.1</string>
+  <key>CFBundleVersion</key><string>5</string>
   <key>LSUIElement</key><true/>
   <key>LSMinimumSystemVersion</key><string>14.0</string>
   <key>NSHumanReadableCopyright</key><string>Copyright © 2026. All rights reserved.</string>

--- a/Sources/Wink/UI/MenuBar/WinkMenuBarScene.swift
+++ b/Sources/Wink/UI/MenuBar/WinkMenuBarScene.swift
@@ -12,7 +12,7 @@ struct WinkMenuBarSceneDescriptor: Equatable {
 
 enum WinkMenuBarTemplateAsset {
     static let name = "MenuBarTemplate"
-    static let imageResource = ImageResource(name: name, bundle: .module)
+    static let imageResource = ImageResource(name: name, bundle: WinkResourceBundle.bundle)
 
     static var image: NSImage {
         let image = NSImage(resource: imageResource)

--- a/Sources/Wink/UI/MenuBar/WinkResourceBundle.swift
+++ b/Sources/Wink/UI/MenuBar/WinkResourceBundle.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+private final class WinkResourceBundleFinder {}
+
+enum WinkResourceBundle {
+    static let bundle: Bundle = {
+        let bundleName = "Wink_Wink.bundle"
+        let finderBundle = Bundle(for: WinkResourceBundleFinder.self)
+        let searchRoots: [URL] = [
+            Bundle.main.resourceURL,
+            Bundle.main.bundleURL,
+            finderBundle.resourceURL,
+            finderBundle.bundleURL,
+        ].compactMap { $0 }
+
+        for root in searchRoots {
+            let candidate = root.appendingPathComponent(bundleName)
+            if FileManager.default.fileExists(atPath: candidate.path),
+               let bundle = Bundle(url: candidate) {
+                return bundle
+            }
+        }
+
+        return .module
+    }()
+}

--- a/Tests/WinkTests/MenuBar/MenuBarSceneTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarSceneTests.swift
@@ -19,4 +19,10 @@ struct MenuBarSceneTests {
         #expect(WinkMenuBarScene<EmptyView>.descriptor(isInserted: true).isInserted == true)
         #expect(WinkMenuBarScene<EmptyView>.descriptor(isInserted: false).isInserted == false)
     }
+
+    @Test
+    func resourceBundleResolvesToANonNilBundle() {
+        let bundlePath = WinkResourceBundle.bundle.bundlePath
+        #expect(!bundlePath.isEmpty)
+    }
 }


### PR DESCRIPTION
Fixes #250

## Summary
The 0.4.0 internal-downloads build crashed on launch with \`EXC_BREAKPOINT\` because SwiftPM's autogenerated \`Bundle.module\` accessor cannot find \`Wink_Wink.bundle\` inside a packaged macOS \`.app\`. This PR replaces the \`.module\` reference at the only crash site with a Wink-specific resolver that searches the standard \`.app\` resource layout first, and ships the fix as **0.4.1**.

## Root cause (recap)
SwiftPM emits \`Bundle.module\` with two candidates:

\`\`\`swift
let mainPath  = Bundle.main.bundleURL.appendingPathComponent("Wink_Wink.bundle").path
let buildPath = "/Users/yvan/developer/Wink/.build/arm64-apple-macosx/release/Wink_Wink.bundle"
\`\`\`

In a packaged \`.app\`, \`Bundle.main.bundleURL\` is the \`.app\` directory, so \`mainPath\` resolves to \`/Applications/Wink.app/Wink_Wink.bundle\` — but \`scripts/package-app.sh\` correctly stores the bundle under \`Contents/Resources/Wink_Wink.bundle\` per the macOS bundle-structure spec. \`buildPath\` is the build-host absolute path and does not exist on user machines. Both candidates miss → \`Swift.fatalError\` → crash during \`applicationDidFinishLaunching → MenuBarExtra → WinkMenuBarTemplateLabel.body\`.

## Fix
- Add \`Sources/Wink/UI/MenuBar/WinkResourceBundle.swift\`: probes \`Bundle.main.resourceURL\`, \`Bundle.main.bundleURL\`, and a finder-class bundle's \`resourceURL\` / \`bundleURL\` for \`Wink_Wink.bundle\`, and only falls back to \`.module\` when none of those candidates exist (SwiftPM dev/test path)
- \`Sources/Wink/UI/MenuBar/WinkMenuBarScene.swift\`: switch \`WinkMenuBarTemplateAsset.imageResource\` from \`bundle: .module\` to \`bundle: WinkResourceBundle.bundle\`
- \`Tests/WinkTests/MenuBar/MenuBarSceneTests.swift\`: add a smoke test that the resolver returns a non-empty bundle path
- \`Sources/Wink/Resources/Info.plist\`: bump \`CFBundleShortVersionString\` 0.4.0 → 0.4.1 and \`CFBundleVersion\` 4 → 5 so the Sparkle feed publishes the patch and broken 0.4.0 installs are upgraded

## Why this is the right shape
- Apple's macOS bundle-structure spec forbids placing sub-bundles outside \`Contents/\`. Moving the resource bundle to satisfy SwiftPM's hard-coded \`Bundle.main.bundleURL/Wink_Wink.bundle\` would violate that contract; using a custom resolver instead is the conventional fix for SwiftPM resources packaged into a real \`.app\`.
- The fallback to \`.module\` is preserved so SwiftPM CLI, \`swift test\`, and developer flows continue to work without changing \`Package.swift\` or the resource bundle layout.
- Only one production call site uses \`.module\` today (\`WinkMenuBarTemplateAsset.imageResource\`), so the blast radius of this change is small. If we add more \`ImageResource(.module)\` callers later, they should also route through \`WinkResourceBundle.bundle\`.

## Testing
- [x] \`swift test\` (367 tests, all green)
- [x] Additional validation noted below when needed

Additional validation:
- \`bash scripts/package-app.sh\`
- \`rm -rf /Applications/Wink.app && cp -R build/Wink.app /Applications/Wink.app\`
- \`open /Applications/Wink.app\` — process stays up (PID 29640 confirmed alive 14s+ later)
- No new \`~/Library/Logs/DiagnosticReports/Wink-*.ips\` after launch (last crash 11:03 against 0.4.0; post-fix launch 11:18 with no new report)

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant \`AGENTS.md\` and \`docs/architecture.md\` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to \`docs/archive/\` as a current source of truth.

## Notes
- Local packaged-app launch confirms the fix on this machine. Before tagging \`v0.4.1\` the clean-machine validation (DMG install on a host without the build cache around) per \`docs/signing-and-release.md\` is still required.
- \`Wink_Wink.bundle\` placement and \`scripts/package-app.sh\` itself are unchanged — the fix is purely in the runtime resolver.