### PR TITLE
fix: return nil from appSupportDirectory() when directory creation fails (Issue #267)

### DIFF
--- a/Sources/Wink/Services/StoragePaths.swift
+++ b/Sources/Wink/Services/StoragePaths.swift
@@ -1,17 +1,35 @@
 import Foundation
+import os.log
+
+private let logger = Logger(subsystem: DiagnosticLog.subsystem, category: "StoragePaths")
 
 enum StoragePaths {
     static let appDirectoryName = "Wink"
 
     static func appSupportDirectory() -> URL? {
-        let fm = FileManager.default
+        appSupportDirectory(fileManager: .default)
+    }
+
+    /// Returns nil when the directory cannot be created, so callers take
+    /// their designed unavailability fallbacks (e.g. UsageTracker's :memory:
+    /// database) instead of failing later at first write/open against a
+    /// valid-looking URL.
+    ///
+    /// Logs via os.log only — DiagnosticLog writes to a file under this very
+    /// directory, so routing the failure there would recurse.
+    static func appSupportDirectory(fileManager fm: FileManager) -> URL? {
         guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             return nil
         }
 
         let directory = appSupport.appendingPathComponent(appDirectoryName, isDirectory: true)
         if !fm.fileExists(atPath: directory.path) {
-            try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
+            do {
+                try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+            } catch {
+                logger.error("Failed to create Application Support directory at \(directory.path, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                return nil
+            }
         }
         return directory
     }

--- a/Tests/WinkTests/StoragePathsTests.swift
+++ b/Tests/WinkTests/StoragePathsTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import Wink
+
+@Suite("StoragePaths directory contract")
+struct StoragePathsTests {
+
+    @Test
+    func appSupportDirectoryReturnsNilWhenDirectoryCreationFails() {
+        // A valid-looking URL to a directory that does not exist bypasses the
+        // callers' nil fallbacks (e.g. UsageTracker's :memory: database) and
+        // fails later at first write/open instead (Issue #267).
+        let url = StoragePaths.appSupportDirectory(fileManager: CreateFailingFileManager())
+        #expect(url == nil)
+    }
+
+    @Test
+    func appSupportDirectoryReturnsExistingDirectoryWithoutCreating() {
+        let fileManager = ExistingDirectoryFileManager()
+        let url = StoragePaths.appSupportDirectory(fileManager: fileManager)
+        #expect(url?.lastPathComponent == StoragePaths.appDirectoryName)
+        #expect(fileManager.createDirectoryCallCount == 0)
+    }
+
+    @Test
+    func appSupportDirectoryReturnsNilWhenNoApplicationSupportExists() {
+        let url = StoragePaths.appSupportDirectory(fileManager: NoSearchPathFileManager())
+        #expect(url == nil)
+    }
+
+    @Test
+    func liveAppSupportDirectoryIsUsable() throws {
+        let url = try #require(StoragePaths.appSupportDirectory())
+        #expect(FileManager.default.fileExists(atPath: url.path))
+    }
+}
+
+private final class CreateFailingFileManager: FileManager, @unchecked Sendable {
+    override func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+        [URL(fileURLWithPath: "/nonexistent-root/Application Support")]
+    }
+
+    override func fileExists(atPath path: String) -> Bool {
+        false
+    }
+
+    override func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]? = nil
+    ) throws {
+        throw CocoaError(.fileWriteNoPermission)
+    }
+}
+
+private final class ExistingDirectoryFileManager: FileManager, @unchecked Sendable {
+    private(set) var createDirectoryCallCount = 0
+
+    override func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+        [URL(fileURLWithPath: "/tmp/storage-paths-tests/Application Support")]
+    }
+
+    override func fileExists(atPath path: String) -> Bool {
+        true
+    }
+
+    override func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]? = nil
+    ) throws {
+        createDirectoryCallCount += 1
+    }
+}
+
+private final class NoSearchPathFileManager: FileManager, @unchecked Sendable {
+    override func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+        []
+    }
+}


### PR DESCRIPTION
Fixes #267

## Summary
- `StoragePaths.appSupportDirectory()` swallowed the `createDirectory` error with `try?` and returned the URL regardless. Callers received a valid-looking URL to a directory that may not exist, so their explicit nil-fallback paths (e.g. `UsageTracker.defaultDatabasePath()`'s `:memory:` fallback, `PersistenceService`'s `storageUnavailable` path) never triggered — they failed later at first write/open, silently degraded and log-only.
- Creation failure now logs via os.log and returns nil, honoring the `-> URL?` unavailability contract. The failure is deliberately not routed through `DiagnosticLog`, whose log file lives under this very directory (it would recurse).
- An `appSupportDirectory(fileManager:)` injection seam makes the contract unit-testable; the public zero-argument entry point is unchanged.

## Testing
- [x] `swift test`
- [ ] Additional validation noted below when needed

New suite `StoragePaths directory contract`:
- `appSupportDirectoryReturnsNilWhenDirectoryCreationFails` — the core contract fix
- `appSupportDirectoryReturnsExistingDirectoryWithoutCreating` — existing directory short-circuits creation
- `appSupportDirectoryReturnsNilWhenNoApplicationSupportExists` — empty search path
- `liveAppSupportDirectoryIsUsable` — live-path smoke check

`swift build` and `swift test` (373 tests, 38 suites) pass locally on macOS.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Per AGENTS.md, user-visible state persisting only after the underlying operation succeeds — this completes the unavailability story that #262 (save failure surfacing) started.