### PR TITLE
fix: route InsightsViewModel async refresh through the cancellation contract (Issue #265)

### DIFF
--- a/Sources/Wink/UI/InsightsViewModel.swift
+++ b/Sources/Wink/UI/InsightsViewModel.swift
@@ -88,14 +88,12 @@ final class InsightsViewModel {
         }
     }
 
-    func refresh() async {
-        refreshGeneration &+= 1
-        await doRefresh(for: period, generation: refreshGeneration)
-    }
-
+    /// Selects `period` and awaits the resulting refresh. Drives the same
+    /// task-tracked, last-selection-wins mechanism as the period picker, so a
+    /// concurrent `scheduleRefresh()` can cancel and supersede this refresh.
     func refresh(for period: InsightsPeriod) async {
-        refreshGeneration &+= 1
-        await doRefresh(for: period, generation: refreshGeneration)
+        self.period = period  // didSet calls scheduleRefresh()
+        await refreshTask?.value
     }
 
     func waitForRefreshForTesting() async {

--- a/Tests/WinkTests/InsightsViewModelTests.swift
+++ b/Tests/WinkTests/InsightsViewModelTests.swift
@@ -151,6 +151,70 @@ func latestPeriodWinsWhenRefreshesOverlap() async {
 }
 
 @Test @MainActor
+func refreshForSyncsPeriodSelectionWithDisplayedData() async {
+    let shortcutId = UUID()
+    let store = ShortcutStore()
+    store.replaceAll(with: [
+        AppShortcut(
+            id: shortcutId,
+            appName: "Terminal",
+            bundleIdentifier: "com.apple.Terminal",
+            keyEquivalent: "t",
+            modifierFlags: ["command"]
+        )
+    ])
+
+    let viewModel = InsightsViewModel(
+        usageTracker: DelayedUsageTracker(shortcutId: shortcutId),
+        shortcutStore: store
+    )
+    #expect(viewModel.period == .week)
+
+    // refresh(for:) must keep the picker state and the displayed data in
+    // sync — month data with a week picker selection is a contract violation
+    // (Issue #265).
+    await viewModel.refresh(for: .month)
+
+    #expect(viewModel.period == .month)
+    #expect(viewModel.totalCount == 30)
+}
+
+@Test @MainActor
+func refreshForIsSupersededByLaterPeriodSelection() async {
+    let shortcutId = UUID()
+    let store = ShortcutStore()
+    store.replaceAll(with: [
+        AppShortcut(
+            id: shortcutId,
+            appName: "Terminal",
+            bundleIdentifier: "com.apple.Terminal",
+            keyEquivalent: "t",
+            modifierFlags: ["command"]
+        )
+    ])
+
+    let viewModel = InsightsViewModel(
+        usageTracker: DelayedUsageTracker(shortcutId: shortcutId),
+        shortcutStore: store
+    )
+
+    // Slow month refresh through the async variant, superseded by a fast
+    // day selection through the picker path. The last selection must win
+    // even when the variants are mixed.
+    let monthRefresh = Task { @MainActor in
+        await viewModel.refresh(for: .month)
+    }
+    await Task.yield()
+    viewModel.period = .day
+    await monthRefresh.value
+    await viewModel.waitForRefreshForTesting()
+
+    #expect(viewModel.period == .day)
+    #expect(viewModel.totalCount == 1)
+    #expect(viewModel.ranking.first?.count == 1)
+}
+
+@Test @MainActor
 func refreshUsesRelativeAnchorQueriesInsteadOfNonRelativeFallbacks() async {
     let shortcutId = UUID()
     let store = ShortcutStore()


### PR DESCRIPTION
Fixes #265

## Summary
- `refresh()` and `refresh(for:)` bumped `refreshGeneration` but bypassed the `refreshTask` cancel/replace mechanism that `scheduleRefresh()` enforces, sitting outside the "last selection wins" contract (single-in-flight invariant broken; only the write-time generation guard saved stale writes). `refresh(for:)` also never assigned `self.period`, so the period picker state and displayed data could diverge. Production only calls `scheduleRefresh()`, so this was a latent API hazard rather than a shipped bug.
- `refresh()` had no callers anywhere and is deleted outright (early-stage repo, no compat shims per AGENTS.md).
- `refresh(for:)` now sets `self.period` — whose `didSet` drives `scheduleRefresh()` — and awaits the tracked `refreshTask`. It therefore participates in cancellation/supersession and is observable via `waitForRefreshForTesting()`.

## Testing
- [x] `swift test`
- [ ] Additional validation noted below when needed

New tests:
- `refreshForSyncsPeriodSelectionWithDisplayedData` — `refresh(for: .month)` updates `period` and loads month data (red on the old implementation, which left the picker on `.week`)
- `refreshForIsSupersededByLaterPeriodSelection` — a slow `refresh(for: .month)` superseded by a fast picker-path `.day` selection ends with day data; guards the mixed-variant overlap contract that #248 previously tracked flakiness around

`swift build` and `swift test` (371 tests, 37 suites) pass locally on macOS.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Async view-model refresh ordering and cancellation ("last selection wins") is a named high-value test target in AGENTS.md; both new tests exercise it directly.