### PR TITLE
docs: local "Wink" signing identity and shared-TCC model

### DIFF
--- a/docs/signing-and-release.md
+++ b/docs/signing-and-release.md
@@ -62,6 +62,53 @@ Release-style signing is controlled by environment variables passed to `scripts/
 - `SPARKLE_FEED_URL`
 - `SPARKLE_PUBLIC_ED_KEY`
 
+### Local development signing identity ("Wink")
+
+`SIGN_IDENTITY` defaults to `Wink`. Keep a self-signed code-signing
+certificate named exactly **Wink** in the login keychain so local packages get
+a **stable designated requirement** instead of the ad-hoc fallback:
+
+- Ad-hoc signatures change every rebuild, which silently invalidates the TCC
+  grants (Accessibility, Input Monitoring) for `build/Wink.app` — the e2e
+  harness then fails capture readiness (`ax=false im=false`) until the rows
+  are manually re-added in System Settings.
+- TCC keys grants by bundle id plus the granted copy's code requirement.
+  With `/Applications/Wink.app` and `build/Wink.app` signed by the **same**
+  "Wink" certificate, one grant covers both copies and survives rebuilds.
+  Do not let one copy drift back to ad-hoc: re-granting a differently signed
+  copy of `com.wink.app` silently breaks the other copy's permissions.
+
+Create the certificate either with Keychain Access → Certificate Assistant →
+Create a Certificate (Name: `Wink`, Type: Code Signing), or from a terminal:
+
+```bash
+cat > /tmp/wink-cert.cnf <<'EOF'
+[req]
+distinguished_name = dn
+x509_extensions = v3_codesign
+prompt = no
+[dn]
+CN = Wink
+[v3_codesign]
+basicConstraints = critical,CA:FALSE
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,codeSigning
+subjectKeyIdentifier = hash
+EOF
+openssl req -x509 -newkey rsa:2048 -keyout /tmp/wink-key.pem \
+  -out /tmp/wink-cert.pem -days 3650 -nodes -config /tmp/wink-cert.cnf
+openssl pkcs12 -export -legacy -out /tmp/wink.p12 \
+  -inkey /tmp/wink-key.pem -in /tmp/wink-cert.pem -passout pass:winktmp
+security import /tmp/wink.p12 -k ~/Library/Keychains/login.keychain-db \
+  -P winktmp -T /usr/bin/codesign
+security add-trusted-cert -p codeSign \
+  -k ~/Library/Keychains/login.keychain-db /tmp/wink-cert.pem   # approve the dialog
+rm -f /tmp/wink-key.pem /tmp/wink.p12 /tmp/wink-cert.pem /tmp/wink-cert.cnf
+```
+
+(`-legacy` matters: macOS `security import` rejects OpenSSL 3's default
+PKCS#12 encoding with "MAC verification failed".)
+
 ### Sparkle update ZIP
 
 ```bash

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -171,10 +171,11 @@ rm -rf \
     "$FRAMEWORKS_DIR/Sparkle.framework/XPCServices"
 
 # Sign with a stable identity if available; fall back to ad-hoc.
-# A stable identity (e.g. "Wink Dev" self-signed cert) lets TCC
-# permissions survive across rebuilds. Create one via:
-#   Keychain Access → Certificate Assistant → Create a Certificate
-#   Name: "Wink Dev", Type: Code Signing
+# A stable identity (the default is a self-signed cert named exactly "Wink")
+# gives a stable designated requirement, so TCC grants survive rebuilds and
+# one grant covers every same-signed copy of com.wink.app. See
+# docs/signing-and-release.md "Local development signing identity" for the
+# Keychain Access and openssl recipes.
 if security find-identity -v -p codesigning 2>/dev/null | grep -Fq "$SIGN_IDENTITY"; then
     echo "==> Signing with '$SIGN_IDENTITY'..."
     SELECTED_SIGN_IDENTITY="$SIGN_IDENTITY"


### PR DESCRIPTION
Fixes #297

## Summary
- Document the local development signing identity in `docs/signing-and-release.md`: `SIGN_IDENTITY` defaults to `Wink`; keeping a self-signed cert with that exact name makes TCC grants survive rebuilds (stable designated requirement), and one grant covers both `/Applications/Wink.app` and `build/Wink.app` when they share the signature
- Warn against mixed signing: re-granting a differently signed copy of `com.wink.app` silently breaks the other copy's permissions (this bit us during Issue #288 validation)
- Include both creation recipes (Keychain Access and openssl, noting OpenSSL 3's `-legacy` PKCS#12 requirement for `security import`)
- Update the stale `package-app.sh` comment that referenced a "Wink Dev" cert name, which the default `SIGN_IDENTITY="Wink"` would also substring-match but nobody had created (comment-only change; no script logic touched)

## Testing
- [x] `swift test` not applicable (docs + shell comment only); `bash -n scripts/package-app.sh` passes
- [x] Additional validation noted below when needed
- [x] The documented flow is exactly what was performed live on 2026-07-08: "Wink" cert created via the openssl recipe, `./scripts/package-app.sh` picked it up by default (`Authority=Wink`, `codesign --verify --deep --strict` clean), both app copies verified `ax=true im=true eventTap=true` under a single grant, and the full e2e suite passed 6/6 on the identically-signed build

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)