### PR TITLE
CHANGELOG, bump-version script, curated release notes (Issue #278)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Release script unit tests
         run: |
           brew install bats-core
-          bats scripts/verify-release-feed.bats
+          bats scripts/verify-release-feed.bats scripts/release-notes.bats scripts/bump-version.bats
 
       - name: Build (debug)
         run: swift build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,11 @@ jobs:
         run: |
           SPARKLE_PUBLIC_BASE_URL="$R2_PUBLIC_BASE_URL" bash scripts/verify-release-feed.sh --mode release
 
+      - name: Extract release notes
+        run: |
+          bash scripts/release-notes.sh "$VERSION" > "$RUNNER_TEMP/release-notes.md"
+          echo "RELEASE_NOTES_PATH=$RUNNER_TEMP/release-notes.md" >> "$GITHUB_ENV"
+
       - name: Import Developer ID certificate
         env:
           DEVELOPER_ID_APP_CERT_BASE64: ${{ secrets.DEVELOPER_ID_APP_CERT_BASE64 }}
@@ -285,6 +290,7 @@ jobs:
           SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
         run: |
           export SPARKLE_PUBLIC_BASE_URL="$R2_PUBLIC_BASE_URL"
+          export SPARKLE_FULL_RELEASE_NOTES_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
           bash scripts/generate-appcast.sh
 
       - name: Verify appcast
@@ -347,10 +353,11 @@ jobs:
         run: |
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             gh release upload "$RELEASE_TAG" "$DMG_PATH" --clobber
+            gh release edit "$RELEASE_TAG" --notes-file "$RELEASE_NOTES_PATH"
           else
             gh release create "$RELEASE_TAG" "$DMG_PATH" \
               --title "$RELEASE_TAG" \
-              --generate-notes
+              --notes-file "$RELEASE_NOTES_PATH"
           fi
 
       - name: Publish live Sparkle appcast to R2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+Newest first. One `## X.Y.Z` section per release, written by hand **before** running
+`scripts/bump-version.sh X.Y.Z`. `scripts/release-notes.sh X.Y.Z` extracts a section as the
+GitHub Release body; the release workflow fails if the tagged version has no section here.
+
+## 0.4.1
+
+- Baseline entry: current version at the time the changelog was introduced. No `v*` release
+  has been published yet; the first published release gets a full section.

--- a/docs/signing-and-release.md
+++ b/docs/signing-and-release.md
@@ -152,17 +152,18 @@ If any required Apple, Sparkle, or R2 secret is missing, the workflow exits succ
 
 0. Check whether all required release secrets are present
 1. Run `scripts/verify-release-feed.sh --mode release`: restore the live `appcast.xml` to `build/live-appcast.xml` and fail unless `CFBundleVersion` is strictly greater than the live feed's maximum `sparkle:version`
-2. Import the `Developer ID Application` certificate into a temporary keychain
-3. Write the `notarytool` API key to a temporary file
-4. Run `swift test`
-5. Run `scripts/package-app.sh` in hardened runtime signing mode, injecting `SPARKLE_FEED_URL` and `SPARKLE_PUBLIC_ED_KEY`
-6. Verify `build/Wink.app`, archive it as a zip for `notarytool`, notarize that archive, and staple `build/Wink.app`
-7. Run `scripts/package-update-zip.sh`
-8. Run `scripts/generate-appcast.sh` with the private EdDSA key, merging the restored live feed so existing entries are preserved
-9. Run `scripts/package-dmg.sh`, then notarize and staple `build/Wink-<version>.dmg`
-10. Upload the versioned DMG and Sparkle ZIP to R2
-11. Create or update the GitHub Release and upload `Wink-<version>.dmg`
-12. Upload `appcast.xml` last so the live Sparkle feed only flips after the earlier release steps succeed
+2. Run `scripts/release-notes.sh <version>`: fail unless `CHANGELOG.md` has a non-empty `## <version>` section, and stage it as the GitHub Release body
+3. Import the `Developer ID Application` certificate into a temporary keychain
+4. Write the `notarytool` API key to a temporary file
+5. Run `swift test`
+6. Run `scripts/package-app.sh` in hardened runtime signing mode, injecting `SPARKLE_FEED_URL` and `SPARKLE_PUBLIC_ED_KEY`
+7. Verify `build/Wink.app`, archive it as a zip for `notarytool`, notarize that archive, and staple `build/Wink.app`
+8. Run `scripts/package-update-zip.sh`
+9. Run `scripts/generate-appcast.sh` with the private EdDSA key, merging the restored live feed so existing entries are preserved; `SPARKLE_FULL_RELEASE_NOTES_URL` points at the tag's GitHub Release page
+10. Run `scripts/package-dmg.sh`, then notarize and staple `build/Wink-<version>.dmg`
+11. Upload the versioned DMG and Sparkle ZIP to R2
+12. Create or update the GitHub Release with the CHANGELOG-derived notes and upload `Wink-<version>.dmg`
+13. Upload `appcast.xml` last so the live Sparkle feed only flips after the earlier release steps succeed
 
 ### Feed safety gate
 
@@ -195,7 +196,7 @@ The internal package path is for trusted testers only. It does not:
 
 ## Manual Release Checklist
 
-1. Update `CFBundleShortVersionString` and `CFBundleVersion` in [Info.plist](../Sources/Wink/Resources/Info.plist)
+1. Write the `## X.Y.Z` section in [CHANGELOG.md](../CHANGELOG.md), then run `./scripts/bump-version.sh X.Y.Z` (validates semver, requires the CHANGELOG section, and increments `CFBundleVersion`)
 2. Run `swift test`
 3. Run `bash scripts/package-app.sh`
 4. Run `bash scripts/package-update-zip.sh`

--- a/scripts/bump-version.bats
+++ b/scripts/bump-version.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/bump-version.sh (spec §4).
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/bump-version.sh"
+  PLIST="$BATS_TEST_TMPDIR/Info.plist"
+  cat >"$PLIST" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleShortVersionString</key><string>0.4.1</string>
+  <key>CFBundleVersion</key><string>5</string>
+</dict></plist>
+XML
+  CL="$BATS_TEST_TMPDIR/CHANGELOG.md"
+  printf '# Changelog\n\n## 0.5.0\n\n- Something new\n' >"$CL"
+}
+
+run_bump() {
+  run env INFO_PLIST="$PLIST" CHANGELOG="$CL" bash "$SCRIPT" "$@"
+}
+
+@test "successful bump writes version and increments build" {
+  run_bump 0.5.0
+  [ "$status" -eq 0 ]
+  [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$PLIST")" = "0.5.0" ]
+  [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$PLIST")" = "6" ]
+}
+
+@test "rejects non-semver argument" {
+  run_bump 1.2
+  [ "$status" -ne 0 ]
+  run_bump v1.2.3
+  [ "$status" -ne 0 ]
+}
+
+@test "rejects bumping to the current version" {
+  run_bump 0.4.1
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already"* ]]
+}
+
+@test "rejects bump without a CHANGELOG section" {
+  run_bump 0.6.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"CHANGELOG"* ]]
+}
+
+@test "rejects non-integer CFBundleVersion without modifying the plist" {
+  /usr/libexec/PlistBuddy -c 'Set :CFBundleVersion 5.1' "$PLIST"
+  run_bump 0.5.0
+  [ "$status" -ne 0 ]
+  [ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$PLIST")" = "0.4.1" ]
+}

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Release step one: sync version numbers (spec docs/superpowers/specs/2026-06-11-release-pipeline-hardening-design.md §4).
+#   ./scripts/bump-version.sh X.Y.Z
+# Writes Info.plist: CFBundleShortVersionString = X.Y.Z and CFBundleVersion += 1 (monotonic
+# integer — Sparkle compares it as sparkle:version). Precondition: CHANGELOG.md already has a
+# "## X.Y.Z" section; notes are creative content written by a human first, this script only gates.
+set -euo pipefail
+
+VER="${1:?usage: bump-version.sh X.Y.Z}"
+if [[ ! "$VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: version must be three-part semver (X.Y.Z), got '$VER'" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+INFO_PLIST="${INFO_PLIST:-$PROJECT_DIR/Sources/Wink/Resources/Info.plist}"
+CHANGELOG="${CHANGELOG:-$PROJECT_DIR/CHANGELOG.md}"
+
+CURRENT="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST")"
+if [ "$VER" = "$CURRENT" ]; then
+    echo "Error: version is already $CURRENT — nothing to bump" >&2
+    exit 1
+fi
+if ! awk -v ver="$VER" '$1 == "##" && $2 == ver { found = 1 } END { exit !found }' "$CHANGELOG"; then
+    echo "Error: CHANGELOG.md has no '## $VER' section — write the release notes first" >&2
+    exit 1
+fi
+BUILD="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST")"
+if [[ ! "$BUILD" =~ ^[0-9]+$ ]]; then
+    echo "Error: CFBundleVersion '$BUILD' is not a non-negative integer — fix $INFO_PLIST first" >&2
+    exit 1
+fi
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VER" "$INFO_PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $((BUILD + 1))" "$INFO_PLIST"
+echo "Bumped $CURRENT -> $VER (CFBundleVersion $BUILD -> $((BUILD + 1)))"
+echo "Next: swift test -> commit -> git tag v$VER -> git push origin main --tags"

