### PR TITLE
Release dry-run rehearsal mode and SwiftPM caching (Issue #279)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,16 @@ jobs:
       - name: Swift version
         run: swift --version
 
+      - name: Capture toolchain cache key
+        run: echo "TOOLCHAIN_KEY=$(swift --version 2>/dev/null | head -1 | shasum -a 256 | cut -c1-12)" >> "$GITHUB_ENV"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .build
+          key: spm-${{ runner.os }}-${{ env.TOOLCHAIN_KEY }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: spm-${{ runner.os }}-${{ env.TOOLCHAIN_KEY }}-
+
       - name: Release script unit tests
         run: |
           brew install bats-core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,15 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing release tag to publish manually (for example v0.2.0)
-        required: true
+        description: Existing v* tag to operate on; leave empty to rehearse the dispatched ref (forces dry run)
+        required: false
+        default: ""
         type: string
+      dry_run:
+        description: Build and validate everything, publish nothing
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -34,7 +40,7 @@ jobs:
         env:
           MANUAL_RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ -n "${MANUAL_RELEASE_TAG}" ]; then
             RELEASE_REF="${MANUAL_RELEASE_TAG}"
           else
             RELEASE_REF="${GITHUB_REF_NAME}"
@@ -141,7 +147,7 @@ jobs:
           echo "NOTARY_KEY_PATH=$RUNNER_TEMP/AuthKey.p8" >> "$GITHUB_ENV"
 
       - name: Checkout manual release tag
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag != '' }}
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
@@ -157,36 +163,59 @@ jobs:
           git rev-parse "refs/tags/$RELEASE_TAG" >/dev/null
           git checkout --force "refs/tags/$RELEASE_TAG"
 
+      - name: Capture toolchain cache key
+        run: echo "TOOLCHAIN_KEY=$(swift --version 2>/dev/null | head -1 | shasum -a 256 | cut -c1-12)" >> "$GITHUB_ENV"
+
+      - name: Cache SwiftPM build
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .build
+          key: spm-${{ runner.os }}-${{ env.TOOLCHAIN_KEY }}-${{ hashFiles('Package.resolved') }}
+          restore-keys: spm-${{ runner.os }}-${{ env.TOOLCHAIN_KEY }}-
+
       - name: Resolve release metadata
         env:
           MANUAL_RELEASE_TAG: ${{ inputs.release_tag }}
+          DRY_RUN_INPUT: ${{ inputs.dry_run }}
           R2_PUBLIC_BASE_URL_RAW: ${{ secrets.R2_PUBLIC_BASE_URL }}
         run: |
           VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' Sources/Wink/Resources/Info.plist)"
 
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            RELEASE_TAG="${MANUAL_RELEASE_TAG}"
+            if [ -z "${MANUAL_RELEASE_TAG}" ]; then
+              # Ref rehearsal: no tag to operate on, publishing is impossible by construction.
+              RELEASE_TAG=""
+              DRY_RUN=true
+            else
+              RELEASE_TAG="${MANUAL_RELEASE_TAG}"
+              DRY_RUN="${DRY_RUN_INPUT:-true}"
+            fi
           else
             RELEASE_TAG="${GITHUB_REF_NAME}"
+            DRY_RUN=false
           fi
 
-          case "$RELEASE_TAG" in
-            v*) ;;
-            *)
-              echo "Error: release workflow requires a v* tag, got '$RELEASE_TAG'" >&2
-              exit 1
-              ;;
-          esac
+          if [ -n "$RELEASE_TAG" ]; then
+            case "$RELEASE_TAG" in
+              v*) ;;
+              *)
+                echo "Error: release workflow requires a v* tag, got '$RELEASE_TAG'" >&2
+                exit 1
+                ;;
+            esac
 
