### PR TITLE
Updates: in-app phase visibility with gentle scheduled reminders (Issue #289, Stage 1)

### DIFF
--- a/Sources/Wink/Services/AppPreferences.swift
+++ b/Sources/Wink/Services/AppPreferences.swift
@@ -57,7 +57,10 @@ final class AppPreferences {
         UpdatePresentation(
             currentVersion: updateService?.currentVersion ?? Self.currentVersionString(),
             isConfigured: updateService?.isConfigured ?? false,
-            checkForUpdatesEnabled: updateService?.canCheckForUpdates ?? false,
+            // Keyed on configuration, not the transient canCheckForUpdates
+            // snapshot: repeat clicks while a session is in flight re-focus
+            // Sparkle's existing session, which is the desired recovery path.
+            checkForUpdatesEnabled: updateService?.isConfigured ?? false,
             automaticChecksEnabled: updateService?.automaticallyChecksForUpdates
                 ?? Self.boolValue(forInfoDictionaryKey: "SUEnableAutomaticChecks", default: true),
             automaticDownloadsEnabled: updateService?.automaticallyDownloadsUpdates
@@ -71,6 +74,11 @@ final class AppPreferences {
     /// mixed states (only reachable via `defaults write`) read as OFF and
     /// normalize on the next toggle.
     private(set) var automaticUpdatesEnabled: Bool = false
+
+    /// Mirrors of the update service's session state, stored so SwiftUI can
+    /// observe changes (the service itself is not @Observable).
+    private(set) var updatePhase: UpdatePhase = .idle
+    private(set) var lastUpdateCheckDate: Date?
 
     var launchAtLoginPresentation: LaunchAtLoginPresentation {
         switch launchAtLoginStatus {
@@ -149,6 +157,8 @@ final class AppPreferences {
         self.updateService = updateService
         self.userDefaults = userDefaults
         self.automaticUpdatesEnabled = Self.resolveAutomaticUpdatesEnabled(from: updateService)
+        self.updatePhase = updateService?.updatePhase ?? .idle
+        self.lastUpdateCheckDate = updateService?.lastUpdateCheckDate
         self.hyperKeyEnabled = initialHyperKeyEnabled
         self.shortcutsPaused = initialShortcutsPaused
         self.frontmostTargetBehavior = initialFrontmostTargetBehavior
@@ -160,6 +170,10 @@ final class AppPreferences {
         let launchAtLoginSnapshot = launchAtLoginService.snapshot
         self.launchAtLoginStatus = launchAtLoginSnapshot.status
         self.launchAtLoginAvailability = launchAtLoginSnapshot.availability
+
+        updateService?.onUpdateStateChange = { [weak self] in
+            self?.refreshUpdateState()
+        }
     }
 
     func refreshPermissions() {
@@ -202,6 +216,16 @@ final class AppPreferences {
 
     func checkForUpdates() {
         updateService?.checkForUpdates()
+    }
+
+    private func refreshUpdateState() {
+        guard let updateService else { return }
+        if updatePhase != updateService.updatePhase {
+            updatePhase = updateService.updatePhase
+        }
+        if lastUpdateCheckDate != updateService.lastUpdateCheckDate {
+            lastUpdateCheckDate = updateService.lastUpdateCheckDate
+        }
     }
 
     /// Drives both Sparkle flags (scheduled checks + background downloads)

--- a/Sources/Wink/Services/SparkleUpdateService.swift
+++ b/Sources/Wink/Services/SparkleUpdateService.swift
@@ -5,17 +5,40 @@ import Sparkle
 final class SparkleUpdateService: UpdateServicing {
     private let bundle: Bundle
     private let updaterController: SPUStandardUpdaterController?
+    private let delegateAdapter: SparkleDelegateAdapter?
+
+    private(set) var updatePhase: UpdatePhase = .idle {
+        didSet {
+            guard updatePhase != oldValue else { return }
+            onUpdateStateChange?()
+        }
+    }
+
+    private(set) var lastUpdateCheckDate: Date? {
+        didSet { onUpdateStateChange?() }
+    }
+
+    var onUpdateStateChange: (@MainActor () -> Void)?
 
     init(bundle: Bundle = .main) {
         self.bundle = bundle
 
         if Self.hasValidConfiguration(bundle: bundle) {
+            // The adapter enables Sparkle's gentle scheduled update reminders:
+            // scheduled checks route into Wink-owned surfaces (menu-bar
+            // popover row, settings card) instead of a stock alert detached
+            // from any Wink window. User-initiated checks still use Sparkle's
+            // standard UI.
+            let adapter = SparkleDelegateAdapter()
+            self.delegateAdapter = adapter
             self.updaterController = SPUStandardUpdaterController(
                 startingUpdater: true,
-                updaterDelegate: nil,
-                userDriverDelegate: nil
+                updaterDelegate: adapter,
+                userDriverDelegate: adapter
             )
+            adapter.service = self
         } else {
+            self.delegateAdapter = nil
             self.updaterController = nil
         }
     }
@@ -56,6 +79,29 @@ final class SparkleUpdateService: UpdateServicing {
         updaterController?.checkForUpdates(nil)
     }
 
+    // MARK: - Delegate glue (called by SparkleDelegateAdapter on the main actor)
+
+    fileprivate func handleFoundUpdate(version: String, stage: UpdatePhase.DeliveryStage) {
+        updatePhase = .forFoundUpdate(version: version, stage: stage)
+    }
+
+    fileprivate func handleUpdateSkipped() {
+        updatePhase = .idle
+    }
+
+    fileprivate func handleUpdateCycleFinished(isUserInitiated: Bool, errorMessage: String?) {
+        lastUpdateCheckDate = Date()
+        if let errorMessage {
+            // Sparkle already presents errors for user-initiated checks in
+            // its own UI; only scheduled failures need a Wink-owned surface.
+            if !isUserInitiated {
+                updatePhase = .error(message: errorMessage)
+            }
+        } else if case .error = updatePhase {
+            updatePhase = .idle
+        }
+    }
+
     private static func hasValidConfiguration(bundle: Bundle) -> Bool {
         hasNonEmptyString("SUFeedURL", bundle: bundle) &&
         hasNonEmptyString("SUPublicEDKey", bundle: bundle)
@@ -83,5 +129,96 @@ final class SparkleUpdateService: UpdateServicing {
         }
 
         return defaultValue
+    }
+}
+
+/// Bridges Sparkle's delegate callbacks onto `SparkleUpdateService`.
+///
+/// Sparkle's updater API is main-thread only, so every callback below arrives
+/// on the main thread and can assume main-actor isolation. Kept as a separate
+/// NSObject because both delegate protocols require NSObjectProtocol and the
+/// controller retains its delegates weakly.
+private final class SparkleDelegateAdapter: NSObject {
+    weak var service: SparkleUpdateService?
+
+    /// Sparkle error codes that are outcomes, not failures: no update found
+    /// (1001) and user-canceled installation (4007).
+    private static let ignoredErrorCodes: Set<Int> = [1001, 4007]
+
+    private static func deliveryStage(from state: SPUUserUpdateState) -> UpdatePhase.DeliveryStage {
+        switch state.stage {
+        case .notDownloaded:
+            return .notDownloaded
+        case .downloaded:
+            return .downloaded
+        case .installing:
+            return .installing
+        @unknown default:
+            return .notDownloaded
+        }
+    }
+
+    private func onMain(_ body: @escaping @MainActor (SparkleUpdateService) -> Void) {
+        MainActor.assumeIsolated { [weak service] in
+            guard let service else { return }
+            body(service)
+        }
+    }
+}
+
+extension SparkleDelegateAdapter: SPUStandardUserDriverDelegate {
+    var supportsGentleScheduledUpdateReminders: Bool { true }
+
+    func standardUserDriverShouldHandleShowingScheduledUpdate(
+        _ update: SUAppcastItem,
+        andInImmediateFocus immediateFocus: Bool
+    ) -> Bool {
+        // Wink handles scheduled updates gently (popover row + settings
+        // card) instead of a stock alert with no dock presence behind it.
+        false
+    }
+
+    func standardUserDriverWillHandleShowingUpdate(
+        _ handleShowingUpdate: Bool,
+        forUpdate update: SUAppcastItem,
+        state: SPUUserUpdateState
+    ) {
+        let version = update.displayVersionString
+        let stage = Self.deliveryStage(from: state)
+        onMain { service in
+            service.handleFoundUpdate(version: version, stage: stage)
+        }
+    }
+}
+
+extension SparkleDelegateAdapter: SPUUpdaterDelegate {
+    func updater(
+        _ updater: SPUUpdater,
+        userDidMake choice: SPUUserUpdateChoice,
+        forUpdate updateItem: SUAppcastItem,
+        state: SPUUserUpdateState
+    ) {
+        guard choice == .skip else { return }
+        onMain { service in
+            service.handleUpdateSkipped()
+        }
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+        error: (any Error)?
+    ) {
+        let isUserInitiated = updateCheck == .updates
+        let errorMessage: String?
+        if let error {
+            let nsError = error as NSError
+            errorMessage = Self.ignoredErrorCodes.contains(nsError.code) ? nil : nsError.localizedDescription
+        } else {
+            errorMessage = nil
+        }
+        onMain { service in
+            service.handleUpdateCycleFinished(isUserInitiated: isUserInitiated, errorMessage: errorMessage)
+        }
     }
 }

--- a/Sources/Wink/Services/UpdateServicing.swift
+++ b/Sources/Wink/Services/UpdateServicing.swift
@@ -8,6 +8,38 @@ struct UpdatePresentation: Equatable {
     let automaticDownloadsEnabled: Bool
 }
 
+/// User-visible update-session state, deliberately free of Sparkle types so
+/// SwiftUI and tests never import Sparkle (per docs/architecture.md the
+/// update seam keeps Sparkle out of the view layer).
+enum UpdatePhase: Equatable {
+    case idle
+    /// A check found an update that is not downloaded yet.
+    case available(version: String)
+    /// The update is downloaded or staged; it installs on quit or relaunch.
+    case ready(version: String)
+    /// A scheduled background check failed (feed unreachable, bad signature).
+    /// Cleared by the next check that completes without error.
+    case error(message: String)
+
+    /// Delivery progress of a found update, mirrored from the updater.
+    enum DeliveryStage: Equatable {
+        case notDownloaded
+        case downloaded
+        case installing
+    }
+
+    /// Pure mapping used by the Sparkle delegate glue; unit-testable without
+    /// Sparkle types.
+    static func forFoundUpdate(version: String, stage: DeliveryStage) -> UpdatePhase {
+        switch stage {
+        case .notDownloaded:
+            return .available(version: version)
+        case .downloaded, .installing:
+            return .ready(version: version)
+        }
+    }
+}
+
 @MainActor
 protocol UpdateServicing: AnyObject {
     var isConfigured: Bool { get }
@@ -18,6 +50,15 @@ protocol UpdateServicing: AnyObject {
     /// setters are no-ops while the updater is unconfigured.
     var automaticallyChecksForUpdates: Bool { get set }
     var automaticallyDownloadsUpdates: Bool { get set }
+    /// Current update-session phase. Changes are announced through
+    /// `onUpdateStateChange`.
+    var updatePhase: UpdatePhase { get }
+    /// When the updater last finished a check cycle (any outcome).
+    var lastUpdateCheckDate: Date? { get }
+    /// Single observer, invoked on the main actor after `updatePhase` or
+    /// `lastUpdateCheckDate` changes. AppPreferences mirrors the values into
+    /// observable stored state for SwiftUI.
+    var onUpdateStateChange: (@MainActor () -> Void)? { get set }
 
     func checkForUpdates()
 }

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -235,15 +235,34 @@ struct GeneralTabView: View {
             return "Automatic updates become available after this build is configured with a signed Sparkle appcast feed."
         }
 
+        // Live session state outranks the static behavior description.
+        switch preferences.updatePhase {
+        case .available(let version):
+            return "Version \(version) is available. Use Check for Updates… to review and install."
+        case .ready(let version):
+            return "Version \(version) is downloaded and installs when Wink quits. Use Check for Updates… to install now."
+        case .error(let message):
+            return "The last automatic update check failed: \(message)"
+        case .idle:
+            break
+        }
+
+        let behavior: String
         if presentation.automaticChecksEnabled && presentation.automaticDownloadsEnabled {
-            return "Automatic update checks and downloads are enabled."
+            behavior = "Automatic update checks and downloads are enabled."
+        } else if presentation.automaticChecksEnabled {
+            behavior = "Wink checks for updates automatically and asks before downloading."
+        } else {
+            behavior = "Automatic update checks are off. Use Check for Updates… to check manually."
         }
 
-        if presentation.automaticChecksEnabled {
-            return "Wink checks for updates automatically and asks before downloading."
+        guard let lastChecked = preferences.lastUpdateCheckDate else {
+            return behavior
         }
-
-        return "Automatic update checks are off. Use Check for Updates… to check manually."
+        let relative = RelativeDateTimeFormatter()
+        relative.unitsStyle = .full
+        let when = relative.localizedString(for: lastChecked, relativeTo: Date())
+        return behavior + " Last checked \(when)."
     }
 }
 

--- a/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
+++ b/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
@@ -92,6 +92,39 @@ final class MenuBarPopoverModel {
         preferences.updatePresentation.checkForUpdatesEnabled
     }
 
+    /// Explains the disabled Check for Updates row instead of leaving a bare
+    /// dead control (dev builds ship without an injected Sparkle feed).
+    var updateUnavailableCaption: String? {
+        preferences.updatePresentation.isConfigured
+            ? nil
+            : "Updates are available in packaged builds with a signed update feed."
+    }
+
+    struct UpdateNotice: Equatable {
+        let title: String
+        let subtitle: String
+    }
+
+    /// Non-modal surface for scheduled update findings (gentle reminders):
+    /// clicking runs a user-initiated check, which re-focuses Sparkle's
+    /// existing session in its standard UI.
+    var updateNotice: UpdateNotice? {
+        switch preferences.updatePhase {
+        case .idle, .error:
+            return nil
+        case .available(let version):
+            return UpdateNotice(
+                title: "Update available — v\(version)",
+                subtitle: "Click to review and install."
+            )
+        case .ready(let version):
+            return UpdateNotice(
+                title: "Update ready — v\(version)",
+                subtitle: "Installs when Wink quits. Click to install now."
+            )
+        }
+    }
+
     var filteredShortcutRows: [ShortcutRow] {
         let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedSearch.isEmpty else {
@@ -349,11 +382,27 @@ struct MenuBarPopoverView: View {
 
                 Divider().overlay(palette.hairline)
 
+                if let notice = model.updateNotice {
+                    MenuBarUpdateNoticeRow(notice: notice, action: model.checkForUpdates)
+
+                    Divider().overlay(palette.hairline)
+                }
+
                 MenuBarActionRow(
                     title: "Check for Updates…",
                     action: model.checkForUpdates
                 )
                 .disabled(!model.isCheckForUpdatesEnabled)
+
+                if let caption = model.updateUnavailableCaption {
+                    Text(caption)
+                        .font(WinkType.labelSmall)
+                        .foregroundStyle(palette.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 12)
+                        .padding(.bottom, 8)
+                }
 
                 Divider().overlay(palette.hairline)
 
@@ -510,6 +559,40 @@ private struct MenuBarToggleRow: View {
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
+    }
+}
+
+private struct MenuBarUpdateNoticeRow: View {
+    @Environment(\.winkPalette) private var palette
+
+    let notice: MenuBarPopoverModel.UpdateNotice
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "arrow.down.circle.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(palette.accent)
+                    .padding(.top, 1)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(notice.title)
+                        .font(WinkType.bodyMedium)
+                        .foregroundStyle(palette.textPrimary)
+                    Text(notice.subtitle)
+                        .font(WinkType.labelSmall)
+                        .foregroundStyle(palette.textSecondary)
+                }
+
+                Spacer(minLength: 8)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("MenuBarUpdateNoticeRow")
     }
 }
 

--- a/Tests/WinkTests/AppPreferencesTests.swift
+++ b/Tests/WinkTests/AppPreferencesTests.swift
@@ -317,6 +317,55 @@ func setAutomaticUpdatesEnabled_isNoOpWithoutService() {
 }
 
 @Test @MainActor
+func updatePhase_mirrorsServiceStateChangesIntoObservableStorage() {
+    let service = FakeUpdateService(
+        isConfigured: true,
+        canCheckForUpdates: true,
+        currentVersion: "0.5.0",
+        automaticallyChecksForUpdates: true,
+        automaticallyDownloadsUpdates: true
+    )
+    let preferences = makePreferences(updateService: service)
+    #expect(preferences.updatePhase == .idle)
+    #expect(preferences.lastUpdateCheckDate == nil)
+
+    let checkedAt = Date(timeIntervalSince1970: 1_750_000_000)
+    service.simulateUpdateState(phase: .available(version: "0.6.0"), lastCheck: checkedAt)
+
+    #expect(preferences.updatePhase == .available(version: "0.6.0"))
+    #expect(preferences.lastUpdateCheckDate == checkedAt)
+
+    service.simulateUpdateState(phase: .ready(version: "0.6.0"))
+    #expect(preferences.updatePhase == .ready(version: "0.6.0"))
+
+    service.simulateUpdateState(phase: .idle)
+    #expect(preferences.updatePhase == .idle)
+}
+
+@Test @MainActor
+func updatePresentation_checkForUpdatesEnabledFollowsConfigurationNotCanCheckSnapshot() {
+    let service = FakeUpdateService(
+        isConfigured: true,
+        canCheckForUpdates: false,
+        currentVersion: "0.5.0",
+        automaticallyChecksForUpdates: true,
+        automaticallyDownloadsUpdates: true
+    )
+    let preferences = makePreferences(updateService: service)
+
+    // A session in flight makes canCheckForUpdates false, but the button
+    // must stay enabled so a repeat click re-focuses the session.
+    #expect(preferences.updatePresentation.checkForUpdatesEnabled == true)
+}
+
+@Test
+func updatePhaseMapping_notDownloadedIsAvailable_downloadedAndInstallingAreReady() {
+    #expect(UpdatePhase.forFoundUpdate(version: "1.2", stage: .notDownloaded) == .available(version: "1.2"))
+    #expect(UpdatePhase.forFoundUpdate(version: "1.2", stage: .downloaded) == .ready(version: "1.2"))
+    #expect(UpdatePhase.forFoundUpdate(version: "1.2", stage: .installing) == .ready(version: "1.2"))
+}
+
+@Test @MainActor
 func initRestoresPausedShortcutPreferenceIntoRuntimeStatus() throws {
     let suiteName = "AppPreferencesTests.initRestoresPausedShortcutPreferenceIntoRuntimeStatus"
     let defaults = try #require(UserDefaults(suiteName: suiteName))
@@ -538,6 +587,9 @@ private final class FakeUpdateService: UpdateServicing {
     var automaticallyChecksForUpdates: Bool
     var automaticallyDownloadsUpdates: Bool
     private(set) var didRequestManualCheck = false
+    private(set) var updatePhase: UpdatePhase = .idle
+    private(set) var lastUpdateCheckDate: Date?
+    var onUpdateStateChange: (@MainActor () -> Void)?
 
     init(
         isConfigured: Bool,
@@ -555,6 +607,14 @@ private final class FakeUpdateService: UpdateServicing {
 
     func checkForUpdates() {
         didRequestManualCheck = true
+    }
+
+    func simulateUpdateState(phase: UpdatePhase, lastCheck: Date? = nil) {
+        updatePhase = phase
+        if let lastCheck {
+            lastUpdateCheckDate = lastCheck
+        }
+        onUpdateStateChange?()
     }
 }
 

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
@@ -93,6 +93,56 @@ struct MenuBarPopoverViewTests {
     }
 
     @Test @MainActor
+    func updateNoticeReflectsMirroredPhase() throws {
+        let defaults = try #require(UserDefaults(suiteName: "MenuBarPopoverViewTests.updateNotice"))
+        defaults.removePersistentDomain(forName: "MenuBarPopoverViewTests.updateNotice")
+        let updateService = FakeUpdateService(
+            isConfigured: true,
+            canCheckForUpdates: true,
+            currentVersion: "0.5.0",
+            automaticallyChecksForUpdates: true,
+            automaticallyDownloadsUpdates: true
+        )
+        let context = makePopoverContext(
+            shortcuts: [],
+            usageTotal: 0,
+            userDefaults: defaults,
+            updateService: updateService
+        )
+
+        #expect(context.model.updateNotice == nil)
+        #expect(context.model.updateUnavailableCaption == nil)
+
+        updateService.simulateUpdateState(phase: .available(version: "0.6.0"))
+        #expect(context.model.updateNotice?.title == "Update available — v0.6.0")
+
+        updateService.simulateUpdateState(phase: .ready(version: "0.6.0"))
+        #expect(context.model.updateNotice?.title == "Update ready — v0.6.0")
+
+        // Errors surface in the settings card, not as a popover notice row.
+        updateService.simulateUpdateState(phase: .error(message: "feed unreachable"))
+        #expect(context.model.updateNotice == nil)
+    }
+
+    @Test @MainActor
+    func unconfiguredUpdaterDisablesCheckRowWithExplanatoryCaption() {
+        let context = makePopoverContext(
+            shortcuts: [],
+            usageTotal: 0,
+            updateService: FakeUpdateService(
+                isConfigured: false,
+                canCheckForUpdates: false,
+                currentVersion: "0.5.0",
+                automaticallyChecksForUpdates: true,
+                automaticallyDownloadsUpdates: true
+            )
+        )
+
+        #expect(context.model.isCheckForUpdatesEnabled == false)
+        #expect(context.model.updateUnavailableCaption != nil)
+    }
+
+    @Test @MainActor
     func refreshBuildsEvenTwentyFourBarHistogramFromTodayTotal() async {
         let context = makePopoverContext(
             shortcuts: [],
@@ -424,6 +474,9 @@ private final class FakeUpdateService: UpdateServicing {
     var automaticallyChecksForUpdates: Bool
     var automaticallyDownloadsUpdates: Bool
     private(set) var didRequestManualCheck = false
+    private(set) var updatePhase: UpdatePhase = .idle
+    private(set) var lastUpdateCheckDate: Date?
+    var onUpdateStateChange: (@MainActor () -> Void)?
 
     init(
         isConfigured: Bool,
@@ -441,6 +494,14 @@ private final class FakeUpdateService: UpdateServicing {
 
     func checkForUpdates() {
         didRequestManualCheck = true
+    }
+
+    func simulateUpdateState(phase: UpdatePhase, lastCheck: Date? = nil) {
+        updatePhase = phase
+        if let lastCheck {
+            lastUpdateCheckDate = lastCheck
+        }
+        onUpdateStateChange?()
     }
 }
 


### PR DESCRIPTION
Fixes #289

## Summary
- `UpdatePhase` (idle / available / ready / error) is a Sparkle-free enum published through `UpdateServicing` and mirrored into observable stored state on `AppPreferences`; the found-update mapping (`notDownloaded → available`, `downloaded/installing → ready`) is a pure function with unit tests
- `SparkleUpdateService` installs a delegate adapter implementing **`SPUStandardUserDriverDelegate` gentle reminders** (`supportsGentleScheduledUpdateReminders = true`, scheduled showings declined): scheduled checks no longer pop a stock alert detached from any Wink surface — the update appears as a menu-bar popover notice row and live text in the settings update card. User-initiated checks keep Sparkle's standard UI; a repeat click re-focuses an in-flight session
- `SPUUpdaterDelegate` maps cycle completion to `lastUpdateCheckDate` and scheduled-check failures to `.error` (ignoring "no update" 1001 and user-canceled 4007, verified against the vendored `SUErrors.h`); skipping a version clears the notice
- Popover: notice row for available/ready ("Update available — vX" / "Update ready — vX, installs when Wink quits"), explanatory caption under the disabled Check row on unconfigured dev builds
- `checkForUpdatesEnabled` now keys on `isConfigured` instead of the unobserved `canCheckForUpdates` snapshot (stale-state finding from the audit)
- Settings card: live phase text plus "Last checked …" (`RelativeDateTimeFormatter`)
- Stage 2 (full custom `SPUUserDriver`, PomoFox-style in-app progress) remains open in #289's staged plan if gentle reminders prove insufficient

## Testing
- [x] `swift test` (399 tests, 40 suites — 8 new: phase mapping, AppPreferences mirroring, popover notice/caption models, configuration-keyed gating)
- [x] Additional validation noted below when needed
- [x] Runtime validation (feed-configured packaged build, backdated `SULastCheckTime` to force an overdue scheduled check at launch): the check ran with **no stock alert and no focus steal**, and the settings card rendered "The last automatic update check failed: An error occurred in retrieving update information…" — the full delegate → phase → mirror → SwiftUI chain live. Validation defaults removed afterwards; user's installed app restored
- [ ] available/ready notice against a real appcast serving a newer signed version — same delegate chain, unit-covered; full live validation lands with the first real release feed

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR). (Update seam still keeps Sparkle types out of SwiftUI per docs/architecture.md.)
- [x] No new references to `docs/archive/` as a current source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)