--- a/scripts/release-notes.bats
+++ b/scripts/release-notes.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# Unit tests for scripts/release-notes.sh (spec §5).
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/release-notes.sh"
+  CL="$BATS_TEST_TMPDIR/CHANGELOG.md"
+  cat >"$CL" <<'MD'
+# Changelog
+
+## 0.5.0
+
+- New thing
+- Fixed thing
+
+## 0.4.1
+
+- Older note
+MD
+}
+
+@test "prints exactly the requested section body" {
+  run env CHANGELOG="$CL" bash "$SCRIPT" 0.5.0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"- New thing"* ]]
+  [[ "$output" == *"- Fixed thing"* ]]
+  [[ "$output" != *"Older note"* ]]
+}
+
+@test "last section runs to EOF" {
+  run env CHANGELOG="$CL" bash "$SCRIPT" 0.4.1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Older note"* ]]
+  [[ "$output" != *"New thing"* ]]
+}
+
+@test "heading match is exact, not a regex-dot match" {
+  cat >"$CL" <<'MD'
+## 0x5x0
+
+- Wrong section
+MD
+  run env CHANGELOG="$CL" bash "$SCRIPT" 0.5.0
+  [ "$status" -ne 0 ]
+}
+
+@test "fails when the section is missing" {
+  run env CHANGELOG="$CL" bash "$SCRIPT" 9.9.9
+  [ "$status" -ne 0 ]
+}
+
+@test "fails when the section is empty" {
+  cat >"$CL" <<'MD'
+## 0.6.0
+
+## 0.5.0
+
+- Real content
+MD
+  run env CHANGELOG="$CL" bash "$SCRIPT" 0.6.0
+  [ "$status" -ne 0 ]
+}
+
+@test "fails when CHANGELOG.md does not exist" {
+  run env CHANGELOG="$BATS_TEST_TMPDIR/missing.md" bash "$SCRIPT" 0.5.0
+  [ "$status" -ne 0 ]
+}

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Print the CHANGELOG.md body for one version (spec docs/superpowers/specs/2026-06-11-release-pipeline-hardening-design.md §5).
+# release.yml calls this both as an early gate and to produce the GitHub Release body (--notes-file).
+#   ./scripts/release-notes.sh X.Y.Z
+set -euo pipefail
+
+VER="${1:?usage: release-notes.sh X.Y.Z}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHANGELOG="${CHANGELOG:-$PROJECT_DIR/CHANGELOG.md}"
+
+if [ ! -f "$CHANGELOG" ]; then
+    echo "Error: $CHANGELOG not found" >&2
+    exit 1
+fi
+
+# Exact heading match ("## X.Y.Z"), body runs until the next "## " heading or EOF.
+NOTES="$(awk -v ver="$VER" '
+    $1 == "##" && $2 == ver { found = 1; next }
+    $1 == "##" { if (found) exit }
+    found { print }
+' "$CHANGELOG")"
+
+if ! printf '%s' "$NOTES" | grep -q '[^[:space:]]'; then
+    echo "Error: CHANGELOG.md has no non-empty '## $VER' section — write the release notes first" >&2
+    exit 1
+fi
+printf '%s\n' "$NOTES"


