### PR TITLE
Onboarding: one-time post-update What's New panel (Issue #290)

### DIFF
--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -22,6 +22,7 @@ final class AppController {
     }
 
     static let firstLaunchCompletedDefaultsKey = "com.wink.firstLaunchCompleted"
+    static let lastSeenVersionDefaultsKey = "com.wink.lastSeenVersion"
 
     private let shortcutStore = ShortcutStore()
     private let persistenceService = PersistenceService()
@@ -30,6 +31,7 @@ final class AppController {
     private let appBundleLocator = AppBundleLocator()
     private let userDefaults: UserDefaults
     private lazy var updateService = SparkleUpdateService()
+    private let whatsNewPresenter = WhatsNewPresenter()
     private lazy var appSwitcher = AppSwitcher()
     private lazy var settingsLauncher = SettingsLauncher(userDefaults: userDefaults)
     private lazy var settingsShortcutStatusProvider = ShortcutStatusProvider()
@@ -118,11 +120,30 @@ final class AppController {
             startShortcutManager: { shortcutManager.start() }
         )
 
+        // Read the onboarded state before consumeFirstLaunchFlag marks it, so
+        // the What's New gate can tell a fresh install from an upgrade.
+        let hasLaunchedBefore = userDefaults.bool(forKey: Self.firstLaunchCompletedDefaultsKey)
+
         if Self.consumeFirstLaunchFlag(
             userDefaults: userDefaults,
             hasExistingShortcuts: !shortcutStore.shortcuts.isEmpty
         ) {
             openSettings()
+        }
+
+        let currentVersion = Self.currentVersionString()
+        let notes = WhatsNewCatalog.notes(for: currentVersion)
+        if Self.consumeWhatsNewGate(
+            userDefaults: userDefaults,
+            currentVersion: currentVersion,
+            hasLaunchedBefore: hasLaunchedBefore,
+            hasNotes: !notes.isEmpty
+        ) {
+            // Slight delay so the panel appears after launch settles; it is
+            // non-activating and never steals focus.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+                self?.whatsNewPresenter.present(version: currentVersion, notes: notes)
+            }
         }
     }
 
@@ -176,5 +197,30 @@ final class AppController {
         guard !userDefaults.bool(forKey: firstLaunchCompletedDefaultsKey) else { return false }
         userDefaults.set(true, forKey: firstLaunchCompletedDefaultsKey)
         return !hasExistingShortcuts
+    }
+
+    /// Returns true exactly once per version change on an already-onboarded
+    /// install (fresh installs only record the version). Always writes back
+    /// `lastSeenVersion` synchronously, mirroring `consumeFirstLaunchFlag`'s
+    /// crash-safe consume-then-act shape. The decision itself is
+    /// `LaunchGates.shouldShowWhatsNew` (pure, unit-tested).
+    static func consumeWhatsNewGate(
+        userDefaults: UserDefaults,
+        currentVersion: String,
+        hasLaunchedBefore: Bool,
+        hasNotes: Bool
+    ) -> Bool {
+        let lastSeenVersion = userDefaults.string(forKey: lastSeenVersionDefaultsKey)
+        userDefaults.set(currentVersion, forKey: lastSeenVersionDefaultsKey)
+        return LaunchGates.shouldShowWhatsNew(
+            currentVersion: currentVersion,
+            hasLaunchedBefore: hasLaunchedBefore,
+            lastSeenVersion: lastSeenVersion,
+            hasNotes: hasNotes
+        )
+    }
+
+    private static func currentVersionString(bundle: Bundle = .main) -> String {
+        bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.0.0"
     }
 }

--- a/Sources/Wink/Services/LaunchGates.swift
+++ b/Sources/Wink/Services/LaunchGates.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Pure launch-time decision for the post-update "What's New" surface.
+///
+/// Semantics (mirrors the PomoFox `LaunchGates` reference):
+/// - Fresh installs never see What's New — the first launch only records the
+///   version.
+/// - A later launch shows it exactly once when the version changed since the
+///   last recorded one and that version has notes. `lastSeenVersion == nil`
+///   on an already-onboarded install (upgrade from a pre-feature build)
+///   counts as changed — the user did just update.
+///
+/// The caller is responsible for writing back `lastSeenVersion` after
+/// deciding (see `AppController.consumeWhatsNewGate`).
+enum LaunchGates {
+    static func shouldShowWhatsNew(
+        currentVersion: String,
+        hasLaunchedBefore: Bool,
+        lastSeenVersion: String?,
+        hasNotes: Bool
+    ) -> Bool {
+        guard hasLaunchedBefore else { return false }
+        return lastSeenVersion != currentVersion && hasNotes
+    }
+}
+
+/// One highlighted change in a release, rendered in the What's New panel.
+struct WhatsNewNote: Equatable, Sendable {
+    /// SF Symbol name.
+    let symbolName: String
+    let title: String
+    let detail: String
+}
+
+/// Version → curated highlights. Versions without an entry never present a
+/// What's New panel (the gate's `hasNotes` input). Keep entries short — the
+/// full notes live on the GitHub Releases page the panel links to; the
+/// authoritative prose is CHANGELOG.md.
+enum WhatsNewCatalog {
+    static let entries: [String: [WhatsNewNote]] = [
+        "0.5.0": [
+            WhatsNewNote(
+                symbolName: "keyboard",
+                title: "Toggle apps with global shortcuts",
+                detail: "Press once to open or focus the target app, press again to hide it."
+            ),
+            WhatsNewNote(
+                symbolName: "capslock",
+                title: "Hyper key path",
+                detail: "Hold Caps Lock as a Hyper modifier alongside normal shortcut combos."
+            ),
+            WhatsNewNote(
+                symbolName: "square.and.arrow.up",
+                title: "Shareable shortcut sets",
+                detail: "Import and export .winkrecipe files, with usage insights in Settings."
+            ),
+        ],
+    ]
+
+    static func notes(for version: String) -> [WhatsNewNote] {
+        entries[version] ?? []
+    }
+}

