### PR TITLE
Settings titlebar: single AppKit-baseline centering, cheap idempotent re-apply (Issue #286)

### DIFF
--- a/Sources/Wink/WinkApp.swift
+++ b/Sources/Wink/WinkApp.swift
@@ -66,13 +66,6 @@ enum SettingsTitlebarLayout {
     /// chrome.jsx: outer flex row `height: 36`.
     static let height: CGFloat = 36
 
-    /// primitives.jsx TrafficLights: `padding: 0 16px`.
-    static let trafficLightContainerHorizontalPadding: CGFloat = 16
-    /// primitives.jsx TrafficLights: each dot `width: 12; height: 12`.
-    static let trafficLightDotSize: CGFloat = 12
-    /// primitives.jsx TrafficLights: flex `gap: 8` between dots.
-    static let trafficLightDotGap: CGFloat = 8
-
     /// chrome.jsx title overlay: `fontSize: 13; fontWeight: 500`.
     static let titleFontSize: CGFloat = 13
     /// CSS `font-weight: 500` ≈ AppKit/SwiftUI `.medium`.
@@ -104,11 +97,6 @@ enum SettingsTitlebarLayout {
     static let sidebarToggleIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarSidebarToggle")
     static let titleIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarTitle")
     static let accessoryIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarAccessory")
-
-    /// Vertical center y shared by traffic lights, toggle and title.
-    static var baselineCenterY: CGFloat {
-        height / 2
-    }
 }
 
 /// Minimal NSWindow surgery for the SwiftUI `Settings` scene:
@@ -124,9 +112,14 @@ enum SettingsTitlebarLayout {
 ///   3. Add an 8pt bottom `NSTitlebarAccessoryViewController` so the Settings
 ///      content starts below the design's 36pt chrome row instead of below the
 ///      native 28pt titlebar safe area.
-///   4. Add Wink's own sidebar toggle beside the system traffic lights without
-///      rewriting the native button frames. AppKit remains the owner of the
-///      standard close/minimize/zoom placement during titlebar updates.
+///   4. Add Wink's own sidebar toggle and title beside the system traffic
+///      lights without rewriting the native button frames. AppKit remains the
+///      owner of the standard close/minimize/zoom placement, and every
+///      Wink-added control shares the traffic lights' vertical centerline
+///      (`zoomButton.frame.midY`) — a single baseline, never a second one
+///      derived from the design row height (PR #239 removed traffic-light
+///      repositioning; a design-height centerline can no longer agree with
+///      the AppKit-owned buttons).
 private struct SettingsWindowChromeConfigurator: NSViewRepresentable {
     func makeCoordinator() -> SettingsWindowChromeCoordinator {
         SettingsWindowChromeCoordinator()
@@ -190,14 +183,17 @@ final class SettingsWindowChromeCoordinator: NSObject {
         self.window = window
         applyOnce()
 
-        // AppKit re-asserts titlebar layout on internal updates (key state,
-        // content attachment, titlebar accessory changes, resize). Re-apply so
-        // the CSS-derived coordinates stay pinned.
+        // AppKit (and SwiftUI's Settings scene) can re-assert titlebar state
+        // on internal updates: a toolbar may be re-attached, the separator
+        // style reset, or the chrome subviews re-laid out. `didUpdate` posts
+        // on essentially every event-loop pass for a visible window, which is
+        // acceptable only because `applyAll()` is idempotent-cheap: every
+        // write below is guarded by an inequality check, so a steady-state
+        // pass reduces to a handful of property reads with no layout work.
+        // `didResize` is listed explicitly for clarity; key-state and expose
+        // changes are already followed by window updates.
         let nc = NotificationCenter.default
         for name in [NSWindow.didUpdateNotification,
-                     NSWindow.didBecomeKeyNotification,
-                     NSWindow.didResignKeyNotification,
-                     NSWindow.didExposeNotification,
                      NSWindow.didResizeNotification] {
             let token = nc.addObserver(forName: name, object: window, queue: .main) { [weak self] _ in
                 MainActor.assumeIsolated { self?.applyAll() }
@@ -212,13 +208,19 @@ final class SettingsWindowChromeCoordinator: NSObject {
         applyAll()
     }
 
+    /// Every write is guarded so a no-drift pass performs reads only — this
+    /// runs on every `didUpdate` notification.
     private func applyWindowChromeOptions(to window: NSWindow) {
-        window.title = "Wink"
-        window.titleVisibility = .hidden
-        window.titlebarAppearsTransparent = true
-        window.styleMask.insert(.fullSizeContentView)
-        window.titlebarSeparatorStyle = .none
-        window.toolbarStyle = .unifiedCompact
+        if window.title != "Wink" { window.title = "Wink" }
+        if window.titleVisibility != .hidden { window.titleVisibility = .hidden }
+        if !window.titlebarAppearsTransparent { window.titlebarAppearsTransparent = true }
+        if !window.styleMask.contains(.fullSizeContentView) {
+            window.styleMask.insert(.fullSizeContentView)
+        }
+        if window.titlebarSeparatorStyle != .none { window.titlebarSeparatorStyle = .none }
+        // Inert while no toolbar is attached; kept so a transiently attached
+        // toolbar lays out compactly before the removal below lands.
+        if window.toolbarStyle != .unifiedCompact { window.toolbarStyle = .unifiedCompact }
         if window.toolbar != nil {
             window.toolbar = nil
         }
@@ -226,29 +228,43 @@ final class SettingsWindowChromeCoordinator: NSObject {
         // inside the detail pane (e.g. the Your Shortcuts grip drag) can
         // receive mouse-down events. The native 28pt titlebar plus the 8pt
         // titlebar accessory keep the full 36pt chrome row draggable.
-        window.isMovableByWindowBackground = false
+        if window.isMovableByWindowBackground { window.isMovableByWindowBackground = false }
     }
 
     fileprivate func applyAll() {
         guard let window else { return }
         applyWindowChromeOptions(to: window)
-        installTitlebarAccessory(in: window)
-        window.layoutIfNeeded()
+        if installTitlebarAccessory(in: window) {
+            window.layoutIfNeeded()
+        }
         guard let titlebarView = titlebarHostView(in: window) else { return }
         installOrUpdateTitlebarChrome(in: titlebarView)
     }
 
-    private func installTitlebarAccessory(in window: NSWindow) {
+    /// Returns `true` when the accessory was added or resized and a layout
+    /// pass is needed before button frames can be read.
+    @discardableResult
+    private func installTitlebarAccessory(in window: NSWindow) -> Bool {
         if let accessory = window.titlebarAccessoryViewControllers.first(where: {
             $0.view.identifier == SettingsTitlebarLayout.accessoryIdentifier
         }) {
-            accessory.layoutAttribute = .bottom
-            accessory.automaticallyAdjustsSize = false
-            accessory.view.setFrameSize(NSSize(
-                width: accessory.view.frame.width,
-                height: SettingsTitlebarLayout.titlebarAccessoryHeight
-            ))
-            return
+            var changed = false
+            if accessory.layoutAttribute != .bottom {
+                accessory.layoutAttribute = .bottom
+                changed = true
+            }
+            if accessory.automaticallyAdjustsSize {
+                accessory.automaticallyAdjustsSize = false
+                changed = true
+            }
+            if accessory.view.frame.height != SettingsTitlebarLayout.titlebarAccessoryHeight {
+                accessory.view.setFrameSize(NSSize(
+                    width: accessory.view.frame.width,
+                    height: SettingsTitlebarLayout.titlebarAccessoryHeight
+                ))
+                changed = true
+            }
+            return changed
         }
 
         let accessoryView = SettingsTitlebarPassthroughView(frame: NSRect(
@@ -265,6 +281,7 @@ final class SettingsWindowChromeCoordinator: NSObject {
         accessory.fullScreenMinHeight = SettingsTitlebarLayout.titlebarAccessoryHeight
         accessory.view = accessoryView
         window.addTitlebarAccessoryViewController(accessory)
+        return true
     }
 
     private func titlebarHostView(in window: NSWindow) -> NSView? {
@@ -284,29 +301,32 @@ final class SettingsWindowChromeCoordinator: NSObject {
         } as? SettingsTitlebarPassthroughView ?? {
             let view = SettingsTitlebarPassthroughView(frame: titlebarView.bounds)
             view.identifier = SettingsTitlebarLayout.backgroundIdentifier
+            view.autoresizingMask = [.width, .height]
             titlebarView.addSubview(view, positioned: .below, relativeTo: nil)
             return view
         }()
-        background.frame = titlebarView.bounds
-        background.autoresizingMask = [.width, .height]
-        background.updateBackgroundColor()
+        if background.frame != titlebarView.bounds {
+            background.frame = titlebarView.bounds
+        }
 
         let hairline = titlebarView.subviews.first {
             $0.identifier == SettingsTitlebarLayout.hairlineIdentifier
         } as? SettingsTitlebarHairlineView ?? {
             let view = SettingsTitlebarHairlineView(frame: .zero)
             view.identifier = SettingsTitlebarLayout.hairlineIdentifier
+            view.autoresizingMask = [.width, .maxYMargin]
             titlebarView.addSubview(view)
             return view
         }()
-        hairline.frame = NSRect(
+        let hairlineFrame = NSRect(
             x: 0,
             y: 0,
             width: titlebarView.bounds.width,
             height: SettingsTitlebarLayout.hairlineThickness
         )
-        hairline.autoresizingMask = [.width, .maxYMargin]
-        hairline.updateBackgroundColor()
+        if hairline.frame != hairlineFrame {
+            hairline.frame = hairlineFrame
+        }
 
         let toggle = titlebarView.subviews.first {
             $0.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier
@@ -325,11 +345,13 @@ final class SettingsWindowChromeCoordinator: NSObject {
             titlebarView.addSubview(button)
             return button
         }()
-        toggle.target = self
-        toggle.action = #selector(toggleSidebar(_:))
-        toggle.contentTintColor = SettingsTitlebarColors.textSecondary(for: titlebarView.effectiveAppearance)
-        toggle.frame = sidebarToggleFrame(in: titlebarView)
-        hideUnownedSidebarToggleButtons(in: titlebarView, keeping: toggle)
+        let toggleTint = SettingsTitlebarColors.textSecondary(for: titlebarView.effectiveAppearance)
+        if toggle.contentTintColor != toggleTint {
+            toggle.contentTintColor = toggleTint
+        }
+        if let toggleFrame = sidebarToggleFrame(in: titlebarView), toggle.frame != toggleFrame {
+            toggle.frame = toggleFrame
+        }
 
         let title = titlebarView.subviews.first {
             $0.identifier == SettingsTitlebarLayout.titleIdentifier
@@ -344,23 +366,37 @@ final class SettingsWindowChromeCoordinator: NSObject {
             label.isSelectable = false
             label.allowsDefaultTighteningForTruncation = false
             label.lineBreakMode = .byClipping
+            label.font = .systemFont(
+                ofSize: SettingsTitlebarLayout.titleFontSize,
+                weight: SettingsTitlebarLayout.titleFontWeight
+            )
             titlebarView.addSubview(label)
             return label
         }()
-        title.stringValue = "Wink"
-        title.font = .systemFont(
-            ofSize: SettingsTitlebarLayout.titleFontSize,
-            weight: SettingsTitlebarLayout.titleFontWeight
-        )
-        title.textColor = SettingsTitlebarColors.textPrimary(for: titlebarView.effectiveAppearance)
-        title.sizeToFit()
+        let titleColor = SettingsTitlebarColors.textPrimary(for: titlebarView.effectiveAppearance)
+        if title.textColor != titleColor {
+            title.textColor = titleColor
+        }
         let titleSize = title.intrinsicContentSize
-        title.frame = NSRect(
+        let titleFrame = NSRect(
             x: (titlebarView.bounds.width - titleSize.width) / 2,
-            y: titlebarView.bounds.height - SettingsTitlebarLayout.baselineCenterY - titleSize.height / 2,
+            y: chromeBaselineCenterY(in: titlebarView) - titleSize.height / 2,
             width: titleSize.width,
             height: titleSize.height
         ).integral
+        if title.frame != titleFrame {
+            title.frame = titleFrame
+        }
+    }
+
+    /// The single vertical centerline shared by every Wink-added titlebar
+    /// control: the AppKit-owned traffic lights' midY. Deriving a second
+    /// centerline from the design row height cannot agree with the buttons
+    /// (native titlebar band is 28pt; the 36pt row adds an 8pt bottom
+    /// accessory below it), so nothing else may define one.
+    private func chromeBaselineCenterY(in titlebarView: NSView) -> CGFloat {
+        window?.standardWindowButton(.zoomButton)?.frame.midY
+            ?? titlebarView.bounds.midY
     }
 
     private func removeInstalledChrome(from hostView: NSView) {
@@ -375,40 +411,6 @@ final class SettingsWindowChromeCoordinator: NSObject {
         }
     }
 
-    private func hideUnownedSidebarToggleButtons(in titlebarView: NSView, keeping customToggle: NSButton) {
-        let customFrame = customToggle.frame.insetBy(dx: -10, dy: -8)
-        for button in descendantButtons(in: titlebarView) where button !== customToggle {
-            guard isSidebarToggleCandidate(button, in: titlebarView, near: customFrame) else {
-                continue
-            }
-            button.isHidden = true
-            button.isEnabled = false
-        }
-    }
-
-    private func isSidebarToggleCandidate(_ button: NSButton, in titlebarView: NSView, near customFrame: NSRect) -> Bool {
-        if button.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier {
-            return false
-        }
-
-        let searchableText = [
-            button.identifier?.rawValue,
-            button.toolTip,
-            button.accessibilityLabel(),
-            button.accessibilityTitle(),
-            button.cell?.accessibilityLabel(),
-            button.cell?.accessibilityTitle(),
-        ]
-        if searchableText.contains(where: { $0?.localizedCaseInsensitiveContains("sidebar") == true }) {
-            return true
-        }
-
-        let frameInTitlebar = button.superview?.convert(button.frame, to: titlebarView) ?? button.frame
-        return button.frame.width <= SettingsTitlebarLayout.toggleHitSize.width + 12
-            && button.frame.height <= SettingsTitlebarLayout.toggleHitSize.height + 12
-            && frameInTitlebar.intersects(customFrame)
-    }
-
     private static func sidebarToggleImage() -> NSImage? {
         NSImage(
             systemSymbolName: SettingsTitlebarLayout.sidebarToggleSymbolName,
@@ -419,42 +421,26 @@ final class SettingsWindowChromeCoordinator: NSObject {
         )
     }
 
-    private func sidebarToggleFrame(in titlebarView: NSView) -> NSRect {
-        let size = SettingsTitlebarLayout.toggleHitSize
-        let isRightToLeft = window?.windowTitlebarLayoutDirection == .rightToLeft
-
-        let x: CGFloat
-        if isRightToLeft,
-           let closeButton = window?.standardWindowButton(.closeButton) {
-            x = closeButton.frame.minX - SettingsTitlebarLayout.toggleGapFromZoomButton - size.width
-        } else if let zoomButton = window?.standardWindowButton(.zoomButton) {
-            x = zoomButton.frame.maxX + SettingsTitlebarLayout.toggleGapFromZoomButton
-        } else {
-            x = SettingsTitlebarLayout.trafficLightContainerHorizontalPadding
-                + 3 * SettingsTitlebarLayout.trafficLightDotSize
-                + 2 * SettingsTitlebarLayout.trafficLightDotGap
-                + SettingsTitlebarLayout.toggleGapFromZoomButton
+    /// The toggle sits `toggleGapFromZoomButton` past the button cluster's
+    /// trailing edge (in reading direction), on the shared baseline. A titled
+    /// window always carries a zoom button alongside its close button, so
+    /// `nil` (leave the current frame untouched) is a defensive fallback, not
+    /// a reachable layout state.
+    private func sidebarToggleFrame(in titlebarView: NSView) -> NSRect? {
+        guard let window,
+              let zoomButton = window.standardWindowButton(.zoomButton) else {
+            return nil
         }
-
-        let centerY = window?.standardWindowButton(.zoomButton)?.frame.midY
-            ?? titlebarView.bounds.midY
+        let size = SettingsTitlebarLayout.toggleHitSize
+        let x = window.windowTitlebarLayoutDirection == .rightToLeft
+            ? zoomButton.frame.minX - SettingsTitlebarLayout.toggleGapFromZoomButton - size.width
+            : zoomButton.frame.maxX + SettingsTitlebarLayout.toggleGapFromZoomButton
         return NSRect(
             x: x,
-            y: centerY - size.height / 2,
+            y: chromeBaselineCenterY(in: titlebarView) - size.height / 2,
             width: size.width,
             height: size.height
         )
-    }
-
-    private func descendantButtons(in view: NSView) -> [NSButton] {
-        var result: [NSButton] = []
-        for subview in view.subviews {
-            if let button = subview as? NSButton {
-                result.append(button)
-            }
-            result.append(contentsOf: descendantButtons(in: subview))
-        }
-        return result
     }
 
     @objc private func toggleSidebar(_ sender: Any?) {

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -631,8 +631,6 @@ struct LayoutRegressionTests {
         let customTitle = try #require(titlebarView.subviews.first {
             $0.identifier == SettingsTitlebarLayout.titleIdentifier
         })
-        let toggleCenterYFromTop = titlebarView.bounds.height - sidebarToggle.frame.midY
-        let titleCenterYFromTop = titlebarView.bounds.height - customTitle.frame.midY
         let expectedToggleLeadingX = zoomButton.frame.maxX + SettingsTitlebarLayout.toggleGapFromZoomButton
 
         #expect(abs(topInset - SettingsTitlebarLayout.height) < 0.5)
@@ -641,10 +639,13 @@ struct LayoutRegressionTests {
         #expect(accessory.automaticallyAdjustsSize == false)
         #expect(abs(accessory.view.frame.height - SettingsTitlebarLayout.titlebarAccessoryHeight) < 0.5)
         #expect(abs(sidebarToggle.frame.minX - expectedToggleLeadingX) < 0.5)
+        // Single baseline: traffic lights, toggle, and title share the
+        // AppKit-owned button centerline. A design-height-derived second
+        // centerline is exactly the regression this guards against.
         #expect(abs(sidebarToggle.frame.midY - zoomButton.frame.midY) < 0.5)
-        #expect(abs(toggleCenterYFromTop - (titlebarView.bounds.height - zoomButton.frame.midY)) < 0.5)
+        #expect(abs(customTitle.frame.midY - zoomButton.frame.midY) < 1.0)
+        #expect(abs(customTitle.frame.midY - sidebarToggle.frame.midY) < 1.0)
         #expect(abs(customTitle.frame.midX - titlebarView.bounds.midX) < 0.5)
-        #expect(abs(titleCenterYFromTop - SettingsTitlebarLayout.baselineCenterY) < 0.5)
     }
 
     @Test @MainActor
@@ -665,38 +666,6 @@ struct LayoutRegressionTests {
 
         #expect(window.toolbar == nil)
         #expect(window.titlebarSeparatorStyle == .none)
-    }
-
-    @Test @MainActor
-    func settingsWindowChromeHidesDuplicateSidebarToggleButtons() throws {
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: SettingsWindowMetrics.width, height: SettingsWindowMetrics.height),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable],
-            backing: .buffered,
-            defer: false
-        )
-        let coordinator = SettingsWindowChromeCoordinator()
-
-        coordinator.attach(to: window)
-        let closeButton = try #require(window.standardWindowButton(.closeButton))
-        let titlebarView = try #require(closeButton.superview)
-        let sidebarToggle = try #require(titlebarView.subviews.first {
-            $0.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier
-        })
-        let duplicateToggle = NSButton(frame: sidebarToggle.frame.offsetBy(dx: 2, dy: 0))
-        duplicateToggle.image = NSImage(systemSymbolName: "sidebar.leading", accessibilityDescription: "Toggle Sidebar")
-        duplicateToggle.imagePosition = .imageOnly
-        duplicateToggle.toolTip = "Toggle Sidebar"
-        titlebarView.addSubview(duplicateToggle)
-
-        coordinator.attach(to: window)
-
-        #expect(duplicateToggle.isHidden)
-        #expect(duplicateToggle.isEnabled == false)
-        let ownedToggles = titlebarView.subviews.filter {
-            $0.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier
-        }
-        #expect(ownedToggles.count == 1)
     }
 
     @Test @MainActor

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -785,3 +785,16 @@ After the traffic-light dots were correctly repositioned to the design coordinat
 - If the title/sidebar-toggle must share a baseline with native traffic lights, place them in the `titlebarView` as AppKit controls after the accessory has grown the titlebar view to the target height. A SwiftUI row below the safe area cannot share y=18 with controls living in the native titlebar.
 - Keep the `NavigationSplitView` content out of the fake chrome row. Once the titlebar accessory makes `contentLayoutRect` start at y=36, the sidebar first row naturally begins below the hairline instead of needing a compensating top spacer.
 - Validate with pixels, not assumptions: assert the traffic-light bboxes, sidebar-toggle y centroid, hairline y, and sidebar first-row icon x alignment from the saved packaged-app screenshot.
+
+## Titlebar Controls Must Share One Vertical Centerline — the AppKit Button Baseline (#286)
+
+**Issue**
+After PR #239 stopped repositioning the native traffic lights (they visibly jumped during sidebar toggling), the title label kept centering on the design row's midline (`36 / 2 = 18pt` from top) while the AppKit-owned buttons — and the sidebar toggle that follows `zoomButton.frame.midY` — sat centered in the native 28pt titlebar band (~14pt from top). The two centerlines disagree by ~4pt *by construction*: the 36pt chrome row is a 28pt native titlebar plus an 8pt bottom accessory, and AppKit centers its buttons only in the native band. No amount of constant tuning can satisfy both references at once.
+
+**Fix (PR for #286)**
+- Every Wink-added titlebar control derives its center y from `zoomButton.frame.midY` (`chromeBaselineCenterY`). `baselineCenterY` (design-height-derived) was deleted so a second centerline cannot come back silently; `LayoutRegressionTests.settingsWindowChromeConfiguratorGrowsTitlebarToDesignHeight` asserts title/toggle/zoom share midY.
+- `applyAll()` is idempotent-cheap: every window-property and frame write is guarded by an inequality check, so the `didUpdate`-driven re-apply reduces to reads in steady state. Observers were cut from five notifications to `didUpdate` + `didResize`.
+- The localized-string + geometry heuristic that hunted duplicate SwiftUI sidebar toggles was removed: with `window.toolbar` nil'd and `.toolbar(removing: .sidebarToggle)`, the packaged app's titlebar exposes exactly four AX buttons (close/minimize/zoom + Wink's toggle). The heuristic's `"sidebar"` substring match was English-only (labels are localized, e.g. "边栏") and its size/overlap fallback could hide arbitrary future system controls.
+
+**Residual design decision**
+The aligned cluster sits on AppKit's ~14pt centerline, i.e. ~4pt above the 36pt row's midline. True centering at 18pt requires owning the lights (hide the standard buttons and draw custom dots, PomoFox-style) — repositioning real buttons is what #239 reverted. Treat "centered in the 36pt row" as a separate, owner-approved issue if design fidelity demands it; do not resurrect per-pass `setFrameOrigin` on standard buttons.


### PR DESCRIPTION
Fixes #286

## Summary
- Unify the vertical centering of every Wink-added titlebar control (sidebar toggle, title) on the AppKit-owned traffic-light centerline (`zoomButton.frame.midY`), and delete `baselineCenterY` — the design-height-derived second centerline that could never agree with the buttons (~4pt disagreement by construction: 28pt native band + 8pt bottom accessory)
- Make `applyAll()` idempotent-cheap: every window-property and frame write is inequality-guarded, so the `didUpdate`-driven re-apply reduces to a handful of reads in steady state (previously: recursive subview scans, `sizeToFit`, unconditional frame writes, and `layoutIfNeeded` on essentially every event-loop pass); observers cut from five notifications to `didUpdate` + `didResize`
- Remove `hideUnownedSidebarToggleButtons`: the `"sidebar"` substring match was English-only (accessibility labels are localized — "边栏" on Chinese macOS), and the size/overlap fallback could hide arbitrary small system buttons. With `window.toolbar` nil'd plus `.toolbar(removing: .sidebarToggle)`, the packaged app's titlebar exposes exactly four AX buttons (close/minimize/zoom + Wink's toggle) — verified live
- Delete the unreachable no-zoom-button fallback branch (chrome only installs when the close button exists, and titled windows always carry a zoom button alongside it) and the now-orphaned CSS traffic-light constants
- RTL: anchor the toggle to the zoom button (the mirrored cluster's leading edge) instead of the close button, which the previous math would overlap
- Regression test now asserts title/toggle/zoom share midY — the exact two-centerline regression this PR removes
- `docs/lessons-learned.md`: recorded the two-centerline root cause and the single-baseline contract

## Testing
- [x] `swift test` (391 tests, 40 suites)
- [x] Additional validation noted below when needed
- [x] `swift build` + `./scripts/package-app.sh`
- [x] Packaged-app runtime validation (dark mode): pixel probe over the Settings window screenshot measures red traffic light y:[8-19] centerY 13.5, toggle glyph y:[8-19] centerY 13.5, title text y:[9-18] centerY 13.5 — one shared baseline (title was previously at 18)
- [x] Sidebar toggle click collapses and re-expands the sidebar; titlebar metrics identical in the collapsed state
- [x] AX button census of the live window: exactly close/zoom/minimize + one Wink toggle, no duplicate sidebar button

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes — residual design decision (owner call)
The aligned cluster now sits on AppKit's centerline (~14pt from the row top), i.e. ~4pt above the 36pt design row's midline. True 18pt centering requires owning the lights — hiding the standard buttons and drawing custom dots (PomoFox-style, `FloatingWindowController.swift:167-169` in the reference repo) — because repositioning real buttons is exactly what PR #239 had to revert (visible jumping during sidebar toggling). If pixel-fidelity to `chrome.jsx` outranks native buttons, that should be a separate issue; this PR deliberately does not resurrect `setFrameOrigin` on standard buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)