### PR DESCRIPTION
Closes #278

## Summary
- **`CHANGELOG.md`** — hand-written, newest first, one `## X.Y.Z` section per release; baseline `0.4.1` entry included.
- **`scripts/bump-version.sh X.Y.Z`** — the new way to bump versions: validates three-part semver, rejects same-version bumps, requires the matching CHANGELOG section to exist first, then writes `CFBundleShortVersionString` and increments `CFBundleVersion` via PlistBuddy. 5 bats tests.
- **`scripts/release-notes.sh X.Y.Z`** — extracts a CHANGELOG section body (exact heading match, runs to next `## ` or EOF), hard-fails on missing/empty sections. 6 bats tests.
- **`release.yml`** — new "Extract release notes" gate right after the feed gate (fails fast before signing if the tagged version has no CHANGELOG section); `gh release create` switches from `--generate-notes` to `--notes-file`; the re-run path now also refreshes the body via `gh release edit --notes-file`; `SPARKLE_FULL_RELEASE_NOTES_URL` points Sparkle's "full release notes" link at the per-tag GitHub Release page.
- **`ci.yml`** — bats step extended to cover the two new scripts.
- **`docs/signing-and-release.md`** — manual checklist step 1 is now "write CHANGELOG section → run bump-version.sh"; release job flow updated.

Implements Issue #278 per `docs/superpowers/specs/2026-06-11-release-pipeline-hardening-design.md` §4–5, §7.

## Testing
- [x] `bats scripts/verify-release-feed.bats scripts/release-notes.bats scripts/bump-version.bats` (24 tests pass)
- [x] `bash scripts/release-notes.sh 0.4.1` against the real CHANGELOG extracts the baseline section (the release-time notes gate passes for the current version)
- [x] `swift test` unaffected (scripts/workflows/docs only); runs in CI

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR). (Not touched — release tooling only; `docs/signing-and-release.md` updated.)
- [x] No new references to `docs/archive/` as a current source of truth.