--- a/Sources/Wink/UI/WhatsNewPanel.swift
+++ b/Sources/Wink/UI/WhatsNewPanel.swift
@@ -1,0 +1,116 @@
+import AppKit
+import SwiftUI
+
+/// Presents the one-time post-update "What's New" panel.
+///
+/// A non-activating floating `NSPanel` ordered front without key status: an
+/// accessory app must never steal focus from the user's current work just to
+/// announce an update (issue #290).
+@MainActor
+final class WhatsNewPresenter {
+    private var panel: NSPanel?
+
+    func present(version: String, notes: [WhatsNewNote]) {
+        guard panel == nil, !notes.isEmpty else { return }
+
+        let hosting = NSHostingView(rootView: WhatsNewView(
+            version: version,
+            notes: notes,
+            dismiss: { [weak self] in self?.dismiss() }
+        ))
+        hosting.frame = NSRect(origin: .zero, size: hosting.fittingSize)
+
+        let panel = NSPanel(
+            contentRect: hosting.frame,
+            styleMask: [.titled, .closable, .nonactivatingPanel, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.isMovableByWindowBackground = true
+        panel.level = .floating
+        panel.isReleasedWhenClosed = false
+        panel.contentView = hosting
+        panel.center()
+        panel.orderFrontRegardless()
+        self.panel = panel
+    }
+
+    private func dismiss() {
+        panel?.orderOut(nil)
+        panel = nil
+    }
+}
+
+struct WhatsNewView: View {
+    let version: String
+    let notes: [WhatsNewNote]
+    let dismiss: () -> Void
+
+    var body: some View {
+        WhatsNewContent(version: version, notes: notes, dismiss: dismiss)
+            .winkChromeRoot()
+    }
+}
+
+private struct WhatsNewContent: View {
+    @Environment(\.winkPalette) private var palette
+
+    let version: String
+    let notes: [WhatsNewNote]
+    let dismiss: () -> Void
+
+    private static let releasesURL = URL(string: "https://github.com/xrf9268-hue/Wink/releases")!
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 10) {
+                WinkAppIcon(size: 36)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("What's New in Wink")
+                        .font(WinkType.tabTitle)
+                        .foregroundStyle(palette.textPrimary)
+                    Text("Version \(version)")
+                        .font(WinkType.labelSmall)
+                        .foregroundStyle(palette.textSecondary)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(notes, id: \.title) { note in
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: note.symbolName)
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(palette.accent)
+                            .frame(width: 22, alignment: .center)
+                            .padding(.top, 1)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(note.title)
+                                .font(WinkType.bodyMedium)
+                                .foregroundStyle(palette.textPrimary)
+                            Text(note.detail)
+                                .font(WinkType.labelSmall)
+                                .foregroundStyle(palette.textSecondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+            }
+
+            HStack {
+                Link("Full release notes", destination: Self.releasesURL)
+                    .font(WinkType.labelSmall)
+                    .foregroundStyle(palette.textTertiary)
+
+                Spacer()
+
+                Button("OK", action: dismiss)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 380)
+        .background(palette.windowBg)
+    }
+}

--- a/Tests/WinkTests/LaunchGatesTests.swift
+++ b/Tests/WinkTests/LaunchGatesTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import Wink
+
+@Suite("Launch gates")
+struct LaunchGatesTests {
+    @Test
+    func freshInstallNeverShowsWhatsNew() {
+        #expect(LaunchGates.shouldShowWhatsNew(
+            currentVersion: "0.5.0",
+            hasLaunchedBefore: false,
+            lastSeenVersion: nil,
+            hasNotes: true
+        ) == false)
+    }
+
+    @Test
+    func sameVersionDoesNotShowAgain() {
+        #expect(LaunchGates.shouldShowWhatsNew(
+            currentVersion: "0.5.0",
+            hasLaunchedBefore: true,
+            lastSeenVersion: "0.5.0",
+            hasNotes: true
+        ) == false)
+    }
+
+    @Test
+    func versionChangeWithNotesShows() {
+        #expect(LaunchGates.shouldShowWhatsNew(
+            currentVersion: "0.6.0",
+            hasLaunchedBefore: true,
+            lastSeenVersion: "0.5.0",
+            hasNotes: true
+        ) == true)
+    }
+
+    @Test
+    func upgradeFromPreFeatureBuildCountsAsVersionChange() {
+        #expect(LaunchGates.shouldShowWhatsNew(
+            currentVersion: "0.6.0",
+            hasLaunchedBefore: true,
+            lastSeenVersion: nil,
+            hasNotes: true
+        ) == true)
+    }
+
+    @Test
+    func versionWithoutNotesStaysSilent() {
+        #expect(LaunchGates.shouldShowWhatsNew(
+            currentVersion: "0.6.0",
+            hasLaunchedBefore: true,
+            lastSeenVersion: "0.5.0",
+            hasNotes: false
+        ) == false)
+    }
+
+    @Test @MainActor
+    func consumeWhatsNewGateFiresOncePerVersionChangeAndRecordsVersion() throws {
+        let suiteName = "LaunchGatesTests.consumeGate"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+
+        // Fresh install: records the version silently.
+        #expect(AppController.consumeWhatsNewGate(
+            userDefaults: defaults,
+            currentVersion: "0.5.0",
+            hasLaunchedBefore: false,
+            hasNotes: true
+        ) == false)
+        #expect(defaults.string(forKey: AppController.lastSeenVersionDefaultsKey) == "0.5.0")
+
+        // Same version relaunch: silent.
+        #expect(AppController.consumeWhatsNewGate(
+            userDefaults: defaults,
+            currentVersion: "0.5.0",
+            hasLaunchedBefore: true,
+            hasNotes: true
+        ) == false)
+
+        // Upgrade: fires exactly once.
+        #expect(AppController.consumeWhatsNewGate(
+            userDefaults: defaults,
+            currentVersion: "0.6.0",
+            hasLaunchedBefore: true,
+            hasNotes: true
+        ) == true)
+        #expect(defaults.string(forKey: AppController.lastSeenVersionDefaultsKey) == "0.6.0")
+
+        // Relaunch after the upgrade: silent again.
+        #expect(AppController.consumeWhatsNewGate(
+            userDefaults: defaults,
+            currentVersion: "0.6.0",
+            hasLaunchedBefore: true,
+            hasNotes: true
+        ) == false)
+    }
+
+    @Test
+    func catalogHasNotesForTheCurrentReleaseLine() {
+        #expect(!WhatsNewCatalog.notes(for: "0.5.0").isEmpty)
+        #expect(WhatsNewCatalog.notes(for: "0.0.1").isEmpty)
+    }
+}


