### PR TITLE
ci: validate the live PR body instead of the event-payload snapshot (Issue #275)

### DIFF
--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -26,4 +26,11 @@ jobs:
       - name: Validate issue linkage and validation status
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: node .github/scripts/validate-pr-metadata.mjs
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        # The event payload snapshots the PR body at trigger time; fetch the
+        # live body so reruns validate what the PR actually says now.
+        run: |
+          PR_BODY="$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" -q '.body // ""')"
+          export PR_BODY
+          node .github/scripts/validate-pr-metadata.mjs


### PR DESCRIPTION
Fixes #275

## Summary
- `validate-pr-metadata.mjs` resolved the PR body from the `pull_request_target` event payload, which is a snapshot taken when the run was created. Rerunning a failed metadata run after fixing the PR body re-validated the stale text and failed again (observed on #268), and the concurrency group's `cancel-in-progress` let that rerun cancel the `edited`-event run that actually carried the fix.
- The workflow step now fetches the current body via `gh api` and passes it through the `PR_BODY` env var the validation script already honors (`process.env.PR_BODY ?? pullRequest.body`), so reruns always converge on the PR's actual state. No script changes needed.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

Workflow-only change; YAML validated locally. This PR's own `Validate PR metadata` check exercises the new step end-to-end (it runs the modified workflow from the base branch? — no: `pull_request_target` checks out the base SHA, so the new step takes effect for PRs opened **after** this merges; validated here by YAML parse + the script's existing `PR_BODY` override contract).

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Companion repository-settings fix already applied (recorded in #275): the `main merge governance` ruleset's required status contexts were renamed from the `Workflow / Job` UI format to the actual check-run names and pinned to the GitHub Actions app, eliminating the permanently-"Expected" required checks that forced bypass merges.