-          if [ "v${VERSION}" != "$RELEASE_TAG" ]; then
-            echo "Error: tag '$RELEASE_TAG' does not match Info.plist version 'v${VERSION}'" >&2
-            exit 1
+            if [ "v${VERSION}" != "$RELEASE_TAG" ]; then
+              echo "Error: tag '$RELEASE_TAG' does not match Info.plist version 'v${VERSION}'" >&2
+              exit 1
+            fi
           fi
 
           R2_PUBLIC_BASE_URL="$(printf '%s' "$R2_PUBLIC_BASE_URL_RAW" | sed 's#/*$#/#')"
 
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "RELEASE_TAG=$RELEASE_TAG" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG_OR_PLANNED=${RELEASE_TAG:-v$VERSION}" >> "$GITHUB_ENV"
+          echo "DRY_RUN=$DRY_RUN" >> "$GITHUB_ENV"
           echo "DMG_PATH=build/Wink-${VERSION}.dmg" >> "$GITHUB_ENV"
           echo "ZIP_PATH=build/Wink-${VERSION}.zip" >> "$GITHUB_ENV"
           echo "APPCAST_PATH=build/appcast.xml" >> "$GITHUB_ENV"
@@ -198,7 +227,9 @@ jobs:
         env:
           WINK_ALLOW_FIRST_RELEASE: ${{ vars.WINK_ALLOW_FIRST_RELEASE }}
         run: |
-          SPARKLE_PUBLIC_BASE_URL="$R2_PUBLIC_BASE_URL" bash scripts/verify-release-feed.sh --mode release
+          MODE=release
+          if [ "$DRY_RUN" = "true" ]; then MODE=rehearse; fi
+          SPARKLE_PUBLIC_BASE_URL="$R2_PUBLIC_BASE_URL" bash scripts/verify-release-feed.sh --mode "$MODE"
 
       - name: Extract release notes
         run: |
@@ -290,7 +321,7 @@ jobs:
           SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
         run: |
           export SPARKLE_PUBLIC_BASE_URL="$R2_PUBLIC_BASE_URL"
-          export SPARKLE_FULL_RELEASE_NOTES_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG}"
+          export SPARKLE_FULL_RELEASE_NOTES_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG_OR_PLANNED}"
           bash scripts/generate-appcast.sh
 
       - name: Verify appcast
@@ -331,13 +362,25 @@ jobs:
           xcrun stapler validate "$DMG_PATH"
           spctl --assess --type open --context context:primary-signature --verbose "$DMG_PATH"
 
