### PR TITLE
fix: bound the streakDays scan and ignore future-dated rows (Issue #266)

### DIFF
--- a/Sources/Wink/Services/UsageTracker.swift
+++ b/Sources/Wink/Services/UsageTracker.swift
@@ -7,6 +7,8 @@ private let logger = Logger(subsystem: DiagnosticLog.subsystem, category: "Usage
 actor UsageTracker: UsageTracking {
     private nonisolated(unsafe) let db: OpaquePointer?
     private static let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    /// Hard cap on the streak scan; the UI never needs unbounded streaks.
+    static let maxStreakDays = 366
 
     private let timeZoneProvider: @Sendable () -> TimeZone
     private var dateFormatter: DateFormatter
@@ -331,10 +333,16 @@ actor UsageTracker: UsageTracking {
     }
 
     func streakDays(relativeTo now: Date) async -> Int {
+        // Bounded to dates up to "today" so future-dated rows (clock skew,
+        // corrupt insert) cannot break the walk on the first iteration, and
+        // capped so the scan never materializes unbounded history. Served by
+        // an ordered walk of idx_daily_usage_date.
         let sql = """
             SELECT DISTINCT date
             FROM daily_usage
+            WHERE date <= ?
             ORDER BY date DESC
+            LIMIT \(Self.maxStreakDays)
             """
         guard let stmt = cachedStatement(&streakDaysStmt, sql: sql) else {
             return 0
@@ -344,6 +352,9 @@ actor UsageTracker: UsageTracking {
         let calendar = UsageWindowMath.calendar(timeZone: tz)
         var expectedDate = calendar.startOfDay(for: now)
         var streak = 0
+
+        let today = dateString(for: expectedDate, in: tz)
+        sqlite3_bind_text(stmt, 1, (today as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
 
         while sqlite3_step(stmt) == SQLITE_ROW {
             guard let datePtr = sqlite3_column_text(stmt, 0) else {
@@ -464,6 +475,8 @@ actor UsageTracker: UsageTracking {
             );
             CREATE INDEX IF NOT EXISTS idx_usage_hourly_date_hour
                 ON usage_hourly(date, hour);
+            CREATE INDEX IF NOT EXISTS idx_daily_usage_date
+                ON daily_usage(date);
             PRAGMA user_version = \(UsageDatabaseBootstrap.requiredSchemaVersion);
             """
 

--- a/Tests/WinkTests/UsageTrackerWindowTests.swift
+++ b/Tests/WinkTests/UsageTrackerWindowTests.swift
@@ -102,6 +102,49 @@ struct UsageTrackerWindowTests {
         let counts = await tracker.usageCounts(days: 1, relativeTo: moment)
         #expect(counts[id] == nil)
     }
+
+    @Test
+    func streakCountsConsecutiveDaysEndingToday() async {
+        let tracker = UsageTracker(databasePath: ":memory:")
+        let id = UUID()
+        let today = isoDate("2026-03-21")
+
+        await tracker.recordUsage(shortcutId: id, on: isoDate("2026-03-19"))
+        await tracker.recordUsage(shortcutId: id, on: isoDate("2026-03-20"))
+        await tracker.recordUsage(shortcutId: id, on: today)
+        // Gap on 2026-03-17 ends the streak; this day must not count.
+        await tracker.recordUsage(shortcutId: id, on: isoDate("2026-03-16"))
+
+        let streak = await tracker.streakDays(relativeTo: today)
+        #expect(streak == 3)
+    }
+
+    @Test
+    func streakIsZeroWithoutUsageToday() async {
+        let tracker = UsageTracker(databasePath: ":memory:")
+        let id = UUID()
+
+        await tracker.recordUsage(shortcutId: id, on: isoDate("2026-03-20"))
+
+        let streak = await tracker.streakDays(relativeTo: isoDate("2026-03-22"))
+        #expect(streak == 0)
+    }
+
+    @Test
+    func streakIgnoresFutureDatedRows() async {
+        let tracker = UsageTracker(databasePath: ":memory:")
+        let id = UUID()
+        let today = isoDate("2026-03-21")
+
+        await tracker.recordUsage(shortcutId: id, on: isoDate("2026-03-20"))
+        await tracker.recordUsage(shortcutId: id, on: today)
+        // Clock skew or a corrupt insert can leave a future-dated row; it must
+        // not zero out a genuine streak (Issue #266).
+        await tracker.recordUsage(shortcutId: id, on: isoDate("2026-03-25"))
+
+        let streak = await tracker.streakDays(relativeTo: today)
+        #expect(streak == 2)
+    }
 }
 
 private final class CountingTimeZoneBox: @unchecked Sendable {


### PR DESCRIPTION
Fixes #266

## Summary
- `streakDays(relativeTo:)` ran `SELECT DISTINCT date FROM daily_usage ORDER BY date DESC` with no `WHERE` clause and no supporting single-column index, so every Insights refresh materialized and sorted the entire usage history — degrading linearly with account age. Any future-dated row (clock skew, corrupt insert) also broke the streak walk on its first iteration, reporting 0 despite a genuine streak.
- The query now binds `WHERE date <= :today` (today's date string in the tracker's reporting time zone), which both bounds the scan and fixes the future-date false break, and caps the result with `LIMIT 366` (`UsageTracker.maxStreakDays`) since the UI never needs unbounded streaks.
- Added `idx_daily_usage_date ON daily_usage(date)` so the `DISTINCT date ... ORDER BY date DESC` walk is index-served. The index is created via `CREATE INDEX IF NOT EXISTS` in `createTables`, which runs on every database open — existing databases get the index in place without a schema-version bump (a bump would trigger `UsageDatabaseBootstrap`'s reset path and wipe usage data, which this change does not need).

## Testing
- [x] `swift test`
- [ ] Additional validation noted below when needed

New tests in `UsageTrackerWindowTests`:
- `streakIgnoresFutureDatedRows` — red before the fix (streak 0), green after (streak 2 with a future-dated row present)
- `streakCountsConsecutiveDaysEndingToday` / `streakIsZeroWithoutUsageToday` — baseline streak semantics (no streak tests existed before)

`swift build` and `swift test` (372 tests, 37 suites) pass locally on macOS.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Date-window boundary semantics are a named high-value test target in AGENTS.md; the new tests sit alongside the existing window-boundary suite.