### PR TITLE
fix: join background run loop thread before releasing EventTapBox (Issue #261)

### DIFF
--- a/Sources/Wink/Services/EventTapManager.swift
+++ b/Sources/Wink/Services/EventTapManager.swift
@@ -560,10 +560,12 @@ final class EventTapManager: EventTapManaging {
 /// Keeps the tap responsive even if the main thread is busy with UI work.
 /// Uses an NSCondition-based readiness mechanism instead of a one-shot semaphore
 /// so that the same thread supports repeated add/remove/recreate cycles.
-private final class BackgroundRunLoopThread: Thread {
+/// internal for @testable access
+final class BackgroundRunLoopThread: Thread {
     private var threadRunLoop: CFRunLoop?
     private let readyCondition = NSCondition()
     private var isReady = false
+    private var didExit = false
 
     override func main() {
         readyCondition.lock()
@@ -576,7 +578,23 @@ private final class BackgroundRunLoopThread: Thread {
         var mutableContext = context
         let dummySource = CFRunLoopSourceCreate(kCFAllocatorDefault, 0, &mutableContext)
         CFRunLoopAddSource(threadRunLoop, dummySource, .commonModes)
-        CFRunLoopRun()
+        // A cancel() issued before this point could not stop the run loop
+        // (CFRunLoopStop on a non-running loop is a no-op), so don't enter it.
+        if !isCancelled {
+            CFRunLoopRun()
+        }
+        readyCondition.lock()
+        didExit = true
+        readyCondition.broadcast()
+        readyCondition.unlock()
+    }
+
+    /// True once `main()` has returned past `CFRunLoopRun()`. Test seam for
+    /// verifying `cancel()`'s join semantics.
+    var hasExited: Bool {
+        readyCondition.lock()
+        defer { readyCondition.unlock() }
+        return didExit
     }
 
     /// Wait for the run loop to become ready and return it.
@@ -601,14 +619,29 @@ private final class BackgroundRunLoopThread: Thread {
         CFRunLoopRemoveSource(rl, source, .commonModes)
     }
 
+    /// Blocks until the thread can no longer touch the `EventTapBox`: either
+    /// `main()` has returned, or the thread exited without ever running
+    /// `main()` (Foundation skips `main()` when the cancelled flag wins the
+    /// race against thread startup). Callers (`EventTapManager.stop()`) rely
+    /// on this join to release the box only after no tap callback can still
+    /// be executing on this thread.
     override func cancel() {
         super.cancel()
         readyCondition.lock()
-        let rl = threadRunLoop
-        readyCondition.unlock()
-        if let rl = rl {
-            CFRunLoopStop(rl)
+        while !didExit {
+            if isReady, let rl = threadRunLoop {
+                // CFRunLoopStop is a no-op if it lands between the readiness
+                // broadcast and CFRunLoopRun() actually starting, so re-issue
+                // it every pass instead of waiting forever on a lost stop.
+                CFRunLoopStop(rl)
+            }
+            if !readyCondition.wait(until: Date().addingTimeInterval(0.01)),
+               isFinished {
+                // Thread exited without running main() — nothing to join.
+                break
+            }
         }
+        readyCondition.unlock()
     }
 }
 

--- a/Tests/WinkTests/EventTapManagerLifecycleTests.swift
+++ b/Tests/WinkTests/EventTapManagerLifecycleTests.swift
@@ -208,6 +208,58 @@ struct EventTapLifecycleLoggingTests {
     }
 }
 
+// MARK: - Background run loop thread teardown
+
+@Suite("BackgroundRunLoopThread teardown synchronization")
+struct BackgroundRunLoopThreadTeardownTests {
+
+    /// `EventTapManager.stop()` releases the retained `EventTapBox` right after
+    /// `cancel()` returns. That is only safe if `cancel()` blocks until the
+    /// background run loop has fully exited — including any in-flight tap
+    /// callback executing on that thread.
+    @Test
+    func cancelBlocksUntilInFlightRunLoopWorkCompletes() {
+        let thread = BackgroundRunLoopThread()
+        thread.start()
+        guard let runLoop = thread.runLoop else {
+            Issue.record("background run loop never became ready")
+            return
+        }
+
+        let blockStarted = DispatchSemaphore(value: 0)
+        let blockFinished = LockedValue(false)
+        CFRunLoopPerformBlock(runLoop, CFRunLoopMode.commonModes.rawValue) {
+            blockStarted.signal()
+            Thread.sleep(forTimeInterval: 0.2)
+            blockFinished.value = true
+        }
+        CFRunLoopWakeUp(runLoop)
+
+        #expect(blockStarted.wait(timeout: .now() + 5) == .success)
+        thread.cancel()
+
+        // cancel() must not return while the run loop is still executing work.
+        #expect(blockFinished.value)
+        #expect(thread.hasExited)
+    }
+
+    /// Hammer the start→cancel transition: CFRunLoopStop is a no-op when it
+    /// lands before CFRunLoopRun() starts, and Foundation may skip main()
+    /// entirely when the cancelled flag wins the race against thread startup.
+    /// cancel() must return (not hang) in every interleaving, and afterwards
+    /// the thread must be unable to touch the box: either main() ran to
+    /// completion or the thread finished without ever running it.
+    @Test
+    func cancelImmediatelyAfterStartDoesNotHang() {
+        for _ in 0..<50 {
+            let thread = BackgroundRunLoopThread()
+            thread.start()
+            thread.cancel()
+            #expect(thread.hasExited || thread.isFinished)
+        }
+    }
+}
+
 // MARK: - Callback-safe recovery dispatch
 
 @Suite("EventTapManagerLifecycle callback safety")


### PR DESCRIPTION
Fixes #261

## Summary
- `EventTapManager.stop()` released the retained `EventTapBox` immediately after requesting the background run loop to stop. Neither `CGEvent.tapEnable(false)` nor `CFRunLoopStop` blocks until an in-flight tap callback returns, so the box could be freed while the callback was still dereferencing it via `userInfo` — a use-after-free race surfacing as sporadic crashes on quit or shortcut disable.
- `BackgroundRunLoopThread.cancel()` now joins the thread before returning, extending the existing `NSCondition` readiness mechanism with a `didExit` flag:
  - `main()` sets `didExit` and broadcasts after `CFRunLoopRun()` returns
  - `cancel()` waits for `didExit`, re-issuing `CFRunLoopStop` on each wait timeout — a single stop request is lost if it lands between the readiness broadcast and `CFRunLoopRun()` actually starting
  - `cancel()` exits via `isFinished` when Foundation skips `main()` entirely (the cancelled flag can win the race against thread startup; observed deterministically in the new stress test)
  - `main()` skips `CFRunLoopRun()` when already cancelled, shortening the immediate start→cancel path
- `stop()` keeps its existing order (`cancel()` → `retainedBox?.release()`), which is now safe because `cancel()` returns only after no tap callback can still be executing. `BackgroundRunLoopThread` visibility was relaxed from `private` to internal for `@testable` access, plus a `hasExited` test seam.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

New suite `BackgroundRunLoopThread teardown synchronization`:
- `cancelBlocksUntilInFlightRunLoopWorkCompletes` — schedules a 200ms block on the background run loop, cancels mid-execution, asserts `cancel()` does not return until the block finished and the run loop exited. Red on the previous implementation (cancel returned immediately).
- `cancelImmediatelyAfterStartDoesNotHang` — hammers the start→cancel transition 50×, covering both the lost-`CFRunLoopStop` window and the Foundation-skips-`main()` path. A naive unconditional join deadlocked here; the re-issue + `isFinished` exit makes it pass.

`swift build` and `swift test` (371 tests, 38 suites) pass locally on macOS. Suggested runtime pass per the issue: repeated start/stop cycles under active keyboard input (Hyper toggling while holding keys), ideally with TSan.

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Teardown-only change to the event tap lifecycle; the documented auto-recovery behavior (`recreateEventTap`, box reuse across recreation) is unchanged, so no docs updates are needed.


---
**Runtime validation completed 2026-06-11** on the packaged /Applications/Wink.app (main 9ee4a50, v0.4.1) after TCC re-grant. Full evidence (commands, logs, screenshots): `build/validation/issues-261-262-263-2026-06-11/RESULTS.md` in the validation artifact directory.