+      - name: Upload dry-run artifacts
+        if: ${{ env.DRY_RUN == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-dry-run-${{ env.VERSION }}
+          path: |
+            build/*.dmg
+            build/*.zip
+            build/appcast.xml
+
       - name: Install boto3 in a virtual environment
+        if: ${{ env.DRY_RUN != 'true' }}
         run: |
           python3 -m venv "$RUNNER_TEMP/r2-upload-venv"
           "$RUNNER_TEMP/r2-upload-venv/bin/pip" install boto3
           echo "R2_UPLOAD_PYTHON=$RUNNER_TEMP/r2-upload-venv/bin/python" >> "$GITHUB_ENV"
 
       - name: Upload DMG and Sparkle ZIP to R2
+        if: ${{ env.DRY_RUN != 'true' }}
         env:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -348,6 +391,7 @@ jobs:
           "$R2_UPLOAD_PYTHON" scripts/upload-r2-object.py "$DMG_PATH" application/x-apple-diskimage
 
       - name: Publish GitHub Release
+        if: ${{ env.DRY_RUN != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -361,6 +405,7 @@ jobs:
           fi
 
       - name: Publish live Sparkle appcast to R2
+        if: ${{ env.DRY_RUN != 'true' }}
         env:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/docs/signing-and-release.md
+++ b/docs/signing-and-release.md
@@ -141,10 +141,12 @@ The release workflow lives at [release.yml](../.github/workflows/release.yml).
 
 ### Trigger
 
-- push a tag named `v<CFBundleShortVersionString>`
-- or run the workflow manually from the default branch and provide an existing matching `release_tag` input
+- push a tag named `v<CFBundleShortVersionString>` (real release)
+- or run the workflow manually: provide an existing matching `release_tag` to operate on that tag, or leave it empty to rehearse the dispatched ref (forces a dry run)
 
-The workflow fails if the Git tag does not match `CFBundleShortVersionString`.
+The `dry_run` input (default `true` for manual runs) builds and validates everything but publishes nothing. Tag pushes always publish.
+
+The workflow fails if the Git tag does not match `CFBundleShortVersionString` (skipped when rehearsing a ref without a tag).
 
 If any required Apple, Sparkle, or R2 secret is missing, the workflow exits successfully with a summary that lists the missing secrets and publishes nothing.
 
@@ -174,6 +176,15 @@ Every release run starts by fetching the live `appcast.xml` from `R2_PUBLIC_BASE
 - A fetch error (5xx, network failure) always fails the run; it is never treated as a first release.
 - If the live feed legitimately does not exist yet (HTTP 404), set the repository variable `WINK_ALLOW_FIRST_RELEASE` to `1` for the first run and delete the variable afterwards.
 - All release runs share one concurrency group and execute serially. If three or more runs queue up, GitHub cancels the intermediate pending run — re-run it; the gate makes any re-run order safe.
+
+### Dry run
+
+A manual `Release` run with `dry_run` enabled (the default) rehearses the full chain — feed gate (report-only `--mode rehearse`), notes gate, tests, signing, notarization, stapling, DMG/ZIP packaging, appcast generation, and artifact validation — then uploads everything as the `release-dry-run-<version>` workflow artifact instead of publishing. R2 and GitHub Releases are never touched.
+
+- Leave `release_tag` empty to rehearse the dispatched ref (dry run is forced).
+- Set `release_tag` to an existing tag with `dry_run` enabled to rehearse that tag.
+- Dry runs require the same secrets as real releases; rehearsing the signed chain is the point.
+- While no live feed exists yet, the rehearse-mode gate still fails on 404 unless the `WINK_ALLOW_FIRST_RELEASE` repository variable is set (the same opt-in a first real release needs).
 
 When secrets are present, the workflow is fail-closed for the live Sparkle feed: if signing, notarization, appcast signing, GitHub Release publication, or the final appcast upload fails, Sparkle clients do not see the new update because `appcast.xml` is published last.
 


### PR DESCRIPTION
Closes #279

## Summary
- **Dry-run rehearsal mode** in `release.yml` (`workflow_dispatch`):
  - `release_tag` is now optional — empty means "rehearse the dispatched ref", which forces a dry run; the tag-checkout step and tag↔version equality check are skipped only in that mode
  - new `dry_run` boolean input (default `true`): runs the full chain — feed gate in report-only `--mode rehearse`, notes gate, `swift test`, signing, notarization, stapling, DMG/ZIP, appcast, validation — then uploads `release-dry-run-<version>` workflow artifacts and skips the four publish-side steps (boto3 venv, R2 uploads, GitHub Release, appcast flip)
  - tag pushes are unchanged: always a real release
  - `release-readiness`'s `release_ref` output falls back to `github.ref_name` when the tag input is empty
  - the Sparkle full-release-notes URL uses `RELEASE_TAG_OR_PLANNED` (`v<version>` when rehearsing without a tag)
- **SwiftPM caching** in `release.yml` and `ci.yml`: `actions/cache` (SHA-pinned to v5.0.5, verified against the upstream tag), `path: .build`, key `spm-<os>-<toolchain-hash>-<Package.resolved hash>` so a runner-image Xcode bump never restores stale build products; in `release.yml` the cache step sits after the manual-tag checkout so the key hashes the right ref
- **`docs/signing-and-release.md`** — trigger semantics and a new "Dry run" section (including the `WINK_ALLOW_FIRST_RELEASE` interaction while no live feed exists yet)

Implements Issue #279 per `docs/superpowers/specs/2026-06-11-release-pipeline-hardening-design.md` §6, §8. After merge, the acceptance check is a manual `Release` dispatch with defaults (empty tag → ref rehearsal).

## Testing
- [x] `actionlint` on both workflows (only pre-existing SC2129 style notes, no errors)
- [x] `bats scripts/*.bats` (24 tests pass, unchanged)
- [x] Action SHAs verified against upstream tags (`actions/cache@v5.0.5`, `actions/upload-artifact@v7.0.1`)
- [ ] Post-merge acceptance: full-chain dry run via `workflow_dispatch`

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR). (Not touched — release tooling only; `docs/signing-and-release.md` updated.)
- [x] No new references to `docs/archive/` as a current source of truth.