### PR TITLE
Hot path: dedupe AX minimized queries, remove redundant executor hops (Issue #288)

### DIFF
--- a/Sources/Wink/Protocols/EventTapManaging.swift
+++ b/Sources/Wink/Protocols/EventTapManaging.swift
@@ -8,7 +8,11 @@ enum EventTapStartResult: Equatable, Sendable {
 @MainActor
 protocol EventTapManaging {
     var isRunning: Bool { get }
-    func start(onKeyPress: @escaping (KeyPress) -> Bool) -> EventTapStartResult
+    /// The handler is invoked on the main actor (the tap's background thread
+    /// hops exactly once, in `MatchedShortcutDelivery`); marking it
+    /// `@MainActor` lets callers run their toggle logic directly instead of
+    /// paying a second executor enqueue per keypress.
+    func start(onKeyPress: @escaping @MainActor (KeyPress) -> Bool) -> EventTapStartResult
     func stop()
     func updateRegisteredShortcuts(_ keyPresses: Set<KeyPress>)
     func setHyperKeyEnabled(_ enabled: Bool)

--- a/Sources/Wink/Services/AppSwitcher.swift
+++ b/Sources/Wink/Services/AppSwitcher.swift
@@ -866,7 +866,7 @@ final class AppSwitcher: AppSwitching {
                 return performFrontmostFocus(
                     shortcut: shortcut,
                     runningApp: runningApp,
-                    windows: preActionWindowObservation.windows,
+                    windowObservation: preActionWindowObservation,
                     snapshot: preActionSnapshot,
                     attemptStartedAt: attemptStartedAt
                 )
@@ -1006,9 +1006,8 @@ final class AppSwitcher: AppSwitching {
         if runningApp.isHidden {
             runningApp.unhide()
         }
-        let windows = preActionWindowObservation.windows
-        unminimizeWindows(of: runningApp, windows: windows)
-        let activated = activateViaWindowServer(runningApp, windows: windows)
+        unminimizeWindows(of: runningApp, observation: preActionWindowObservation)
+        let activated = activateViaWindowServer(runningApp, windows: preActionWindowObservation.windows)
         guard activated || continuingPendingActivation else {
             clearActivationTracking(for: shortcut.bundleIdentifier)
             return false
@@ -1084,15 +1083,15 @@ final class AppSwitcher: AppSwitching {
     private func performFrontmostFocus(
         shortcut: AppShortcut,
         runningApp: NSRunningApplication,
-        windows: [AXUIElement]?,
+        windowObservation: ApplicationObservation.WindowObservation,
         snapshot: ActivationObservationSnapshot,
         attemptStartedAt: CFAbsoluteTime
     ) -> Bool {
         if runningApp.isHidden {
             runningApp.unhide()
         }
-        unminimizeWindows(of: runningApp, windows: windows)
-        let activated = activateViaWindowServer(runningApp, windows: windows)
+        unminimizeWindows(of: runningApp, observation: windowObservation)
+        let activated = activateViaWindowServer(runningApp, windows: windowObservation.windows)
         logToggleTrace(
             family: .decision,
             bundleIdentifier: shortcut.bundleIdentifier,
@@ -1239,9 +1238,8 @@ final class AppSwitcher: AppSwitching {
         if runningApp.isHidden {
             runningApp.unhide()
         }
-        let windows = preActionWindowObservation.windows
-        unminimizeWindows(of: runningApp, windows: windows)
-        _ = activateViaWindowServer(runningApp, windows: windows)
+        unminimizeWindows(of: runningApp, observation: preActionWindowObservation)
+        _ = activateViaWindowServer(runningApp, windows: preActionWindowObservation.windows)
 
         let continuedState = pendingActivationState(for: shortcut.bundleIdentifier) ?? pendingState
         schedulePendingConfirmation(
@@ -1490,25 +1488,25 @@ final class AppSwitcher: AppSwitching {
         return windows
     }
 
-    /// Unminimize all minimized windows using pre-fetched window list.
-    private func unminimizeWindows(of app: NSRunningApplication, windows: [AXUIElement]?) {
-        guard let windows else {
+    /// Unminimize the windows the observation already found minimized.
+    /// Consumes the per-window `kAXMinimized` reads captured during the
+    /// single pre-action observation pass instead of re-issuing them — in
+    /// the common nothing-minimized case this performs zero AX IPC on the
+    /// keypress→activation path.
+    private func unminimizeWindows(
+        of app: NSRunningApplication,
+        observation: ApplicationObservation.WindowObservation
+    ) {
+        guard observation.windows != nil else {
             logger.error("unminimize: no windows for pid \(app.processIdentifier)")
             DiagnosticLog.log("unminimize: no windows for pid \(app.processIdentifier)")
             return
         }
-        #if DEBUG
-        logger.debug("unminimize: found \(windows.count) windows for pid \(app.processIdentifier)")
-        #endif
-        for (i, window) in windows.enumerated() {
-            var minimizedRef: CFTypeRef?
-            let minResult = AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimizedRef)
-            if minResult == .success, let isMinimized = minimizedRef as? Bool, isMinimized {
-                let setResult = AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, false as CFTypeRef)
-                #if DEBUG
-                logger.debug("unminimize: window[\(i)] was minimized, unminimize result=\(setResult.rawValue)")
-                #endif
-            }
+        for (i, window) in observation.minimizedWindows.enumerated() {
+            let setResult = AXUIElementSetAttributeValue(window, kAXMinimizedAttribute as CFString, false as CFTypeRef)
+            #if DEBUG
+            logger.debug("unminimize: window[\(i)] was minimized, unminimize result=\(setResult.rawValue)")
+            #endif
         }
     }
 
@@ -1729,8 +1727,17 @@ extension AppSwitcher.ConfirmationClient {
             CFAbsoluteTimeGetCurrent()
         },
         schedule: { delay, operation in
+            // Callers are @MainActor (the client type pins schedule to the
+            // main actor), so a zero delay runs inline instead of paying a
+            // dispatch-timer turn plus an executor enqueue on the toggle-off
+            // hot path. Nonzero delays land on the main queue, which is the
+            // main actor's executor — no second hop needed.
+            if delay <= 0 {
+                operation()
+                return
+            }
             DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                Task { @MainActor in
+                MainActor.assumeIsolated {
                     operation()
                 }
             }

--- a/Sources/Wink/Services/ApplicationObservation.swift
+++ b/Sources/Wink/Services/ApplicationObservation.swift
@@ -123,6 +123,10 @@ struct ActivationObservationSnapshot: Sendable, Equatable {
 struct ApplicationObservation {
     struct WindowObservation {
         let windows: [AXUIElement]?
+        /// Windows whose `kAXMinimized` read true during this observation
+        /// pass. Captured here so consumers (unminimize) never re-issue the
+        /// per-window AX roundtrips the observation already paid for.
+        var minimizedWindows: [AXUIElement] = []
         let visibleWindowCount: Int
         let hasFocusedWindow: Bool
         let hasMainWindow: Bool
@@ -233,17 +237,22 @@ extension ApplicationObservation.Client {
         var windowsRef: CFTypeRef?
         let result = AXUIElementCopyAttributeValue(axApp, kAXWindowsAttribute as CFString, &windowsRef)
         let windows = result == .success ? windowsRef as? [AXUIElement] : nil
-        let visibleWindowCount = (windows ?? []).reduce(into: 0) { count, window in
+        var visibleWindowCount = 0
+        var minimizedWindows: [AXUIElement] = []
+        for window in windows ?? [] {
             var minimizedRef: CFTypeRef?
             let minimizedResult = AXUIElementCopyAttributeValue(window, kAXMinimizedAttribute as CFString, &minimizedRef)
             let isMinimized = minimizedResult == .success && (minimizedRef as? Bool ?? false)
-            if !isMinimized {
-                count += 1
+            if isMinimized {
+                minimizedWindows.append(window)
+            } else {
+                visibleWindowCount += 1
             }
         }
 
         return ApplicationObservation.WindowObservation(
             windows: windows,
+            minimizedWindows: minimizedWindows,
             visibleWindowCount: visibleWindowCount,
             hasFocusedWindow: hasAppWindowAttribute(kAXFocusedWindowAttribute, on: axApp),
             hasMainWindow: hasAppWindowAttribute(kAXMainWindowAttribute, on: axApp),

--- a/Sources/Wink/Services/EventTapCaptureProvider.swift
+++ b/Sources/Wink/Services/EventTapCaptureProvider.swift
@@ -23,10 +23,10 @@ final class EventTapCaptureProvider: HyperShortcutCaptureProvider {
     }
 
     func start(onKeyPress: @escaping @MainActor @Sendable (KeyPress) -> Void) {
+        // The manager delivers on the main actor already; invoke the handler
+        // directly rather than enqueueing a second main-actor Task per press.
         let result = manager.start { keyPress in
-            Task { @MainActor in
-                onKeyPress(keyPress)
-            }
+            onKeyPress(keyPress)
             return true
         }
         if result == .started {

--- a/Sources/Wink/Services/EventTapManager.swift
+++ b/Sources/Wink/Services/EventTapManager.swift
@@ -296,7 +296,9 @@ private let eventTapCallback: CGEventTapCallBack = { _, type, event, userInfo in
 @MainActor
 final class EventTapManager: EventTapManaging {
     /// Returns `true` if the key press was handled and should be consumed (not passed to other apps).
-    typealias ShortcutHandler = (KeyPress) -> Bool
+    /// Main-actor bound: delivery already hops to the main actor once in
+    /// `MatchedShortcutDelivery`, so the handler runs there directly.
+    typealias ShortcutHandler = @MainActor (KeyPress) -> Bool
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?

--- a/Tests/WinkTests/EventTapCaptureProviderTests.swift
+++ b/Tests/WinkTests/EventTapCaptureProviderTests.swift
@@ -9,7 +9,7 @@ private final class FakeEventTapManager: EventTapManaging {
     private(set) var registeredShortcuts: Set<KeyPress> = []
     private(set) var setHyperEnabledCalls: [(enabled: Bool, whileRunning: Bool)] = []
 
-    func start(onKeyPress: @escaping (KeyPress) -> Bool) -> EventTapStartResult {
+    func start(onKeyPress: @escaping @MainActor (KeyPress) -> Bool) -> EventTapStartResult {
         isRunning = true
         return .started
     }


### PR DESCRIPTION
Fixes #288

## Summary
- `WindowObservation` now carries the windows found minimized during the single pre-action observation pass; `unminimizeWindows` consumes that list instead of re-querying `kAXMinimized` on every window. Common case (nothing minimized): **zero** AX IPC in the unminimize step, was n synchronous main-thread roundtrips into the target app, each blockable up to the 1s AX messaging timeout. Applies to all three call sites (activate, frontmost-focus, launch-confirmation)
- `EventTapManaging`'s handler is now `@MainActor`: delivery already hops to the main actor exactly once (`MatchedShortcutDelivery`), so `EventTapCaptureProvider` runs the toggle logic directly instead of enqueueing a second main-actor `Task` per Hyper keypress (the Carbon route already did zero extra hops)
- `ConfirmationClient.live.schedule` short-circuits `delay <= 0` to an inline call (`hideRequestDispatchDelay` is constant 0) and uses `MainActor.assumeIsolated` for nonzero delays instead of a nested `Task`. Re-entrancy audited: every `performHideToggle` caller registers the pending-deactivation session via `acceptPendingDeactivation` **before** scheduling, so the generation guard still passes when the hide closure runs inline
- Out of scope per the issue (verified deliberate): the pre-activation observation itself ("observation-first toggle truth"), `fetchWindows`/`hasVisibleWindows` on post-activation confirmation paths, debounce/cooldown values

## Testing
- [x] `swift test` (391 tests, 40 suites)
- [x] Additional validation noted below when needed
- [x] `./scripts/e2e-full-test.sh` on macOS against the packaged branch build: **all 6 modules PASS** (Startup & Lifecycle, Configured Toggle ON/OFF, Hyper Key CGEvent hold, Debounce & Cooldown, Toggle Loop Prevention, Multi-Shortcut Isolation), Hyper capture readiness confirmed (`ax=true im=true eventTap=true`, 19-shortcut trigger index)
- [x] Manual minimized-window check: minimized Firefox's window, fired its Hyper shortcut → window unminimized and Firefox frontmost (exercises the observation-captured minimized flags end-to-end)
- [x] Toggle-off: second press hid Firefox with `TOGGLE_HIDE_ATTEMPT → HIDE_REQUEST` 1ms apart (inline short-circuit live) and `TOGGLE_HIDE_CONFIRMED` at 28ms; macOS promoted the next app per the documented toggle semantics
- [x] Physical-path key events delivered via `osascript` System Events per AGENTS.md E2E guidance

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR). (Behavioral contracts unchanged: observation-first ordering, single main-actor delivery hop, hide-request semantics; only redundant work removed.)
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Validation was performed on a build signed with the local "Quickey " signing identity (`SIGN_IDENTITY="Quickey " ./scripts/package-app.sh`) so TCC grants now survive rebuilds — the script's stable-identity path, previously unused because it defaults to an identity named "Wink".

🤖 Generated with [Claude Code](https://claude.com/claude-code)