### PR DESCRIPTION
Fixes #290

## Summary
- `LaunchGates.shouldShowWhatsNew` — pure launch-time decision (PomoFox `LaunchGates.swift:13-25` pattern): fresh installs record the version silently; a later launch shows the panel exactly once when the version changed and that version has catalog notes; `nil` lastSeenVersion on an onboarded install (upgrade from a pre-feature build) counts as changed
- `AppController.consumeWhatsNewGate` — crash-safe consume-then-act seam matching the existing `consumeFirstLaunchFlag` style; the onboarded flag is read **before** the first-launch gate marks it, so fresh installs and upgrades are distinguished on the same launch and the first-run settings-open path is unchanged
- `WhatsNewCatalog` — embedded per-version highlights (0.5.0 seeded from CHANGELOG.md; versions without an entry stay silent); the panel links to GitHub Releases for full notes. Chosen over fetching appcast note files (which are external URLs) per the issue's pick-one instruction
- `WhatsNewPresenter` — non-activating floating `NSPanel` (`orderFrontRegardless`, never key): an accessory app must not steal focus to announce an update; shown 0.8s post-launch, dismissible via OK/close

## Testing
- [x] `swift test` (401 tests, 41 suites — 7 new in LaunchGatesTests: decision truth table, once-per-version consume semantics, catalog coverage)
- [x] Additional validation noted below when needed
- [x] Runtime validation (packaged build, `lastSeenVersion` backdated to 0.4.0): panel appeared ~1s after launch **with focus remaining on the previously frontmost app** (verified via System Events), rendered icon + three notes + release-notes link + OK; `lastSeenVersion` recorded 0.5.0; relaunch showed no panel; installed app restored afterwards

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Release discipline follow-up: add a `WhatsNewCatalog` entry per release alongside the CHANGELOG section (kept deliberately optional — a version without an entry simply stays silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)