### PR TITLE
fix: stop silently dropping shortcut changes when disk write fails (Issue #262)

### DIFF
--- a/Sources/Wink/Services/PersistenceService.swift
+++ b/Sources/Wink/Services/PersistenceService.swift
@@ -11,6 +11,20 @@ struct PersistenceService: Sendable {
         static let live = DiagnosticClient(log: DiagnosticLog.log)
     }
 
+    enum SaveError: Error, LocalizedError, Sendable {
+        case storageUnavailable
+        case writeFailed(path: String, reason: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .storageUnavailable:
+                return "Failed to save shortcuts: path unavailable"
+            case let .writeFailed(path, reason):
+                return "Failed to save shortcuts: path=\(path) reason=\(reason)"
+            }
+        }
+    }
+
     enum LoadError: Error, LocalizedError, Sendable {
         case storageUnavailable
         case fileReadFailed(path: String, reason: String)
@@ -82,12 +96,11 @@ struct PersistenceService: Sendable {
         }
     }
 
-    func save(_ shortcuts: [AppShortcut]) {
+    func save(_ shortcuts: [AppShortcut]) throws {
         guard let url = storageURLProvider() else {
-            let message = "Failed to save shortcuts: path unavailable"
-            logger.error("\(message, privacy: .public)")
-            diagnosticClient.log(message)
-            return
+            let error = SaveError.storageUnavailable
+            logSaveFailure(error)
+            throw error
         }
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -96,10 +109,19 @@ struct PersistenceService: Sendable {
             let data = try encoder.encode(shortcuts)
             try data.write(to: url, options: .atomic)
         } catch {
-            let message = "Failed to save shortcuts: path=\(url.path) reason=\(error.localizedDescription)"
-            logger.error("\(message, privacy: .public)")
-            diagnosticClient.log(message)
+            let saveError = SaveError.writeFailed(
+                path: url.path,
+                reason: error.localizedDescription
+            )
+            logSaveFailure(saveError)
+            throw saveError
         }
+    }
+
+    private func logSaveFailure(_ error: SaveError) {
+        let message = error.localizedDescription
+        logger.error("\(message, privacy: .public)")
+        diagnosticClient.log(message)
     }
 
     private func preserveUnreadablePayload(_ data: Data, originalURL: URL) -> String? {

--- a/Sources/Wink/Services/ShortcutEditorState.swift
+++ b/Sources/Wink/Services/ShortcutEditorState.swift
@@ -75,6 +75,7 @@ final class ShortcutEditorState {
     var recordedShortcut: RecordedShortcut?
     var isRecordingShortcut: Bool = false
     var conflictMessage: String?
+    var saveErrorMessage: String?
     var recipeFeedback: RecipeFeedback?
     var pendingRecipeImport: WinkRecipeImportPlanner.ImportPlan?
     var usageCounts: [UUID: Int] = [:]
@@ -134,8 +135,7 @@ final class ShortcutEditorState {
 
         var updated = shortcuts
         updated.append(candidate)
-        shortcuts = updated
-        shortcutManager.save(shortcuts: updated)
+        guard persist(updated) else { return }
         onShortcutConfigurationChange()
         conflictMessage = nil
         resetDraft()
@@ -144,8 +144,7 @@ final class ShortcutEditorState {
 
     func removeShortcut(id: UUID) {
         let updated = shortcuts.filter { $0.id != id }
-        shortcuts = updated
-        shortcutManager.save(shortcuts: updated)
+        guard persist(updated) else { return }
         onShortcutConfigurationChange()
         if let usageTracker {
             Task {
@@ -158,8 +157,7 @@ final class ShortcutEditorState {
     func moveShortcut(from source: IndexSet, to destination: Int) {
         var updated = shortcuts
         updated.moveItems(from: source, to: destination)
-        shortcuts = updated
-        shortcutManager.save(shortcuts: updated)
+        guard persist(updated) else { return }
         onShortcutConfigurationChange()
     }
 
@@ -201,16 +199,18 @@ final class ShortcutEditorState {
 
     func toggleShortcutEnabled(id: UUID) {
         guard let index = shortcuts.firstIndex(where: { $0.id == id }) else { return }
-        shortcuts[index].isEnabled.toggle()
-        shortcutManager.save(shortcuts: shortcuts)
+        var updated = shortcuts
+        updated[index].isEnabled.toggle()
+        guard persist(updated) else { return }
         onShortcutConfigurationChange()
     }
 
     func setAllEnabled(_ enabled: Bool) {
-        for index in shortcuts.indices {
-            shortcuts[index].isEnabled = enabled
+        var updated = shortcuts
+        for index in updated.indices {
+            updated[index].isEnabled = enabled
         }
-        shortcutManager.save(shortcuts: shortcuts)
+        guard persist(updated) else { return }
         onShortcutConfigurationChange()
     }
 
@@ -304,8 +304,8 @@ final class ShortcutEditorState {
             strategy: strategy
         )
 
-        shortcuts = updatedShortcuts
-        shortcutManager.save(shortcuts: updatedShortcuts)
+        // Keep the pending import on failure so the user can retry.
+        guard persist(updatedShortcuts) else { return }
         onShortcutConfigurationChange()
         conflictMessage = nil
         self.pendingRecipeImport = nil
@@ -329,6 +329,23 @@ final class ShortcutEditorState {
         async let lastUsedMap = usageTracker.lastUsedPerShortcut()
         usageCounts = await counts
         lastUsed = await lastUsedMap
+    }
+
+    /// Saves through the manager (disk first, then in-memory store). On
+    /// failure the editor list is reverted to the canonical store contents and
+    /// the error is surfaced via `saveErrorMessage` instead of silently
+    /// showing state that would not survive a relaunch.
+    private func persist(_ updated: [AppShortcut]) -> Bool {
+        do {
+            try shortcutManager.save(shortcuts: updated)
+            shortcuts = updated
+            saveErrorMessage = nil
+            return true
+        } catch {
+            shortcuts = shortcutStore.shortcuts
+            saveErrorMessage = error.localizedDescription
+            return false
+        }
     }
 
     private func observeShortcutStore() {

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -97,10 +97,13 @@ final class ShortcutManager {
         captureCoordinator.stop()
     }
 
-    func save(shortcuts: [AppShortcut]) {
+    /// Persists to disk first and only then updates the in-memory store, so a
+    /// failed write cannot leave the running app showing state that silently
+    /// reverts on next launch (`shortcuts.json` is the canonical state).
+    func save(shortcuts: [AppShortcut]) throws {
         let inputMonitoringWasRequired = captureCoordinator.inputMonitoringRequired
+        try persistenceService.save(shortcuts)
         shortcutStore.replaceAll(with: shortcuts)
-        persistenceService.save(shortcuts)
         rebuildIndex()
         handleCaptureConfigurationChange(
             inputMonitoringWasRequired: inputMonitoringWasRequired

--- a/Sources/Wink/UI/ShortcutsTabView.swift
+++ b/Sources/Wink/UI/ShortcutsTabView.swift
@@ -432,6 +432,12 @@ struct ShortcutsTabView: View {
                     .foregroundStyle(palette.red)
             }
 
+            if let saveErrorMessage = editor.saveErrorMessage {
+                Text(saveErrorMessage)
+                    .font(WinkType.labelSmall)
+                    .foregroundStyle(palette.red)
+            }
+
             if let recipeFeedback = editor.recipeFeedback {
                 Text(recipeFeedback.message)
                     .font(WinkType.labelSmall)

--- a/Tests/WinkTests/AppPreferencesTests.swift
+++ b/Tests/WinkTests/AppPreferencesTests.swift
@@ -70,7 +70,7 @@ func setHyperKeyEnabledTracksActualServiceStateAfterFailure() {
 }
 
 @Test @MainActor
-func setHyperKeyEnabledRefreshesShortcutCaptureStatusForHyperRoutingChanges() {
+func setHyperKeyEnabledRefreshesShortcutCaptureStatusForHyperRoutingChanges() throws {
     let suiteName = "AppPreferencesTests.setHyperKeyEnabledRefreshesShortcutCaptureStatusForHyperRoutingChanges"
     let defaults = UserDefaults(suiteName: suiteName)!
     defaults.removePersistentDomain(forName: suiteName)
@@ -92,7 +92,7 @@ func setHyperKeyEnabledRefreshesShortcutCaptureStatusForHyperRoutingChanges() {
         permissionService: FakePermissionService(ax: true, input: false),
         diagnosticClient: .live
     )
-    manager.save(shortcuts: shortcutStore.shortcuts)
+    try manager.save(shortcuts: shortcutStore.shortcuts)
 
     let preferences = AppPreferences(
         shortcutManager: manager,
@@ -283,7 +283,7 @@ func initRestoresPausedShortcutPreferenceIntoRuntimeStatus() throws {
         permissionService: FakePermissionService(ax: true, input: true),
         diagnosticClient: .live
     )
-    manager.save(shortcuts: shortcutStore.shortcuts)
+    try manager.save(shortcuts: shortcutStore.shortcuts)
 
     let preferences = AppPreferences(
         shortcutManager: manager,
@@ -318,7 +318,7 @@ func setShortcutsPausedPersistsPreferenceAfterRuntimeUpdate() throws {
         permissionService: FakePermissionService(ax: true, input: true),
         diagnosticClient: .live
     )
-    manager.save(shortcuts: shortcutStore.shortcuts)
+    try manager.save(shortcuts: shortcutStore.shortcuts)
 
     let preferences = AppPreferences(
         shortcutManager: manager,

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverSearchTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverSearchTests.swift
@@ -42,7 +42,7 @@ struct MenuBarPopoverSearchTests {
     }
 
     @Test @MainActor
-    func blankSearchKeepsSavedOrdering() {
+    func blankSearchKeepsSavedOrdering() throws {
         let context = makeSearchPopoverContext(
             shortcuts: [
                 AppShortcut(
@@ -89,7 +89,7 @@ private func makeSearchPopoverContext(shortcuts: [AppShortcut]) -> SearchPopover
         permissionService: SearchFakePermissionService(),
         diagnosticClient: .live
     )
-    manager.save(shortcuts: shortcuts)
+    try! manager.save(shortcuts: shortcuts)
 
     let preferences = AppPreferences(
         shortcutManager: manager,

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
@@ -151,7 +151,7 @@ struct MenuBarPopoverViewTests {
     }
 
     @Test @MainActor
-    func modelRefreshesUnavailableStateForActivationNotificationsWhilePopoverIsOpen() {
+    func modelRefreshesUnavailableStateForActivationNotificationsWhilePopoverIsOpen() throws {
         let runtimeState = PopoverRuntimeState(
             applicationURLs: [
                 "com.apple.Safari": URL(fileURLWithPath: "/Applications/Safari.app")
@@ -219,7 +219,7 @@ private func makePopoverContext(
         permissionService: FakePermissionService(ax: true, input: true),
         diagnosticClient: .live
     )
-    manager.save(shortcuts: shortcuts)
+    try! manager.save(shortcuts: shortcuts)
 
     let preferences = AppPreferences(
         shortcutManager: manager,

--- a/Tests/WinkTests/PauseAllShortcutsTests.swift
+++ b/Tests/WinkTests/PauseAllShortcutsTests.swift
@@ -5,7 +5,7 @@ import Testing
 @Suite("Pause all shortcuts")
 struct PauseAllShortcutsTests {
     @Test @MainActor
-    func pausingStopsStandardAndHyperCaptureAndMarksStatusPaused() {
+    func pausingStopsStandardAndHyperCaptureAndMarksStatusPaused() throws {
         let standardProvider = FakeCaptureProvider()
         let hyperProvider = FakeHyperCaptureProvider()
         let coordinator = ShortcutCaptureCoordinator(
@@ -23,7 +23,7 @@ struct PauseAllShortcutsTests {
         )
         let shortcuts = [standardShortcut(), hyperShortcut()]
 
-        manager.save(shortcuts: shortcuts)
+        try manager.save(shortcuts: shortcuts)
         manager.setHyperKeyEnabled(true)
         manager.start()
         manager.setShortcutsPaused(true)
@@ -39,7 +39,7 @@ struct PauseAllShortcutsTests {
     }
 
     @Test @MainActor
-    func unpausingRestartsConfiguredCaptureWithoutRewritingShortcuts() async {
+    func unpausingRestartsConfiguredCaptureWithoutRewritingShortcuts() async throws {
         let standardProvider = FakeCaptureProvider()
         let hyperProvider = FakeHyperCaptureProvider()
         let coordinator = ShortcutCaptureCoordinator(
@@ -57,7 +57,7 @@ struct PauseAllShortcutsTests {
         )
         let shortcuts = [standardShortcut(), hyperShortcut()]
 
-        manager.save(shortcuts: shortcuts)
+        try manager.save(shortcuts: shortcuts)
         manager.setHyperKeyEnabled(true)
         manager.start()
         manager.setShortcutsPaused(true)

--- a/Tests/WinkTests/PersistenceServiceTests.swift
+++ b/Tests/WinkTests/PersistenceServiceTests.swift
@@ -20,7 +20,7 @@ struct PersistenceServiceDiskLoadingTests {
         ]
 
         let service = harness.makePersistenceService()
-        service.save(shortcuts)
+        try service.save(shortcuts)
 
         let liveShortcutsURL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Application Support/Wink", isDirectory: true)
@@ -58,7 +58,7 @@ struct PersistenceServiceDiskLoadingTests {
                 diagnostics.append(message)
             })
         )
-        service.save(shortcuts)
+        try service.save(shortcuts)
 
         let loaded = try service.load()
 
@@ -164,6 +164,55 @@ struct PersistenceServiceDiskLoadingTests {
         let backupURL = harness.directory.appendingPathComponent("shortcuts.load-failure-unsupported-schema.json")
         #expect(try Data(contentsOf: harness.shortcutsURL) == unsupportedPayload)
         #expect(try Data(contentsOf: backupURL) == unsupportedPayload)
+    }
+
+    @Test
+    func saveThrowsWhenStorageIsUnavailable() {
+        let diagnostics = DiagnosticRecorder()
+        let service = PersistenceService(
+            storageURLProvider: { nil },
+            diagnosticClient: .init(log: { message in
+                diagnostics.append(message)
+            })
+        )
+
+        #expect(throws: PersistenceService.SaveError.self) {
+            try service.save([])
+        }
+        #expect(diagnostics.messages.contains {
+            $0.contains("Failed to save shortcuts")
+        })
+    }
+
+    @Test
+    func saveThrowsWhenDiskWriteFails() throws {
+        let harness = TestPersistenceHarness()
+        defer { harness.cleanup() }
+        let diagnostics = DiagnosticRecorder()
+
+        let missingDirectoryURL = harness.directory
+            .appendingPathComponent("missing-subdirectory", isDirectory: true)
+            .appendingPathComponent("shortcuts.json")
+        let service = PersistenceService(
+            storageURLProvider: { missingDirectoryURL },
+            diagnosticClient: .init(log: { message in
+                diagnostics.append(message)
+            })
+        )
+
+        #expect(throws: PersistenceService.SaveError.self) {
+            try service.save([
+                AppShortcut(
+                    appName: "Safari",
+                    bundleIdentifier: "com.apple.Safari",
+                    keyEquivalent: "s",
+                    modifierFlags: ["command", "shift"]
+                ),
+            ])
+        }
+        #expect(diagnostics.messages.contains {
+            $0.contains("path=\(missingDirectoryURL.path)") && $0.contains("reason=")
+        })
     }
 }
 

--- a/Tests/WinkTests/ShortcutEditorStateTests.swift
+++ b/Tests/WinkTests/ShortcutEditorStateTests.swift
@@ -39,6 +39,81 @@ func savingShortcutChangesInvokesConfigurationChangeHandler() {
     #expect(callbackCount == 2)
 }
 
+@MainActor
+private func makeFailingSaveEditorContext(
+    existingShortcuts: [AppShortcut]
+) -> (editor: ShortcutEditorState, shortcutStore: ShortcutStore, callbackCount: CallbackCounter) {
+    let shortcutStore = ShortcutStore()
+    shortcutStore.replaceAll(with: existingShortcuts)
+
+    let manager = ShortcutManager(
+        shortcutStore: shortcutStore,
+        persistenceService: PersistenceService(storageURLProvider: { nil }),
+        appSwitcher: FakeAppSwitcher(),
+        captureCoordinator: ShortcutCaptureCoordinator(
+            standardProvider: FakeCaptureProvider(),
+            hyperProvider: FakeHyperCaptureProvider()
+        ),
+        permissionService: FakePermissionService(ax: true, input: false),
+        diagnosticClient: .init(log: { _ in })
+    )
+    let callbackCount = CallbackCounter()
+    let editor = ShortcutEditorState(
+        shortcutStore: shortcutStore,
+        shortcutManager: manager,
+        onShortcutConfigurationChange: {
+            callbackCount.value += 1
+        }
+    )
+    return (editor, shortcutStore, callbackCount)
+}
+
+@Test @MainActor
+func failedSaveRevertsEditorShortcutsAndSurfacesError() {
+    let safari = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "s",
+        modifierFlags: ["command", "shift"]
+    )
+    let context = makeFailingSaveEditorContext(existingShortcuts: [safari])
+
+    context.editor.removeShortcut(id: safari.id)
+
+    #expect(context.editor.shortcuts == [safari])
+    #expect(context.shortcutStore.shortcuts == [safari])
+    #expect(context.editor.saveErrorMessage?.contains("Failed to save shortcuts") == true)
+    #expect(context.callbackCount.value == 0)
+}
+
+@Test @MainActor
+func failedToggleLeavesEnabledStateUnchanged() {
+    let safari = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "s",
+        modifierFlags: ["command", "shift"]
+    )
+    let context = makeFailingSaveEditorContext(existingShortcuts: [safari])
+
+    context.editor.toggleShortcutEnabled(id: safari.id)
+
+    #expect(context.editor.shortcuts.first?.isEnabled == true)
+    #expect(context.shortcutStore.shortcuts.first?.isEnabled == true)
+    #expect(context.editor.saveErrorMessage != nil)
+}
+
+@Test @MainActor
+func successfulSaveClearsPreviousSaveError() {
+    let context = makeEditorContext()
+    defer { context.harness.cleanup() }
+
+    context.editor.saveErrorMessage = "stale error"
+    context.editor.setAllEnabled(true)
+
+    #expect(context.editor.saveErrorMessage == nil)
+}
+
 @Test @MainActor
 func editorSynchronizesWhenShortcutStoreChangesExternally() async {
     let context = makeEditorContext()
@@ -771,7 +846,7 @@ private func makeEditorContext(
     )
 
     if !existingShortcuts.isEmpty {
-        manager.save(shortcuts: existingShortcuts)
+        try! manager.save(shortcuts: existingShortcuts)
     }
 
     let callbackCount = CallbackCounter()

--- a/Tests/WinkTests/ShortcutManagerStatusTests.swift
+++ b/Tests/WinkTests/ShortcutManagerStatusTests.swift
@@ -263,13 +263,37 @@ private func alternateStandardShortcutKeyPress() -> KeyPress {
 }
 
 @Test @MainActor
+func saveFailureLeavesInMemoryStoreUnchanged() throws {
+    let shortcutStore = ShortcutStore()
+    let existing = [standardShortcut()]
+    shortcutStore.replaceAll(with: existing)
+
+    let manager = ShortcutManager(
+        shortcutStore: shortcutStore,
+        persistenceService: PersistenceService(storageURLProvider: { nil }),
+        appSwitcher: FakeAppSwitcher(),
+        captureCoordinator: ShortcutCaptureCoordinator(
+            standardProvider: FakeCaptureProvider(),
+            hyperProvider: FakeHyperCaptureProvider()
+        ),
+        permissionService: FakePermissionService(ax: true, input: false),
+        diagnosticClient: .init(log: { _ in })
+    )
+
+    #expect(throws: PersistenceService.SaveError.self) {
+        try manager.save(shortcuts: [standardShortcut(), alternateStandardShortcut()])
+    }
+    #expect(shortcutStore.shortcuts == existing)
+}
+
+@Test @MainActor
 func helperBuiltShortcutManagerCanPersistIntoInjectedHarness() throws {
     let shortcuts = [standardShortcut()]
     let context = makeShortcutManager(
         permissionService: FakePermissionService(ax: true, input: false)
     )
 
-    context.manager.save(shortcuts: shortcuts)
+    try context.manager.save(shortcuts: shortcuts)
 
     let persisted = try context.persistenceHarness.makePersistenceService().load()
     #expect(persisted == shortcuts)
@@ -289,7 +313,7 @@ func saveRegistersOnlyCurrentlyAvailableShortcuts() throws {
     )
     let shortcuts = [standardShortcut(), unavailableShortcut()]
 
-    context.manager.save(shortcuts: shortcuts)
+    try context.manager.save(shortcuts: shortcuts)
 
     let persisted = try context.persistenceHarness.makePersistenceService().load()
     #expect(persisted == shortcuts)
@@ -297,7 +321,7 @@ func saveRegistersOnlyCurrentlyAvailableShortcuts() throws {
 }
 
 @Test @MainActor
-func availabilityGainRebuildsRegisteredShortcutsWithoutAnotherSave() {
+func availabilityGainRebuildsRegisteredShortcutsWithoutAnotherSave() throws {
     let bundleLocatorState = MutableAppBundleLocatorState(entries: [:])
     let context = makeShortcutManager(
         permissionService: FakePermissionService(ax: true, input: false),
@@ -305,7 +329,7 @@ func availabilityGainRebuildsRegisteredShortcutsWithoutAnotherSave() {
             bundleLocatorState.entries[bundleIdentifier]
         }
     )
-    context.manager.save(shortcuts: [standardShortcut()])
+    try context.manager.save(shortcuts: [standardShortcut()])
     context.manager.start()
 
     #expect(context.standardProvider.registeredShortcuts.isEmpty)
@@ -317,7 +341,7 @@ func availabilityGainRebuildsRegisteredShortcutsWithoutAnotherSave() {
 }
 
 @Test @MainActor
-func availabilityGainForHyperShortcutRequestsInputMonitoringAndStartsEventTap() {
+func availabilityGainForHyperShortcutRequestsInputMonitoringAndStartsEventTap() throws {
     let bundleLocatorState = MutableAppBundleLocatorState(entries: [:])
     let permissionService = MutablePermissionService(ax: true, input: false)
     permissionService.grantInputMonitoringOnPrompt = true
@@ -328,7 +352,7 @@ func availabilityGainForHyperShortcutRequestsInputMonitoringAndStartsEventTap() 
         }
     )
 
-    context.manager.save(shortcuts: [hyperShortcut()])
+    try context.manager.save(shortcuts: [hyperShortcut()])
     context.manager.setHyperKeyEnabled(true)
     context.manager.start()
 
@@ -348,7 +372,7 @@ func availabilityGainForHyperShortcutRequestsInputMonitoringAndStartsEventTap() 
 }
 
 @Test @MainActor
-func availabilityLossRemovesRegisteredShortcutsWithoutAnotherSave() {
+func availabilityLossRemovesRegisteredShortcutsWithoutAnotherSave() throws {
     let bundleLocatorState = MutableAppBundleLocatorState(entries: [
         "com.apple.Safari": URL(fileURLWithPath: "/Applications/Safari.app")
     ])
@@ -358,7 +382,7 @@ func availabilityLossRemovesRegisteredShortcutsWithoutAnotherSave() {
             bundleLocatorState.entries[bundleIdentifier]
         }
     )
-    context.manager.save(shortcuts: [standardShortcut()])
+    try context.manager.save(shortcuts: [standardShortcut()])
     context.manager.start()
 
     #expect(context.standardProvider.registeredShortcuts == [standardShortcutKeyPress()])
@@ -370,7 +394,7 @@ func availabilityLossRemovesRegisteredShortcutsWithoutAnotherSave() {
 }
 
 @Test @MainActor
-func resumeRebuildsAvailableShortcutSetAfterAvailabilityChangesWhilePaused() {
+func resumeRebuildsAvailableShortcutSetAfterAvailabilityChangesWhilePaused() throws {
     let bundleLocatorState = MutableAppBundleLocatorState(entries: [
         "com.apple.Safari": URL(fileURLWithPath: "/Applications/Safari.app")
     ])
@@ -380,7 +404,7 @@ func resumeRebuildsAvailableShortcutSetAfterAvailabilityChangesWhilePaused() {
             bundleLocatorState.entries[bundleIdentifier]
         }
     )
-    context.manager.save(shortcuts: [standardShortcut(), alternateStandardShortcut()])
+    try context.manager.save(shortcuts: [standardShortcut(), alternateStandardShortcut()])
     context.manager.start()
 
     #expect(context.standardProvider.registeredShortcuts == [standardShortcutKeyPress()])
@@ -396,11 +420,11 @@ func resumeRebuildsAvailableShortcutSetAfterAvailabilityChangesWhilePaused() {
 }
 
 @Test @MainActor
-func captureStatusKeepsStandardShortcutsReadyWhenInputMonitoringIsMissing() {
+func captureStatusKeepsStandardShortcutsReadyWhenInputMonitoringIsMissing() throws {
     let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
         permissionService: FakePermissionService(ax: true, input: false)
     )
-    manager.save(shortcuts: [standardShortcut()])
+    try manager.save(shortcuts: [standardShortcut()])
     manager.start()
 
     let status = manager.shortcutCaptureStatus()
@@ -419,11 +443,11 @@ func captureStatusKeepsStandardShortcutsReadyWhenInputMonitoringIsMissing() {
 }
 
 @Test @MainActor
-func hyperShortcutsNeedInputMonitoringAndDoNotStartEventTapWithoutIt() {
+func hyperShortcutsNeedInputMonitoringAndDoNotStartEventTapWithoutIt() throws {
     let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
         permissionService: FakePermissionService(ax: true, input: false)
     )
-    manager.save(shortcuts: [hyperShortcut()])
+    try manager.save(shortcuts: [hyperShortcut()])
     manager.setHyperKeyEnabled(true)
     manager.start()
 
@@ -441,19 +465,19 @@ func hyperShortcutsNeedInputMonitoringAndDoNotStartEventTapWithoutIt() {
 }
 
 @Test @MainActor
-func hyperRoutingFollowsHyperKeyToggle() {
+func hyperRoutingFollowsHyperKeyToggle() throws {
     #expect(ShortcutCaptureRoute.route(for: hyperShortcut(), hyperKeyEnabled: false) == .standard)
     #expect(ShortcutCaptureRoute.route(for: hyperShortcut(), hyperKeyEnabled: true) == .hyper)
     #expect(ShortcutCaptureRoute.route(for: standardShortcut(), hyperKeyEnabled: true) == .standard)
 }
 
 @Test @MainActor
-func permissionGainStartsStandardCaptureWhenAccessibilityBecomesAvailable() {
+func permissionGainStartsStandardCaptureWhenAccessibilityBecomesAvailable() throws {
     let permissionService = MutablePermissionService(ax: true, input: false)
     let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
         permissionService: permissionService
     )
-    manager.save(shortcuts: [standardShortcut()])
+    try manager.save(shortcuts: [standardShortcut()])
 
     manager.checkPermissionChange()
 
@@ -463,12 +487,12 @@ func permissionGainStartsStandardCaptureWhenAccessibilityBecomesAvailable() {
 }
 
 @Test @MainActor
-func startDoesNotRequestInputMonitoringWhenCurrentConfigurationIsStandardOnly() {
+func startDoesNotRequestInputMonitoringWhenCurrentConfigurationIsStandardOnly() throws {
     let permissionService = MutablePermissionService(ax: true, input: false)
     let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
         permissionService: permissionService
     )
-    manager.save(shortcuts: [standardShortcut()])
+    try manager.save(shortcuts: [standardShortcut()])
 
     manager.start()
 
@@ -480,13 +504,13 @@ func startDoesNotRequestInputMonitoringWhenCurrentConfigurationIsStandardOnly() 
 }
 
 @Test @MainActor
-func startRequestsInputMonitoringWhenCurrentConfigurationNeedsHyperTransport() {
+func startRequestsInputMonitoringWhenCurrentConfigurationNeedsHyperTransport() throws {
     let permissionService = MutablePermissionService(ax: true, input: false)
     permissionService.grantInputMonitoringOnPrompt = true
     let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
         permissionService: permissionService
     )
-    manager.save(shortcuts: [hyperShortcut()])
+    try manager.save(shortcuts: [hyperShortcut()])
     manager.setHyperKeyEnabled(true)
 
     manager.start()
@@ -505,13 +529,13 @@ func startRequestsInputMonitoringWhenCurrentConfigurationNeedsHyperTransport() {
 }
 
 @Test @MainActor
-func startDefersInputMonitoringPromptUntilAccessibilityIsGrantedForHyperConfiguration() {
+func startDefersInputMonitoringPromptUntilAccessibilityIsGrantedForHyperConfiguration() throws {
     let permissionService = MutablePermissionService(ax: false, input: false)
     permissionService.grantInputMonitoringOnPrompt = true
     let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
         permissionService: permissionService
     )
-    manager.save(shortcuts: [hyperShortcut()])
+    try manager.save(shortcuts: [hyperShortcut()])
     manager.setHyperKeyEnabled(true)
 
     manager.start()
@@ -539,12 +563,12 @@ func startDefersInputMonitoringPromptUntilAccessibilityIsGrantedForHyperConfigur
 }
 
 @Test @MainActor
-func mixedConfigurationKeepsStandardShortcutsReadyWhileHyperWaitsForInputMonitoring() {
+func mixedConfigurationKeepsStandardShortcutsReadyWhileHyperWaitsForInputMonitoring() throws {
     let permissionService = MutablePermissionService(ax: true, input: false)
     let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
         permissionService: permissionService
     )
-    manager.save(shortcuts: [standardShortcut(), hyperShortcut()])
+    try manager.save(shortcuts: [standardShortcut(), hyperShortcut()])
     manager.setHyperKeyEnabled(true)
 
     manager.start()
@@ -562,13 +586,13 @@ func mixedConfigurationKeepsStandardShortcutsReadyWhileHyperWaitsForInputMonitor
 }
 
 @Test @MainActor
-func enablingHyperAtRuntimeRequestsInputMonitoringAndResyncsCapture() {
+func enablingHyperAtRuntimeRequestsInputMonitoringAndResyncsCapture() throws {
     let permissionService = MutablePermissionService(ax: true, input: false)
     permissionService.grantInputMonitoringOnPrompt = true
     let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
         permissionService: permissionService
     )
-    manager.save(shortcuts: [hyperShortcut()])
+    try manager.save(shortcuts: [hyperShortcut()])
     manager.start()
 
     #expect(permissionService.requestedPromptFlags == [true])
@@ -591,13 +615,13 @@ func enablingHyperAtRuntimeRequestsInputMonitoringAndResyncsCapture() {
 }
 
 @Test @MainActor
-func grantingAccessibilityAfterHyperBecomesRequiredRequestsInputMonitoring() {
+func grantingAccessibilityAfterHyperBecomesRequiredRequestsInputMonitoring() throws {
     let permissionService = MutablePermissionService(ax: false, input: false)
     permissionService.grantInputMonitoringOnPrompt = true
     let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
         permissionService: permissionService
     )
-    manager.save(shortcuts: [hyperShortcut()])
+    try manager.save(shortcuts: [hyperShortcut()])
 
     manager.start()
     manager.setHyperKeyEnabled(true)
@@ -624,7 +648,7 @@ func grantingAccessibilityAfterHyperBecomesRequiredRequestsInputMonitoring() {
 }
 
 @Test @MainActor
-func accessibilityLossStopsAllShortcutCapture() {
+func accessibilityLossStopsAllShortcutCapture() throws {
     let permissionService = MutablePermissionService(ax: false, input: false)
     let standardProvider = FakeCaptureProvider()
     let hyperProvider = FakeHyperCaptureProvider()
@@ -652,12 +676,12 @@ func accessibilityLossStopsAllShortcutCapture() {
 }
 
 @Test @MainActor
-func unchangedPermissionsDoNotResyncCaptureRepeatedly() {
+func unchangedPermissionsDoNotResyncCaptureRepeatedly() throws {
     let permissionService = MutablePermissionService(ax: true, input: false)
     let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
         permissionService: permissionService
     )
-    manager.save(shortcuts: [standardShortcut()])
+    try manager.save(shortcuts: [standardShortcut()])
     manager.start()
 
     let standardStartsAfterLaunch = standardProvider.startCallCount
@@ -670,13 +694,13 @@ func unchangedPermissionsDoNotResyncCaptureRepeatedly() {
 }
 
 @Test @MainActor
-func startSuppressesAutomaticPermissionPromptsWhenDisabledForThisLaunch() {
+func startSuppressesAutomaticPermissionPromptsWhenDisabledForThisLaunch() throws {
     let permissionService = MutablePermissionService(ax: true, input: false)
     let (manager, standardProvider, hyperProvider, _) = makeShortcutManager(
         permissionService: permissionService,
         automaticPermissionPromptingEnabled: false
     )
-    manager.save(shortcuts: [hyperShortcut()])
+    try manager.save(shortcuts: [hyperShortcut()])
     manager.setHyperKeyEnabled(true)
 
     manager.start()
@@ -693,14 +717,14 @@ func startSuppressesAutomaticPermissionPromptsWhenDisabledForThisLaunch() {
 }
 
 @Test @MainActor
-func explicitPermissionRequestStillPromptsWhenAutomaticPromptsAreDisabled() {
+func explicitPermissionRequestStillPromptsWhenAutomaticPromptsAreDisabled() throws {
     let permissionService = MutablePermissionService(ax: true, input: false)
     permissionService.grantInputMonitoringOnPrompt = true
     let (manager, _, hyperProvider, _) = makeShortcutManager(
         permissionService: permissionService,
         automaticPermissionPromptingEnabled: false
     )
-    manager.save(shortcuts: [hyperShortcut()])
+    try manager.save(shortcuts: [hyperShortcut()])
     manager.setHyperKeyEnabled(true)
 
     manager.start()
@@ -716,7 +740,7 @@ func explicitPermissionRequestStillPromptsWhenAutomaticPromptsAreDisabled() {
 }
 
 @Test @MainActor
-func matchedShortcutEmitsTraceOnlyForMatchedKeys() {
+func matchedShortcutEmitsTraceOnlyForMatchedKeys() throws {
     let diagnostics = DiagnosticCapture()
     let standardProvider = FakeCaptureProvider()
     let (manager, _, _, _) = makeShortcutManager(
@@ -724,7 +748,7 @@ func matchedShortcutEmitsTraceOnlyForMatchedKeys() {
         standardProvider: standardProvider,
         diagnosticSink: diagnostics.record
     )
-    manager.save(shortcuts: [standardShortcut()])
+    try manager.save(shortcuts: [standardShortcut()])
     manager.start()
 
     standardProvider.emit(KeyPress(
@@ -744,7 +768,7 @@ func matchedShortcutEmitsTraceOnlyForMatchedKeys() {
 }
 
 @Test @MainActor
-func missingStandardRegistrationEmitsCaptureBlockedDiagnostic() {
+func missingStandardRegistrationEmitsCaptureBlockedDiagnostic() throws {
     let diagnostics = DiagnosticCapture()
     let standardProvider = FakeCaptureProvider()
     standardProvider.startSucceeds = false
@@ -753,7 +777,7 @@ func missingStandardRegistrationEmitsCaptureBlockedDiagnostic() {
         standardProvider: standardProvider,
         diagnosticSink: diagnostics.record
     )
-    manager.save(shortcuts: [standardShortcut()])
+    try manager.save(shortcuts: [standardShortcut()])
 
     manager.start()
     let status = manager.shortcutCaptureStatus()
@@ -770,7 +794,7 @@ func missingStandardRegistrationEmitsCaptureBlockedDiagnostic() {
 }
 
 @Test @MainActor
-func partialStandardRegistrationMarksStandardCaptureNotReadyAndIncludesFailedBindingDetails() {
+func partialStandardRegistrationMarksStandardCaptureNotReadyAndIncludesFailedBindingDetails() throws {
     let diagnostics = DiagnosticCapture()
     let standardProvider = FakeCaptureProvider()
     let failedKeyPress = KeyPress(
@@ -783,7 +807,7 @@ func partialStandardRegistrationMarksStandardCaptureNotReadyAndIncludesFailedBin
         standardProvider: standardProvider,
         diagnosticSink: diagnostics.record
     )
-    manager.save(shortcuts: [standardShortcut(), alternateStandardShortcut()])
+    try manager.save(shortcuts: [standardShortcut(), alternateStandardShortcut()])
 
     manager.start()
 
@@ -803,13 +827,13 @@ func partialStandardRegistrationMarksStandardCaptureNotReadyAndIncludesFailedBin
 }
 
 @Test @MainActor
-func missingInputMonitoringEmitsHyperCaptureBlockedDiagnostic() {
+func missingInputMonitoringEmitsHyperCaptureBlockedDiagnostic() throws {
     let diagnostics = DiagnosticCapture()
     let (manager, _, _, _) = makeShortcutManager(
         permissionService: FakePermissionService(ax: true, input: false),
         diagnosticSink: diagnostics.record
     )
-    manager.save(shortcuts: [hyperShortcut()])
+    try manager.save(shortcuts: [hyperShortcut()])
     manager.setHyperKeyEnabled(true)
 
     manager.start()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -278,9 +278,9 @@ User opens settings
   -> ShortcutRecorderView stores RecordedShortcut in ShortcutEditorState
   -> ShortcutEditorState.addShortcut() builds AppShortcut
   -> ShortcutValidator checks conflicts against current shortcuts
-  -> ShortcutManager.save(updated shortcuts)
+  -> ShortcutManager.save(updated shortcuts) — throws on write failure
+  -> PersistenceService.save() (disk first; on failure the in-memory store is untouched and ShortcutEditorState reverts + surfaces saveErrorMessage)
   -> ShortcutStore.replaceAll()
-  -> PersistenceService.save()
   -> ShortcutCaptureCoordinator refreshes routed shortcuts / provider state
   -> onShortcutConfigurationChange triggers AppPreferences.refreshPermissions()
 ```


### PR DESCRIPTION
Fixes #262

## Summary
- `ShortcutManager.save` updated the in-memory `ShortcutStore` before writing to disk, and `PersistenceService.save` returned `Void` while swallowing write errors. A failed write (disk full, permissions, filesystem error) left the running app showing state that silently reverted to the old `shortcuts.json` on next launch — user changes lost with no feedback, violating the AGENTS.md rule that user-visible state is persisted only after the underlying operation succeeds.
- `PersistenceService.save` now throws `SaveError` (`storageUnavailable` / `writeFailed`), keeping the existing diagnostic logging.
- `ShortcutManager.save` persists to disk first and only updates `ShortcutStore` + the trigger index on success, rethrowing failures.
- `ShortcutEditorState` routes every mutation path (`addShortcut`, `removeShortcut`, `moveShortcut`, `toggleShortcutEnabled`, `setAllEnabled`, `applyPendingImport`) through a `persist` helper that reverts the editor list to the canonical store contents on failure and surfaces the error via the new `saveErrorMessage` property. A failed recipe import keeps the pending plan so the user can retry. `onShortcutConfigurationChange` and usage-tracking side effects no longer fire on failed saves.
- `ShortcutsTabView` renders `saveErrorMessage` in red alongside the existing `conflictMessage`.
- `docs/architecture.md` add-shortcut flow updated to the new disk-first ordering.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

New tests:
- `saveThrowsWhenStorageIsUnavailable` / `saveThrowsWhenDiskWriteFails` — `PersistenceService.save` failure contract incl. diagnostics
- `saveFailureLeavesInMemoryStoreUnchanged` — `ShortcutManager.save` with a failing persistence seam leaves the store untouched and throws
- `failedSaveRevertsEditorShortcutsAndSurfacesError` / `failedToggleLeavesEnabledStateUnchanged` / `successfulSaveClearsPreviousSaveError` — editor-level revert, error surfacing, no configuration-change callback on failure, and error clearing on the next successful save

`swift build` and `swift test` (375 tests, 37 suites) pass locally on macOS.

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- The repository's metadata gate classifies `ShortcutManager.swift` as runtime-sensitive, so this carries `macOS runtime validation pending`. Suggested runtime pass: trigger a save with a read-only Application Support directory and confirm the editor reverts and shows the save error instead of silently losing the change on relaunch.



---
**Runtime validation completed 2026-06-11** on the packaged /Applications/Wink.app (main 9ee4a50, v0.4.1) after TCC re-grant. Full evidence (commands, logs, screenshots): `build/validation/issues-261-262-263-2026-06-11/RESULTS.md` in the validation artifact directory.