### PR TITLE
fix: reset app picker highlight when the search text changes (Issue #264)

### DIFF
--- a/Sources/Wink/UI/AppPickerPopover.swift
+++ b/Sources/Wink/UI/AppPickerPopover.swift
@@ -1,14 +1,51 @@
 import AppKit
 import SwiftUI
 
+/// Keyboard-navigation highlight state for `AppPickerPopover`, kept as a pure
+/// value type so the highlight/Return semantics are unit-testable.
+struct AppPickerHighlightState {
+    private(set) var highlightedIndex: Int?
+
+    /// Highlight the first row (onAppear behavior).
+    mutating func reset() {
+        highlightedIndex = 0
+    }
+
+    /// A new query re-filters the list, so a retained index can point past the
+    /// new bounds (Return would no-op) or at the wrong row. Re-anchor on the
+    /// first visible result to match the type-ahead-then-Enter flow.
+    mutating func searchTextChanged() {
+        highlightedIndex = 0
+    }
+
+    /// Move the highlight by `delta`, clamped to `0..<count`. Returns the new
+    /// index so the caller can scroll to it, or nil when the list is empty.
+    mutating func move(_ delta: Int, count: Int) -> Int? {
+        guard count > 0 else { return nil }
+        let newIndex = max(0, min(count - 1, (highlightedIndex ?? 0) + delta))
+        highlightedIndex = newIndex
+        return newIndex
+    }
+
+    /// The highlighted entry, or nil when the index is unset or out of bounds.
+    func selection<Entry>(in entries: [Entry]) -> Entry? {
+        guard let highlightedIndex, entries.indices.contains(highlightedIndex) else {
+            return nil
+        }
+        return entries[highlightedIndex]
+    }
+}
+
 struct AppPickerPopover: View {
     @Bindable var appListProvider: AppListProvider
     let onSelect: (AppEntry) -> Void
     let onBrowse: () -> Void
 
     @State private var searchText = ""
-    @State private var highlightedIndex: Int?
+    @State private var highlight = AppPickerHighlightState()
     @Environment(\.dismiss) private var dismiss
+
+    private var highlightedIndex: Int? { highlight.highlightedIndex }
 
     /// SwiftUI reads these lists several times per body render; computed
     /// properties would re-filter on each access.
@@ -100,7 +137,10 @@ struct AppPickerPopover: View {
         .frame(width: 320, height: 400)
         .onAppear {
             appListProvider.refreshIfNeeded()
-            highlightedIndex = 0
+            highlight.reset()
+        }
+        .onChange(of: searchText) {
+            highlight.searchTextChanged()
         }
         .onKeyPress(.escape) { dismiss(); return .handled }
     }
@@ -146,17 +186,13 @@ struct AppPickerPopover: View {
     // MARK: - Navigation
 
     private func moveHighlight(_ delta: Int, proxy: ScrollViewProxy, in sections: Sections) {
-        let count = sections.flat.count
-        guard count > 0 else { return }
-        let current = highlightedIndex ?? 0
-        let newIndex = max(0, min(count - 1, current + delta))
-        highlightedIndex = newIndex
+        guard let newIndex = highlight.move(delta, count: sections.flat.count) else { return }
         proxy.scrollTo(newIndex, anchor: .center)
     }
 
     private func selectHighlighted(in sections: Sections) {
-        guard let index = highlightedIndex, index < sections.flat.count else { return }
-        select(sections.flat[index])
+        guard let entry = highlight.selection(in: sections.flat) else { return }
+        select(entry)
     }
 
     private func select(_ entry: AppEntry) {

--- a/Tests/WinkTests/AppPickerHighlightStateTests.swift
+++ b/Tests/WinkTests/AppPickerHighlightStateTests.swift
@@ -1,0 +1,64 @@
+import Testing
+@testable import Wink
+
+@Suite("AppPickerPopover highlight state")
+struct AppPickerHighlightStateTests {
+
+    @Test
+    func searchTextChangeResetsHighlightToFirstResult() {
+        var state = AppPickerHighlightState()
+        state.reset()
+        for _ in 0..<5 {
+            _ = state.move(1, count: 10)
+        }
+        #expect(state.highlightedIndex == 5)
+
+        // Typing a query shrinks the filtered list; the stale index must not
+        // survive or Return would silently no-op (Issue #264).
+        state.searchTextChanged()
+
+        #expect(state.highlightedIndex == 0)
+        let filtered = ["OnlyMatch"]
+        #expect(state.selection(in: filtered) == "OnlyMatch")
+    }
+
+    @Test
+    func selectionReturnsNilWhenIndexIsOutOfBounds() {
+        var state = AppPickerHighlightState()
+        state.reset()
+        _ = state.move(1, count: 6)
+        _ = state.move(1, count: 6)
+        #expect(state.highlightedIndex == 2)
+
+        #expect(state.selection(in: ["a", "b"]) == nil)
+        #expect(state.selection(in: [String]()) == nil)
+    }
+
+    @Test
+    func moveClampsToListBounds() {
+        var state = AppPickerHighlightState()
+        state.reset()
+
+        #expect(state.move(-1, count: 3) == 0)
+        #expect(state.move(1, count: 3) == 1)
+        #expect(state.move(1, count: 3) == 2)
+        #expect(state.move(1, count: 3) == 2)
+        #expect(state.move(-5, count: 3) == 0)
+    }
+
+    @Test
+    func moveOnEmptyListLeavesHighlightUntouched() {
+        var state = AppPickerHighlightState()
+        state.reset()
+
+        #expect(state.move(1, count: 0) == nil)
+        #expect(state.highlightedIndex == 0)
+    }
+
+    @Test
+    func selectionBeforeAppearReturnsNil() {
+        let state = AppPickerHighlightState()
+        #expect(state.highlightedIndex == nil)
+        #expect(state.selection(in: ["a"]) == nil)
+    }
+}


### PR DESCRIPTION
Fixes #264

## Summary
- `AppPickerPopover` initialized `highlightedIndex = 0` only in `onAppear` and never reset it when `searchText` changed. Typing a query shrinks the filtered list, so the retained index could exceed the new bounds: no row appeared highlighted (or the wrong one did) and Return silently no-oped on `selectHighlighted`'s bounds guard.
- The highlight/Return logic is extracted into `AppPickerHighlightState`, a pure value type (`reset` / `searchTextChanged` / `move` / `selection`), and the view re-anchors the highlight on the first visible result via `.onChange(of: searchText)` — matching the type-ahead-then-Enter flow suggested in the issue. `moveHighlight` and `selectHighlighted` now delegate to the same state type, so the rendering index comparison and the Return selection can no longer disagree.

## Testing
- [x] `swift test`
- [ ] Additional validation noted below when needed

New suite `AppPickerPopover highlight state` covers: stale index reset on query change with Return selecting the first filtered entry, out-of-bounds selection returning nil, move clamping at both ends, empty-list moves, and the pre-onAppear nil state.

`swift build` and `swift test` (374 tests, 38 suites) pass locally on macOS.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- UI-only change per the issue's classification; a packaged-app sanity pass of the picker keyboard flow is nice-to-have but not required.