### PR TITLE
fix: discard stale launch completion before it mutates the superseding session (Issue #263)

### DIFF
--- a/Sources/Wink/Services/AppSwitcher.swift
+++ b/Sources/Wink/Services/AppSwitcher.swift
@@ -755,7 +755,7 @@ final class AppSwitcher: AppSwitching {
         guard let runningApp = appLookupClient.runningApplications(shortcut.bundleIdentifier).first else {
             // App not running — launch it
             if let appURL = appLookupClient.applicationURL(shortcut.bundleIdentifier) {
-                _ = acceptPendingLaunch(
+                let launchState = acceptPendingLaunch(
                     for: shortcut,
                     startedAt: attemptStartedAt
                 )
@@ -775,6 +775,7 @@ final class AppSwitcher: AppSwitching {
                     elapsedMilliseconds: elapsedMilliseconds(since: attemptStartedAt)
                 )
                 let bundleId = shortcut.bundleIdentifier
+                let launchGeneration = launchState.generation
                 let configuration = NSWorkspace.OpenConfiguration()
                 fallbackActivationClient.openApplication(appURL, configuration) { [weak self] launchedApp, error in
                     if let error {
@@ -798,7 +799,8 @@ final class AppSwitcher: AppSwitching {
                     Task { @MainActor [weak self] in
                         self?.continueOwnedLaunchConfirmation(
                             for: shortcut,
-                            launchedProcessIdentifier: launchedProcessIdentifier
+                            launchedProcessIdentifier: launchedProcessIdentifier,
+                            expectedGeneration: launchGeneration
                         )
                     }
                 }
@@ -1162,9 +1164,25 @@ final class AppSwitcher: AppSwitching {
 
     private func continueOwnedLaunchConfirmation(
         for shortcut: AppShortcut,
-        launchedProcessIdentifier: pid_t?
+        launchedProcessIdentifier: pid_t?,
+        expectedGeneration: Int
     ) {
         guard let pendingState = pendingActivationState(for: shortcut.bundleIdentifier) else {
+            return
+        }
+
+        // A slow launch can be superseded by a second press that replaced the
+        // pending session (new generation). The superseding session's own
+        // completion manages its lifecycle; discard this stale callback before
+        // it can overwrite the new session's activationPath/pid.
+        guard pendingState.generation == expectedGeneration else {
+            logToggleTrace(
+                family: .confirmation,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "stale_completion_discarded",
+                reason: "launch_completion_superseded",
+                activationPath: .launch
+            )
             return
         }
 

--- a/Tests/WinkTests/AppSwitcherTests.swift
+++ b/Tests/WinkTests/AppSwitcherTests.swift
@@ -1390,6 +1390,97 @@ func clearActivationTrackingResetsCoordinatorSession() {
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
 }
 
+// MARK: - Stale launch completion
+
+/// A slow launch whose `openApplication` completion arrives after a second
+/// shortcut press has replaced the pending session (new generation) must not
+/// mutate the superseding session's `activationPath`/`pid` (Issue #263).
+@Test @MainActor
+func staleLaunchCompletionDoesNotMutateSupersedingSession() async {
+    let clock = MutableClock(time: 1000.0)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let runningApps = LockedValue<[NSRunningApplication]>([])
+    let launchCompletions = LockedValue<[@Sendable (NSRunningApplication?, Error?) -> Void]>([])
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        fallbackActivationClient: .init(openApplication: { _, _, completion in
+            launchCompletions.value.append(completion)
+        }),
+        appLookupClient: .init(
+            runningApplications: { _ in runningApps.value },
+            applicationURL: { _ in URL(fileURLWithPath: "/Applications/StaleLaunch.app") }
+        ),
+        confirmationClient: .init(now: { clock.time }, schedule: { _, _ in }),
+        sessionCoordinator: coordinator
+    )
+    let shortcut = AppShortcut(
+        appName: "StaleLaunch",
+        bundleIdentifier: "com.test.StaleLaunch",
+        keyEquivalent: "l",
+        modifierFlags: ["command"]
+    )
+
+    // First press: not running → launch path begins session S1.
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    let firstGeneration = coordinator.session(for: shortcut.bundleIdentifier)?.generation
+    #expect(launchCompletions.value.count == 1)
+
+    // Past the 400ms cooldown the app still is not running, so the second
+    // press takes the launch path again and replaces S1 with S2.
+    clock.time += 0.5
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    let supersedingSession = coordinator.session(for: shortcut.bundleIdentifier)
+    #expect(supersedingSession != nil)
+    #expect(supersedingSession?.generation != firstGeneration)
+    #expect(supersedingSession?.phase == .launching)
+    #expect(supersedingSession?.pid == nil)
+    #expect(launchCompletions.value.count == 2)
+
+    // The app becomes visible to lookup, then S1's completion arrives late.
+    // The completion hops through one Task { @MainActor }, so yielding the
+    // main actor drains it deterministically.
+    runningApps.value = [NSRunningApplication.current]
+    launchCompletions.value[0](nil, nil)
+    for _ in 0..<10 { await Task.yield() }
+
+    // The stale callback must be discarded outright: S2 keeps its launching
+    // phase, nil pid, and generation.
+    let after = coordinator.session(for: shortcut.bundleIdentifier)
+    #expect(after?.generation == supersedingSession?.generation)
+    #expect(after?.phase == .launching)
+    #expect(after?.pid == nil)
+
+    // The current session's own completion still attaches normally.
+    launchCompletions.value[1](nil, nil)
+    await waitUntilAppSwitcher("current completion attaches the launched process") {
+        coordinator.session(for: shortcut.bundleIdentifier)?.pid != nil
+    }
+    let attached = coordinator.session(for: shortcut.bundleIdentifier)
+    #expect(attached?.generation == supersedingSession?.generation)
+    // NSRunningApplication.current's processIdentifier is unstable in the
+    // test-runner process, so assert attachment rather than the exact pid.
+    #expect(attached?.pid != nil)
+    #expect(attached?.phase == .activating)
+}
+
+@MainActor
+private func waitUntilAppSwitcher(
+    _ description: String,
+    timeout: Duration = .seconds(2),
+    pollInterval: Duration = .milliseconds(20),
+    condition: @escaping @MainActor () -> Bool
+) async {
+    let clock = ContinuousClock()
+    let deadline = clock.now + timeout
+    while !condition() {
+        if clock.now >= deadline {
+            Issue.record("Timed out waiting for: \(description)")
+            return
+        }
+        try? await Task.sleep(for: pollInterval)
+    }
+}
+
 // MARK: - Cooldown and structured metrics
 
 @Test @MainActor


### PR DESCRIPTION
Fixes #263

## Summary
- `continueOwnedLaunchConfirmation` called `sessionCoordinator.continueActivation(...)` unconditionally before the generation-guarded promotion. When a slow launch was superseded by a second press past the 400ms cooldown (which replaces the pending session with a new generation), the first launch's late `openApplication` completion overwrote the *new* session's `activationPath` and `pid`. The promotion guard rejected the stale attempt afterwards, but the state corruption had already happened — polluting toggle diagnostics (wrong `activationPath` recorded for the superseding session) and, in multi-instance edge cases, carrying the wrong pid into subsequent toggle decisions.
- The launch path now captures the accepted session's generation (`acceptPendingLaunch` already returns it) and passes it through the `openApplication` completion. `continueOwnedLaunchConfirmation` verifies the pending session's generation still matches before touching any session state and discards stale callbacks with a `stale_completion_discarded` / `launch_completion_superseded` trace event. The superseding session's own completion manages its lifecycle.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

New test `staleLaunchCompletionDoesNotMutateSupersedingSession` drives the exact issue scenario with injected clock/lookup/launch clients: first press takes the launch path (S1), a second press past the cooldown replaces it (S2), then S1's completion arrives late. Red on the previous implementation (S2's phase flipped to `.activating` and its pid was overwritten); green with the fix (S2 stays `.launching`/nil-pid, and S2's own completion still attaches normally).

`swift build` and `swift test` (370 tests, 37 suites) pass locally on macOS.

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Runtime-sensitive (app activation / launch lifecycle). Suggested runtime pass per the issue: launch a heavy app, double-press the shortcut past the cooldown, and inspect toggle trace logs for `stale_completion_discarded`.
- `ToggleSessionCoordinator` semantics are unchanged; the guard lives entirely in the `AppSwitcher` launch-completion path, matching the AGENTS.md rule that session state machine inputs stay minimal.


---
**Runtime validation completed 2026-06-11** on the packaged /Applications/Wink.app (main 9ee4a50, v0.4.1) after TCC re-grant. Full evidence (commands, logs, screenshots): `build/validation/issues-261-262-263-2026-06-11/RESULTS.md` in the validation artifact directory.