### PR TITLE
Ad-hoc signing fallback while Apple Developer credentials are unavailable (Issue #283)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
     outputs:
       release_ready: ${{ steps.check.outputs.release_ready }}
       missing_secrets: ${{ steps.check.outputs.missing_secrets }}
+      signing_mode: ${{ steps.check.outputs.signing_mode }}
       release_ref: ${{ steps.resolve.outputs.release_ref }}
     steps:
       - name: Resolve requested release ref
@@ -66,16 +67,12 @@ jobs:
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
           R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
         run: |
-          missing=()
-
+          # Core secrets (Sparkle feed signing + R2 distribution) are always required.
+          # Apple secrets are optional AS A COMPLETE SET (issue #283): all present =
+          # Developer ID signing + notarization; all absent = ad-hoc interim mode;
+          # a partial set is a misconfiguration and fails instead of degrading silently.
+          core_missing=()
           for secret_name in \
-            DEVELOPER_ID_APP_CERT_BASE64 \
-            DEVELOPER_ID_APP_CERT_PASSWORD \
-            KEYCHAIN_PASSWORD \
-            DEVELOPER_ID_APP_SIGNING_IDENTITY \
-            NOTARYTOOL_KEY \
-            NOTARYTOOL_KEY_ID \
-            NOTARYTOOL_ISSUER \
             SPARKLE_PUBLIC_ED_KEY \
             SPARKLE_PRIVATE_ED_KEY \
             R2_ACCOUNT_ID \
@@ -85,18 +82,47 @@ jobs:
             R2_PUBLIC_BASE_URL
           do
             if [ -z "${!secret_name:-}" ]; then
-              missing+=("$secret_name")
+              core_missing+=("$secret_name")
             fi
           done
 
-          if [ "${#missing[@]}" -eq 0 ]; then
-            echo "release_ready=true" >> "$GITHUB_OUTPUT"
-            echo "missing_secrets=" >> "$GITHUB_OUTPUT"
-          else
-            missing_csv="$(IFS=,; echo "${missing[*]}")"
+          apple_missing=()
+          for secret_name in \
+            DEVELOPER_ID_APP_CERT_BASE64 \
+            DEVELOPER_ID_APP_CERT_PASSWORD \
+            KEYCHAIN_PASSWORD \
+            DEVELOPER_ID_APP_SIGNING_IDENTITY \
+            NOTARYTOOL_KEY \
+            NOTARYTOOL_KEY_ID \
+            NOTARYTOOL_ISSUER
+          do
+            if [ -z "${!secret_name:-}" ]; then
+              apple_missing+=("$secret_name")
+            fi
+          done
+
+          if [ "${#core_missing[@]}" -gt 0 ]; then
+            missing_csv="$(IFS=,; echo "${core_missing[*]}")"
             echo "release_ready=false" >> "$GITHUB_OUTPUT"
             echo "missing_secrets=$missing_csv" >> "$GITHUB_OUTPUT"
+            echo "signing_mode=" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          if [ "${#apple_missing[@]}" -eq 0 ]; then
+            SIGNING_MODE=developer-id
+          elif [ "${#apple_missing[@]}" -eq 7 ]; then
+            SIGNING_MODE=adhoc
+            echo "::notice title=Ad-hoc release mode::No Apple Developer secrets configured — releasing ad-hoc signed, unnotarized artifacts (issue #283)."
+          else
+            apple_csv="$(IFS=,; echo "${apple_missing[*]}")"
+            echo "::error title=Partial Apple secrets::Configure all Apple secrets or none. Missing: $apple_csv" >&2
+            exit 1
+          fi
+
+          echo "release_ready=true" >> "$GITHUB_OUTPUT"
+          echo "missing_secrets=" >> "$GITHUB_OUTPUT"
+          echo "signing_mode=$SIGNING_MODE" >> "$GITHUB_OUTPUT"
 
   release-unavailable:
     name: Skip release without signing credentials
@@ -114,8 +140,8 @@ jobs:
           {
             echo "## Release skipped"
             echo
-            echo "Wink's formal release pipeline requires Developer ID signing, Apple notarization, Sparkle signing keys, and Cloudflare R2 credentials."
-            echo "Those secrets are not configured in this repository, so no signed/notarized release or Sparkle update feed was published."
+            echo "Wink's release pipeline always requires Sparkle signing keys and Cloudflare R2 credentials (Apple Developer secrets are optional — without them releases ship ad-hoc signed, see issue #283)."
+            echo "The required core secrets below are not configured, so no release or Sparkle update feed was published."
             echo
             echo "Missing secrets:"
 
@@ -134,6 +160,8 @@ jobs:
     if: ${{ needs.release-readiness.outputs.release_ready == 'true' }}
     runs-on: macos-15
     timeout-minutes: 45
+    env:
+      SIGNING_MODE: ${{ needs.release-readiness.outputs.signing_mode }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -234,9 +262,18 @@ jobs:
       - name: Extract release notes
         run: |
           bash scripts/release-notes.sh "$VERSION" > "$RUNNER_TEMP/release-notes.md"
+          if [ "$SIGNING_MODE" = "adhoc" ]; then
+            {
+              printf '\n---\n'
+              printf 'First install on macOS 15+: System Settings → Privacy & Security → **Open Anyway** '
+              printf '(this build is ad-hoc signed and not notarized — issue #283). '
+              printf 'Updates after that arrive in-app via Sparkle.\n'
+            } >> "$RUNNER_TEMP/release-notes.md"
+          fi
           echo "RELEASE_NOTES_PATH=$RUNNER_TEMP/release-notes.md" >> "$GITHUB_ENV"
 
       - name: Import Developer ID certificate
+        if: ${{ env.SIGNING_MODE == 'developer-id' }}
         env:
           DEVELOPER_ID_APP_CERT_BASE64: ${{ secrets.DEVELOPER_ID_APP_CERT_BASE64 }}
           DEVELOPER_ID_APP_CERT_PASSWORD: ${{ secrets.DEVELOPER_ID_APP_CERT_PASSWORD }}
@@ -258,6 +295,7 @@ jobs:
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
       - name: Write notarytool API key
+        if: ${{ env.SIGNING_MODE == 'developer-id' }}
         env:
           NOTARYTOOL_KEY: ${{ secrets.NOTARYTOOL_KEY }}
         run: |
@@ -271,6 +309,7 @@ jobs:
         run: swift test
 
       - name: Package signed app bundle
+        if: ${{ env.SIGNING_MODE == 'developer-id' }}
         env:
           SIGN_IDENTITY: ${{ secrets.DEVELOPER_ID_APP_SIGNING_IDENTITY }}
           ENTITLEMENTS_PLIST: ${{ github.workspace }}/entitlements.plist
@@ -280,18 +319,29 @@ jobs:
           SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
         run: bash scripts/package-app.sh
 
+      - name: Package ad-hoc app bundle
+        if: ${{ env.SIGNING_MODE == 'adhoc' }}
+        env:
+          SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
+        run: bash scripts/package-app.sh
+
       - name: Verify app signature
         run: |
           codesign --verify --deep --strict --verbose=2 build/Wink.app
-          spctl --assess --type exec --verbose build/Wink.app
           test -d build/Wink.app/Contents/Frameworks/Sparkle.framework
 
+      - name: Assess app with Gatekeeper
+        if: ${{ env.SIGNING_MODE == 'developer-id' }}
+        run: spctl --assess --type exec --verbose build/Wink.app
+
       - name: Archive app bundle for notarization
+        if: ${{ env.SIGNING_MODE == 'developer-id' }}
         run: |
           rm -f "$APP_NOTARIZATION_ZIP_PATH"
           ditto -c -k --sequesterRsrc --keepParent build/Wink.app "$APP_NOTARIZATION_ZIP_PATH"
 
       - name: Submit app notarization archive
+        if: ${{ env.SIGNING_MODE == 'developer-id' }}
         env:
           NOTARYTOOL_KEY_ID: ${{ secrets.NOTARYTOOL_KEY_ID }}
           NOTARYTOOL_ISSUER: ${{ secrets.NOTARYTOOL_ISSUER }}
@@ -303,9 +353,11 @@ jobs:
             --wait
 
       - name: Staple app notarization ticket
+        if: ${{ env.SIGNING_MODE == 'developer-id' }}
         run: xcrun stapler staple build/Wink.app
 
       - name: Validate notarized app bundle
+        if: ${{ env.SIGNING_MODE == 'developer-id' }}
         run: |
           xcrun stapler validate build/Wink.app
           spctl --assess --type exec --verbose build/Wink.app
@@ -319,6 +371,7 @@ jobs:
       - name: Generate appcast
         env:
           SPARKLE_PRIVATE_ED_KEY: ${{ secrets.SPARKLE_PRIVATE_ED_KEY }}
+          WINK_ALLOW_FIRST_RELEASE: ${{ vars.WINK_ALLOW_FIRST_RELEASE }}
         run: |
           export SPARKLE_PUBLIC_BASE_URL="$R2_PUBLIC_BASE_URL"
           export SPARKLE_FULL_RELEASE_NOTES_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG_OR_PLANNED}"
@@ -338,12 +391,14 @@ jobs:
             fi
           fi
 
-      - name: Package signed DMG
+      - name: Package DMG
         env:
+          # Empty in adhoc mode — package-dmg.sh skips DMG signing when unset.
           DMG_SIGN_IDENTITY: ${{ secrets.DEVELOPER_ID_APP_SIGNING_IDENTITY }}
         run: bash scripts/package-dmg.sh
 
       - name: Submit DMG for notarization
+        if: ${{ env.SIGNING_MODE == 'developer-id' }}
         env:
           NOTARYTOOL_KEY_ID: ${{ secrets.NOTARYTOOL_KEY_ID }}
           NOTARYTOOL_ISSUER: ${{ secrets.NOTARYTOOL_ISSUER }}
@@ -355,12 +410,18 @@ jobs:
             --wait
 
       - name: Staple notarization ticket
+        if: ${{ env.SIGNING_MODE == 'developer-id' }}
         run: xcrun stapler staple "$DMG_PATH"
 
       - name: Validate final DMG
+        if: ${{ env.SIGNING_MODE == 'developer-id' }}
         run: |
           xcrun stapler validate "$DMG_PATH"
           spctl --assess --type open --context context:primary-signature --verbose "$DMG_PATH"
+
+      - name: Verify ad-hoc DMG exists
+        if: ${{ env.SIGNING_MODE == 'adhoc' }}
+        run: test -f "$DMG_PATH"
 
       - name: Upload dry-run artifacts
         if: ${{ env.DRY_RUN == 'true' }}

--- a/docs/signing-and-release.md
+++ b/docs/signing-and-release.md
@@ -148,7 +148,20 @@ The `dry_run` input (default `true` for manual runs) builds and validates everyt
 
 The workflow fails if the Git tag does not match `CFBundleShortVersionString` (skipped when rehearsing a ref without a tag).
 
-If any required Apple, Sparkle, or R2 secret is missing, the workflow exits successfully with a summary that lists the missing secrets and publishes nothing.
+Secret requirements are split into two groups (issue #283):
+
+- **Core (always required):** the two Sparkle keys and the five R2 credentials. If any is missing, the workflow exits successfully with a summary that lists the missing secrets and publishes nothing.
+- **Apple (optional as a complete set):** the four signing secrets (including `KEYCHAIN_PASSWORD`) and the three notarytool secrets. All seven present → Developer ID signing plus notarization (`signing_mode=developer-id`). All seven absent → ad-hoc interim mode (`signing_mode=adhoc`). A partial set fails the run instead of silently degrading.
+
+### Ad-hoc interim mode
+
+While the maintainer has no Apple Developer Program membership, releases ship ad-hoc signed and unnotarized:
+
+- the app bundle is ad-hoc signed (`codesign -s -`) without hardened runtime; the DMG is unsigned
+- all notarization, stapling, and Gatekeeper (`spctl`) steps are skipped — `codesign --verify` still runs
+- Sparkle's EdDSA feed signature remains the update trust anchor, so in-app auto updates work exactly as in the full path
+- first install on macOS 15+ requires System Settings → Privacy & Security → **Open Anyway**; the release workflow appends this hint to the GitHub Release notes automatically
+- enrolling in the Apple Developer Program later requires no workflow changes: configure the seven Apple secrets and the next release is signed and notarized
 
 ### Release job flow
 


### PR DESCRIPTION
Closes #283

## Summary
- **`release-readiness` splits secrets into two groups**: core (Sparkle ×2 + R2 ×5, always required → skip path when missing) and Apple (cert ×4 incl. `KEYCHAIN_PASSWORD` + notarytool ×3, optional **as a complete set**). All seven Apple secrets → `signing_mode=developer-id` (unchanged full path); all absent → `signing_mode=adhoc`; a partial set hard-fails the run instead of silently degrading.
- **Adhoc mode** skips cert import, notary key write, app/DMG notarization, stapling, and `spctl` Gatekeeper assessments (which cannot pass for ad-hoc signatures); `codesign --verify --deep --strict` and the Sparkle framework check still run. The app falls back to `package-app.sh`'s existing ad-hoc path (no hardened runtime); `package-dmg.sh` already no-ops on empty `DMG_SIGN_IDENTITY`. Sparkle's EdDSA feed signature remains the update trust anchor, so auto updates work identically.
- **Release notes**: adhoc releases automatically append a first-install hint (macOS 15: System Settings → Privacy & Security → Open Anyway).
- **Bug fix**: `WINK_ALLOW_FIRST_RELEASE` is now also passed to the "Generate appcast" step — previously only the feed gate received it, so a genuine first release would have hard-failed in `generate-appcast.sh` ("restored live feed not found").
- **Docs**: `docs/signing-and-release.md` documents the two-group secret model and the ad-hoc interim mode; enrolling in the Apple Developer Program later requires no workflow changes — configure the seven Apple secrets and the next release is signed and notarized.

Context: Sparkle + R2 secrets are now fully configured; the maintainer has not enrolled in the Apple Developer Program yet, and the previous all-14-secrets readiness gate made every release take the skip path.

## Testing
- [x] `actionlint` (only pre-existing SC2129 style notes)
- [x] `bats scripts/*.bats` unaffected (no script changes)
- [ ] Post-merge acceptance: full-chain dry run via `workflow_dispatch` must now reach and complete the release job in adhoc mode

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR). (Not touched — release tooling only; `docs/signing-and-release.md` updated.)
- [x] No new references to `docs/archive/` as a current source of truth.