### PR TITLE
fix: gate Hyper routing on startup reapply

### DIFF
--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -144,7 +144,7 @@ final class AppController {
         startUpdateService: @MainActor () -> Void,
         loadShortcuts: @MainActor () throws -> [AppShortcut],
         replaceShortcuts: @MainActor ([AppShortcut]) -> Void,
-        reapplyHyperIfNeeded: @MainActor () -> Void,
+        reapplyHyperIfNeeded: @MainActor () -> Bool,
         isHyperEnabled: @MainActor () -> Bool,
         setHyperKeyEnabled: @MainActor (Bool) -> Void,
         preparePreferences: @MainActor () -> Void = {},
@@ -158,8 +158,9 @@ final class AppController {
                 "Startup skipped shortcut restore because persistence loading failed: \(error.localizedDescription)"
             )
         }
-        reapplyHyperIfNeeded()
-        setHyperKeyEnabled(isHyperEnabled())
+        let isHyperEnabled = isHyperEnabled()
+        let isHyperMappingApplied = reapplyHyperIfNeeded()
+        setHyperKeyEnabled(isHyperEnabled && isHyperMappingApplied)
         preparePreferences()
         startShortcutManager()
     }

--- a/Sources/Wink/Services/HyperKeyService.swift
+++ b/Sources/Wink/Services/HyperKeyService.swift
@@ -75,11 +75,17 @@ final class HyperKeyService {
     }
 
     /// Re-apply mapping on app launch if previously enabled (hidutil mappings don't survive reboot).
-    func reapplyIfNeeded() {
-        guard isEnabled else { return }
-        guard applyMapping() else { return }
+    /// Returns whether the Hyper key mapping is actually applied after the call.
+    func reapplyIfNeeded() -> Bool {
+        guard isEnabled else { return false }
+        guard applyMapping() else {
+            logger.error("Failed to re-apply Hyper Key mapping on launch")
+            DiagnosticLog.log("Failed to re-apply Hyper Key mapping on launch")
+            return false
+        }
         logger.info("Hyper Key mapping re-applied on launch")
         DiagnosticLog.log("Hyper Key mapping re-applied on launch")
+        return true
     }
 
     /// Clear mapping on app exit to restore normal Caps Lock behavior.

--- a/Tests/WinkTests/AppControllerTests.swift
+++ b/Tests/WinkTests/AppControllerTests.swift
@@ -20,6 +20,7 @@ func startupSequenceAppliesPersistedHyperStateBeforeStartingShortcutManager() {
         },
         reapplyHyperIfNeeded: {
             events.append("reapplyHyper")
+            return true
         },
         isHyperEnabled: {
             events.append("readHyperEnabled")
@@ -37,9 +38,51 @@ func startupSequenceAppliesPersistedHyperStateBeforeStartingShortcutManager() {
         "startUpdateService",
         "load",
         "replace",
-        "reapplyHyper",
         "readHyperEnabled",
+        "reapplyHyper",
         "setHyper:true",
+        "startShortcutManager",
+    ])
+}
+
+@Test @MainActor
+func startupSequenceDisablesHyperRoutingWhenPersistedReapplyFails() {
+    var events: [String] = []
+
+    AppController.runStartupSequence(
+        startUpdateService: {
+            events.append("startUpdateService")
+        },
+        loadShortcuts: {
+            events.append("load")
+            return []
+        },
+        replaceShortcuts: { _ in
+            events.append("replace")
+        },
+        reapplyHyperIfNeeded: {
+            events.append("reapplyHyper")
+            return false
+        },
+        isHyperEnabled: {
+            events.append("readHyperEnabled")
+            return true
+        },
+        setHyperKeyEnabled: { enabled in
+            events.append("setHyper:\(enabled)")
+        },
+        startShortcutManager: {
+            events.append("startShortcutManager")
+        }
+    )
+
+    #expect(events == [
+        "startUpdateService",
+        "load",
+        "replace",
+        "readHyperEnabled",
+        "reapplyHyper",
+        "setHyper:false",
         "startShortcutManager",
     ])
 }
@@ -81,6 +124,7 @@ func startupSequenceStartsUpdateServiceBeforeShortcutManager() {
         },
         reapplyHyperIfNeeded: {
             events.append("reapplyHyper")
+            return false
         },
         isHyperEnabled: {
             events.append("readHyperEnabled")
@@ -119,6 +163,7 @@ func startupSequenceAppliesPersistedPreferencesBeforeStartingShortcutManager() {
         },
         reapplyHyperIfNeeded: {
             events.append("reapplyHyper")
+            return false
         },
         isHyperEnabled: {
             events.append("readHyperEnabled")

--- a/Tests/WinkTests/HyperKeyServiceTests.swift
+++ b/Tests/WinkTests/HyperKeyServiceTests.swift
@@ -36,6 +36,24 @@ func disableDoesNotClearPersistedStateWhenHidutilFails() {
 }
 
 @Test @MainActor
+func reapplyFailurePreservesPreferenceButReportsMappingUnavailable() {
+    let suiteName = "HyperKeyServiceTests.reapply.failure"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "hyperKeyEnabled")
+
+    let service = HyperKeyService(
+        runner: { _ in false },
+        defaults: defaults
+    )
+
+    let didApply = service.reapplyIfNeeded()
+
+    #expect(didApply == false)
+    #expect(service.isEnabled == true)
+}
+
+@Test @MainActor
 func disableRestoresCapsLockDelayOverrideDefault() {
     let suiteName = "HyperKeyServiceTests.disable.capsLockDelay"
     let defaults = UserDefaults(suiteName: suiteName)!


### PR DESCRIPTION
Fixes #254

## Summary
- make `HyperKeyService.reapplyIfNeeded()` report whether the Caps Lock -> F19 mapping was actually applied on startup
- gate `ShortcutManager.setHyperKeyEnabled` during startup on both the persisted Hyper preference and a successful mapping reapply
- preserve the user's Hyper preference when `hidutil` reapply fails, but avoid treating Hyper routing as ready for that launch

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

Additional validation:
- `swift test --filter 'HyperKeyServiceTests|startupSequenceDisablesHyperRoutingWhenPersistedReapplyFails|startupSequenceAppliesPersistedHyperStateBeforeStartingShortcutManager|startupSequenceStartsUpdateServiceBeforeShortcutManager|startupSequenceAppliesPersistedPreferencesBeforeStartingShortcutManager'`
- `node --test .github/scripts/tests/*.test.mjs`
- `swift build -c release`

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- This is runtime-sensitive because it changes startup Hyper routing behavior. Unit tests use injected `hidutil` runners; no real `hidutil` mapping, TCC, login item, system setting, Keychain, or user data state was modified locally.
- Full runtime validation would require exercising the packaged app with Hyper enabled and may affect the local keyboard mapping / Caps Lock behavior, so it remains pending until explicitly approved.

