### PR TITLE
Updates: functional Automatic Updates master switch (Issue #287)

### DIFF
--- a/Sources/Wink/Services/AppPreferences.swift
+++ b/Sources/Wink/Services/AppPreferences.swift
@@ -58,12 +58,19 @@ final class AppPreferences {
             currentVersion: updateService?.currentVersion ?? Self.currentVersionString(),
             isConfigured: updateService?.isConfigured ?? false,
             checkForUpdatesEnabled: updateService?.canCheckForUpdates ?? false,
-            automaticChecksEnabledByDefault: updateService?.automaticallyChecksForUpdates
+            automaticChecksEnabled: updateService?.automaticallyChecksForUpdates
                 ?? Self.boolValue(forInfoDictionaryKey: "SUEnableAutomaticChecks", default: true),
-            automaticDownloadsEnabledByDefault: updateService?.automaticallyDownloadsUpdates
+            automaticDownloadsEnabled: updateService?.automaticallyDownloadsUpdates
                 ?? Self.boolValue(forInfoDictionaryKey: "SUAutomaticallyUpdate", default: true)
         )
     }
+
+    /// Master switch mirrored from the live updater values so SwiftUI can
+    /// observe flips (`updatePresentation` is computed off non-observable
+    /// service state). ON means scheduled checks plus background downloads;
+    /// mixed states (only reachable via `defaults write`) read as OFF and
+    /// normalize on the next toggle.
+    private(set) var automaticUpdatesEnabled: Bool = false
 
     var launchAtLoginPresentation: LaunchAtLoginPresentation {
         switch launchAtLoginStatus {
@@ -141,6 +148,7 @@ final class AppPreferences {
         self.launchAtLoginService = launchAtLoginService
         self.updateService = updateService
         self.userDefaults = userDefaults
+        self.automaticUpdatesEnabled = Self.resolveAutomaticUpdatesEnabled(from: updateService)
         self.hyperKeyEnabled = initialHyperKeyEnabled
         self.shortcutsPaused = initialShortcutsPaused
         self.frontmostTargetBehavior = initialFrontmostTargetBehavior
@@ -194,6 +202,35 @@ final class AppPreferences {
 
     func checkForUpdates() {
         updateService?.checkForUpdates()
+    }
+
+    /// Drives both Sparkle flags (scheduled checks + background downloads)
+    /// as one user-facing switch. The mirrored state is read back from the
+    /// service after the write so it only reflects what actually persisted.
+    ///
+    /// Order matters: without an `SUAllowsAutomaticUpdates` Info.plist key,
+    /// Sparkle derives `allowsAutomaticUpdates` from the checks flag and
+    /// silently drops writes to `automaticallyDownloadsUpdates` while checks
+    /// are off (SPUUpdaterSettings.setAutomaticallyDownloadsUpdates). Write
+    /// the downloads flag while checks are still on so both flags persist.
+    func setAutomaticUpdatesEnabled(_ enabled: Bool) {
+        guard let updateService else { return }
+        if enabled {
+            updateService.automaticallyChecksForUpdates = true
+            updateService.automaticallyDownloadsUpdates = true
+        } else {
+            updateService.automaticallyDownloadsUpdates = false
+            updateService.automaticallyChecksForUpdates = false
+        }
+        automaticUpdatesEnabled = Self.resolveAutomaticUpdatesEnabled(from: updateService)
+    }
+
+    private static func resolveAutomaticUpdatesEnabled(from updateService: UpdateServicing?) -> Bool {
+        let checks = updateService?.automaticallyChecksForUpdates
+            ?? boolValue(forInfoDictionaryKey: "SUEnableAutomaticChecks", default: true)
+        let downloads = updateService?.automaticallyDownloadsUpdates
+            ?? boolValue(forInfoDictionaryKey: "SUAutomaticallyUpdate", default: true)
+        return checks && downloads
     }
 
     func setHyperKeyEnabled(_ enabled: Bool) {

--- a/Sources/Wink/Services/SparkleUpdateService.swift
+++ b/Sources/Wink/Services/SparkleUpdateService.swift
@@ -33,13 +33,23 @@ final class SparkleUpdateService: UpdateServicing {
     }
 
     var automaticallyChecksForUpdates: Bool {
-        updaterController?.updater.automaticallyChecksForUpdates
-            ?? Self.boolValue(forInfoDictionaryKey: "SUEnableAutomaticChecks", bundle: bundle, default: true)
+        get {
+            updaterController?.updater.automaticallyChecksForUpdates
+                ?? Self.boolValue(forInfoDictionaryKey: "SUEnableAutomaticChecks", bundle: bundle, default: true)
+        }
+        set {
+            updaterController?.updater.automaticallyChecksForUpdates = newValue
+        }
     }
 
     var automaticallyDownloadsUpdates: Bool {
-        updaterController?.updater.automaticallyDownloadsUpdates
-            ?? Self.boolValue(forInfoDictionaryKey: "SUAutomaticallyUpdate", bundle: bundle, default: true)
+        get {
+            updaterController?.updater.automaticallyDownloadsUpdates
+                ?? Self.boolValue(forInfoDictionaryKey: "SUAutomaticallyUpdate", bundle: bundle, default: true)
+        }
+        set {
+            updaterController?.updater.automaticallyDownloadsUpdates = newValue
+        }
     }
 
     func checkForUpdates() {

--- a/Sources/Wink/Services/UpdateServicing.swift
+++ b/Sources/Wink/Services/UpdateServicing.swift
@@ -4,8 +4,8 @@ struct UpdatePresentation: Equatable {
     let currentVersion: String
     let isConfigured: Bool
     let checkForUpdatesEnabled: Bool
-    let automaticChecksEnabledByDefault: Bool
-    let automaticDownloadsEnabledByDefault: Bool
+    let automaticChecksEnabled: Bool
+    let automaticDownloadsEnabled: Bool
 }
 
 @MainActor
@@ -13,8 +13,11 @@ protocol UpdateServicing: AnyObject {
     var isConfigured: Bool { get }
     var canCheckForUpdates: Bool { get }
     var currentVersion: String { get }
-    var automaticallyChecksForUpdates: Bool { get }
-    var automaticallyDownloadsUpdates: Bool { get }
+    /// Live updater values. Setting persists through the updater's own store
+    /// (Sparkle writes user defaults that override the Info.plist seeds);
+    /// setters are no-ops while the updater is unconfigured.
+    var automaticallyChecksForUpdates: Bool { get set }
+    var automaticallyDownloadsUpdates: Bool { get set }
 
     func checkForUpdates()
 }

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -93,12 +93,12 @@ struct GeneralTabView: View {
                         SettingsToggleRow(
                             title: "Automatic Updates",
                             subtitle: "Download and install new versions in the background.",
-                            isOn: .constant(
-                                updatePresentation.automaticChecksEnabledByDefault
-                                    && updatePresentation.automaticDownloadsEnabledByDefault
+                            isOn: Binding(
+                                get: { preferences.automaticUpdatesEnabled },
+                                set: { preferences.setAutomaticUpdatesEnabled($0) }
                             )
                         )
-                        .disabled(true)
+                        .disabled(!updatePresentation.isConfigured)
                     }
                 }
 
@@ -235,15 +235,15 @@ struct GeneralTabView: View {
             return "Automatic updates become available after this build is configured with a signed Sparkle appcast feed."
         }
 
-        if presentation.automaticChecksEnabledByDefault && presentation.automaticDownloadsEnabledByDefault {
+        if presentation.automaticChecksEnabled && presentation.automaticDownloadsEnabled {
             return "Automatic update checks and downloads are enabled."
         }
 
-        if presentation.automaticChecksEnabledByDefault {
+        if presentation.automaticChecksEnabled {
             return "Wink checks for updates automatically and asks before downloading."
         }
 
-        return "Automatic update checks are disabled by default."
+        return "Automatic update checks are off. Use Check for Updates… to check manually."
     }
 }
 

--- a/Tests/WinkTests/AppPreferencesTests.swift
+++ b/Tests/WinkTests/AppPreferencesTests.swift
@@ -243,8 +243,8 @@ func updatePresentation_exposesVersionAndEnablesManualChecksWhenServiceIsAvailab
     #expect(presentation.currentVersion == "0.3.0")
     #expect(presentation.isConfigured == true)
     #expect(presentation.checkForUpdatesEnabled == true)
-    #expect(presentation.automaticChecksEnabledByDefault == true)
-    #expect(presentation.automaticDownloadsEnabledByDefault == true)
+    #expect(presentation.automaticChecksEnabled == true)
+    #expect(presentation.automaticDownloadsEnabled == true)
 }
 
 @Test @MainActor
@@ -255,8 +255,65 @@ func updatePresentation_defaultsToDisabledChecksWithoutService() {
 
     #expect(presentation.isConfigured == false)
     #expect(presentation.checkForUpdatesEnabled == false)
-    #expect(presentation.automaticChecksEnabledByDefault == true)
-    #expect(presentation.automaticDownloadsEnabledByDefault == true)
+    #expect(presentation.automaticChecksEnabled == true)
+    #expect(presentation.automaticDownloadsEnabled == true)
+}
+
+@Test @MainActor
+func setAutomaticUpdatesEnabled_writesBothUpdaterFlagsAndMirrorsState() {
+    let service = FakeUpdateService(
+        isConfigured: true,
+        canCheckForUpdates: true,
+        currentVersion: "0.3.0",
+        automaticallyChecksForUpdates: true,
+        automaticallyDownloadsUpdates: true
+    )
+    let preferences = makePreferences(updateService: service)
+    #expect(preferences.automaticUpdatesEnabled == true)
+
+    preferences.setAutomaticUpdatesEnabled(false)
+
+    #expect(service.automaticallyChecksForUpdates == false)
+    #expect(service.automaticallyDownloadsUpdates == false)
+    #expect(preferences.automaticUpdatesEnabled == false)
+    #expect(preferences.updatePresentation.automaticChecksEnabled == false)
+    #expect(preferences.updatePresentation.automaticDownloadsEnabled == false)
+
+    preferences.setAutomaticUpdatesEnabled(true)
+
+    #expect(service.automaticallyChecksForUpdates == true)
+    #expect(service.automaticallyDownloadsUpdates == true)
+    #expect(preferences.automaticUpdatesEnabled == true)
+}
+
+@Test @MainActor
+func automaticUpdatesEnabled_readsMixedExternalStateAsOffAndNormalizesOnToggle() {
+    let service = FakeUpdateService(
+        isConfigured: true,
+        canCheckForUpdates: true,
+        currentVersion: "0.3.0",
+        automaticallyChecksForUpdates: true,
+        automaticallyDownloadsUpdates: false
+    )
+    let preferences = makePreferences(updateService: service)
+
+    #expect(preferences.automaticUpdatesEnabled == false)
+
+    preferences.setAutomaticUpdatesEnabled(true)
+
+    #expect(service.automaticallyChecksForUpdates == true)
+    #expect(service.automaticallyDownloadsUpdates == true)
+    #expect(preferences.automaticUpdatesEnabled == true)
+}
+
+@Test @MainActor
+func setAutomaticUpdatesEnabled_isNoOpWithoutService() {
+    let preferences = makePreferences()
+    let initial = preferences.automaticUpdatesEnabled
+
+    preferences.setAutomaticUpdatesEnabled(!initial)
+
+    #expect(preferences.automaticUpdatesEnabled == initial)
 }
 
 @Test @MainActor
@@ -478,8 +535,8 @@ private final class FakeUpdateService: UpdateServicing {
     let isConfigured: Bool
     let canCheckForUpdates: Bool
     let currentVersion: String
-    let automaticallyChecksForUpdates: Bool
-    let automaticallyDownloadsUpdates: Bool
+    var automaticallyChecksForUpdates: Bool
+    var automaticallyDownloadsUpdates: Bool
     private(set) var didRequestManualCheck = false
 
     init(

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
@@ -421,8 +421,8 @@ private final class FakeUpdateService: UpdateServicing {
     let isConfigured: Bool
     let canCheckForUpdates: Bool
     let currentVersion: String
-    let automaticallyChecksForUpdates: Bool
-    let automaticallyDownloadsUpdates: Bool
+    var automaticallyChecksForUpdates: Bool
+    var automaticallyDownloadsUpdates: Bool
     private(set) var didRequestManualCheck = false
 
     init(


### PR DESCRIPTION
Fixes #287

## Summary
- The "Automatic Updates" row in Settings was a permanently disabled `.constant` display while Info.plist hard-enabled auto-check + auto-download with no in-app opt-out; it is now a real master switch
- `UpdateServicing` gains read-write `automaticallyChecksForUpdates` / `automaticallyDownloadsUpdates`, implemented on `SPUUpdater` — Sparkle persists them to user defaults, overriding the Info.plist seeds
- `AppPreferences` mirrors the live updater state into an observable stored property (`automaticUpdatesEnabled`) so SwiftUI observes flips; the mirror is read back from the service after each write, so it only reflects what actually persisted
- Write ordering works around a Sparkle behavior verified in the vendored source (`SPUUpdaterSettings.m:330-339`): without an `SUAllowsAutomaticUpdates` Info.plist key, `allowsAutomaticUpdates` derives from the checks flag, and writes to `automaticallyDownloadsUpdates` are **silently dropped while checks are off** — so disabling writes downloads first, enabling writes checks first
- Toggle is disabled only while the updater is unconfigured (dev builds without an injected feed); the existing caption explains that state. Mixed external states (`defaults write`) read as OFF and normalize on the next toggle
- `UpdatePresentation` fields renamed `automaticChecksEnabledByDefault` → `automaticChecksEnabled` (live values, not defaults); the "checks off" description now points at manual checking

## Testing
- [x] `swift test` (394 tests, 40 suites — 3 new: master-switch write-through + mirror, mixed-state normalization, no-service no-op)
- [x] Additional validation noted below when needed
- [x] Runtime validation on a feed-configured packaged build (`SPARKLE_FEED_URL`/`SPARKLE_PUBLIC_ED_KEY` injected): clicking the switch OFF persists `SUEnableAutomaticChecks=0` **and** `SUAutomaticallyUpdate=0`; clicking ON persists both to 1; the switch visual tracks each flip (pixel-probe on window screenshots). Validation defaults removed afterwards; user's installed app restored

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Per-user Sparkle state (user defaults) intentionally wins over Info.plist — that is Sparkle's own precedence; Info.plist keys remain the first-run defaults
- Follow-ups #289 (in-app update phase visibility) and #290 (What's New) build on this seam

🤖 Generated with [Claude Code](https://claude.com/claude-code)