### PR TITLE
Updates: full in-app update UI via custom SPUUserDriver (Issue #298)

### DIFF
--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -32,6 +32,7 @@ final class AppController {
     private let userDefaults: UserDefaults
     private lazy var updateService = SparkleUpdateService()
     private let whatsNewPresenter = WhatsNewPresenter()
+    private let updatePanelPresenter = UpdatePanelPresenter()
     private lazy var appSwitcher = AppSwitcher()
     private lazy var settingsLauncher = SettingsLauncher(userDefaults: userDefaults)
     private lazy var settingsShortcutStatusProvider = ShortcutStatusProvider()
@@ -108,6 +109,16 @@ final class AppController {
         // Prevents AX calls from blocking threads for too long when apps are unresponsive.
         // Reference: alt-tab-macos
         AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide(), 1.0)
+
+        // Wire the update panel before the updater starts so a launch-time
+        // resumed session can present immediately.
+        updateService.presentUpdatePanel = { [weak self] activate in
+            guard let self else { return }
+            self.updatePanelPresenter.present(preferences: self.appPreferences, activate: activate)
+        }
+        updateService.dismissUpdatePanel = { [weak self] in
+            self?.updatePanelPresenter.dismiss()
+        }
 
         Self.runStartupSequence(
             startUpdateService: { _ = updateService },

--- a/Sources/Wink/Services/AppPreferences.swift
+++ b/Sources/Wink/Services/AppPreferences.swift
@@ -228,6 +228,44 @@ final class AppPreferences {
         }
     }
 
+    // MARK: - Update session actions (update panel / popover)
+
+    func installUpdateNow() {
+        updateService?.installUpdateNow()
+    }
+
+    func remindUpdateLater() {
+        updateService?.remindUpdateLater()
+    }
+
+    func skipUpdateVersion() {
+        updateService?.skipUpdateVersion()
+    }
+
+    func cancelUpdateOperation() {
+        updateService?.cancelUpdateOperation()
+    }
+
+    func acknowledgeUpdateResult() {
+        updateService?.acknowledgeUpdateResult()
+    }
+
+    /// Routes the update panel's close button to the session action that
+    /// matches the current phase, so closing the window never leaks a held
+    /// Sparkle reply or acknowledgement.
+    func handleUpdatePanelCloseRequest() {
+        switch updatePhase {
+        case .checking, .downloading:
+            cancelUpdateOperation()
+        case .available, .ready, .extracting, .installing:
+            remindUpdateLater()
+        case .upToDate, .error:
+            acknowledgeUpdateResult()
+        case .idle:
+            break
+        }
+    }
+
     /// Drives both Sparkle flags (scheduled checks + background downloads)
     /// as one user-facing switch. The mirrored state is read back from the
     /// service after the write so it only reflects what actually persisted.

--- a/Sources/Wink/Services/SparkleUpdateService.swift
+++ b/Sources/Wink/Services/SparkleUpdateService.swift
@@ -1,11 +1,27 @@
+import AppKit
 import Foundation
 import Sparkle
 
+/// Sparkle 2 wrapper built on a raw `SPUUpdater` with a **custom**
+/// `SPUUserDriver` (Issue #298, Stage 2): every update-session state renders
+/// in Wink-owned UI instead of Sparkle's stock windows. The class itself is
+/// the user driver (the protocol is `NS_SWIFT_UI_ACTOR`, so every callback
+/// arrives on the main actor); it translates callbacks into `UpdatePhase`
+/// and holds Sparkle's action callbacks so the panel only calls semantic
+/// methods.
+///
+/// Session semantics for an LSUIElement app:
+/// - User-initiated checks present the update panel with focus.
+/// - Scheduled checks stay gentle: found/ready updates hold their reply and
+///   surface only through `updatePhase` (popover notice row, settings card);
+///   scheduled up-to-date/error outcomes are acknowledged immediately so the
+///   session never leaks (an unconsumed acknowledgement leaves Sparkle's
+///   `sessionInProgress` stuck and silently kills all later checks).
 @MainActor
-final class SparkleUpdateService: UpdateServicing {
+final class SparkleUpdateService: NSObject, UpdateServicing {
     private let bundle: Bundle
-    private let updaterController: SPUStandardUpdaterController?
-    private let delegateAdapter: SparkleDelegateAdapter?
+    private var updater: SPUUpdater?
+    private let updaterDelegate: SparkleUpdaterDelegate
 
     private(set) var updatePhase: UpdatePhase = .idle {
         didSet {
@@ -20,35 +36,58 @@ final class SparkleUpdateService: UpdateServicing {
 
     var onUpdateStateChange: (@MainActor () -> Void)?
 
+    /// Panel host hooks, injected by AppController. `activate` distinguishes
+    /// user-initiated presentations (panel takes focus) from session resumes.
+    var presentUpdatePanel: (@MainActor (_ activate: Bool) -> Void)?
+    var dismissUpdatePanel: (@MainActor () -> Void)?
+
+    // MARK: - In-flight Sparkle callbacks (one-shot; see Optional.take())
+
+    private var checkCancellation: (() -> Void)?
+    private var downloadCancellation: (() -> Void)?
+    private var updateReply: ((SPUUserUpdateChoice) -> Void)?
+    private var readyReply: ((SPUUserUpdateChoice) -> Void)?
+    private var pendingAcknowledgement: (() -> Void)?
+
+    private var sessionIsUserInitiated = false
+    private var downloadVersion = ""
+    private var downloadReceived: UInt64 = 0
+    private var downloadExpected: UInt64 = 0
+    /// URLSession reports every chunk; publishing each one re-renders SwiftUI
+    /// per chunk. Throttle to ~10Hz — the extracting phase that follows
+    /// covers any missed final chunk.
+    private var lastDownloadPublish: Date = .distantPast
+
     init(bundle: Bundle = .main) {
         self.bundle = bundle
+        self.updaterDelegate = SparkleUpdaterDelegate()
+        super.init()
 
-        if Self.hasValidConfiguration(bundle: bundle) {
-            // The adapter enables Sparkle's gentle scheduled update reminders:
-            // scheduled checks route into Wink-owned surfaces (menu-bar
-            // popover row, settings card) instead of a stock alert detached
-            // from any Wink window. User-initiated checks still use Sparkle's
-            // standard UI.
-            let adapter = SparkleDelegateAdapter()
-            self.delegateAdapter = adapter
-            self.updaterController = SPUStandardUpdaterController(
-                startingUpdater: true,
-                updaterDelegate: adapter,
-                userDriverDelegate: adapter
-            )
-            adapter.service = self
-        } else {
-            self.delegateAdapter = nil
-            self.updaterController = nil
+        guard Self.hasValidConfiguration(bundle: bundle) else { return }
+
+        let updater = SPUUpdater(
+            hostBundle: bundle,
+            applicationBundle: bundle,
+            userDriver: self,
+            delegate: updaterDelegate
+        )
+        do {
+            try updater.start()
+            self.updater = updater
+            updaterDelegate.service = self
+        } catch {
+            // Non-bundle runs (swift run) or broken configuration: updates
+            // are unavailable; the rest of the app is unaffected.
+            DiagnosticLog.log("Updater unavailable: \(error.localizedDescription)")
         }
     }
 
     var isConfigured: Bool {
-        updaterController != nil
+        updater != nil
     }
 
     var canCheckForUpdates: Bool {
-        updaterController?.updater.canCheckForUpdates ?? false
+        updater?.canCheckForUpdates ?? false
     }
 
     var currentVersion: String {
@@ -57,54 +96,102 @@ final class SparkleUpdateService: UpdateServicing {
 
     var automaticallyChecksForUpdates: Bool {
         get {
-            updaterController?.updater.automaticallyChecksForUpdates
+            updater?.automaticallyChecksForUpdates
                 ?? Self.boolValue(forInfoDictionaryKey: "SUEnableAutomaticChecks", bundle: bundle, default: true)
         }
         set {
-            updaterController?.updater.automaticallyChecksForUpdates = newValue
+            updater?.automaticallyChecksForUpdates = newValue
         }
     }
 
     var automaticallyDownloadsUpdates: Bool {
         get {
-            updaterController?.updater.automaticallyDownloadsUpdates
+            updater?.automaticallyDownloadsUpdates
                 ?? Self.boolValue(forInfoDictionaryKey: "SUAutomaticallyUpdate", bundle: bundle, default: true)
         }
         set {
-            updaterController?.updater.automaticallyDownloadsUpdates = newValue
+            updater?.automaticallyDownloadsUpdates = newValue
         }
     }
 
+    /// Deliberately not gated on `canCheckForUpdates`: with a session already
+    /// in flight Sparkle dispatches to `showUpdateInFocus`, re-presenting the
+    /// current phase — gating would turn the button into a dead key.
     func checkForUpdates() {
-        updaterController?.checkForUpdates(nil)
+        updater?.checkForUpdates()
     }
 
-    // MARK: - Delegate glue (called by SparkleDelegateAdapter on the main actor)
+    // MARK: - Session actions (UpdateServicing)
 
-    fileprivate func handleFoundUpdate(version: String, stage: UpdatePhase.DeliveryStage) {
-        updatePhase = .forFoundUpdate(version: version, stage: stage)
-    }
-
-    fileprivate func handleUpdateSkipped() {
-        updatePhase = .idle
-    }
-
-    fileprivate func handleUpdateCycleFinished(isUserInitiated: Bool, errorMessage: String?) {
-        lastUpdateCheckDate = Date()
-        if let errorMessage {
-            // Sparkle already presents errors for user-initiated checks in
-            // its own UI; only scheduled failures need a Wink-owned surface.
-            if !isUserInitiated {
-                updatePhase = .error(message: errorMessage)
-            }
-        } else if case .error = updatePhase {
-            updatePhase = .idle
+    /// Only ever send **one** reply: with background auto-download, the
+    /// found-reply (`showUpdateFound(.downloaded)`) and the ready-reply
+    /// (`showReady`) can both be in hand; double-replying corrupts Sparkle's
+    /// state machine. The ready reply is newer and wins.
+    func installUpdateNow() {
+        if let reply = readyReply.take() {
+            updateReply = nil
+            reply(.install)
+        } else if let reply = updateReply.take() {
+            reply(.install)
         }
     }
+
+    func remindUpdateLater() {
+        if let reply = readyReply.take() {
+            updateReply = nil
+            reply(.dismiss)
+        } else if let reply = updateReply.take() {
+            reply(.dismiss)
+        }
+        closeAndIdle()
+    }
+
+    func skipUpdateVersion() {
+        updateReply.take()?(.skip)
+        closeAndIdle()
+    }
+
+    func cancelUpdateOperation() {
+        checkCancellation.take()?()
+        downloadCancellation.take()?()
+        closeAndIdle()
+    }
+
+    func acknowledgeUpdateResult() {
+        pendingAcknowledgement.take()?()
+        closeAndIdle()
+    }
+
+    private func closeAndIdle() {
+        // Consume any pending acknowledgement on every close path — Sparkle's
+        // UI-based update driver only aborts the session inside that
+        // callback. Leaving it unconsumed wedges the session for the rest of
+        // the run. (No-op when nothing is pending; dismissUpdateInstallation
+        // nils it first, preserving its discard-without-calling semantics.)
+        pendingAcknowledgement.take()?()
+        updatePhase = .idle
+        dismissUpdatePanel?()
+    }
+
+    private func present(_ newPhase: UpdatePhase, activatePanel: Bool) {
+        updatePhase = newPhase
+        presentUpdatePanel?(activatePanel)
+    }
+
+    // MARK: - Delegate glue
+
+    fileprivate func handleUpdateCycleFinished() {
+        lastUpdateCheckDate = Date()
+    }
+
+    // MARK: - Configuration helpers
 
     private static func hasValidConfiguration(bundle: Bundle) -> Bool {
-        hasNonEmptyString("SUFeedURL", bundle: bundle) &&
-        hasNonEmptyString("SUPublicEDKey", bundle: bundle)
+        if SparkleUpdaterDelegate.feedURLOverride(from: .standard) != nil {
+            return hasNonEmptyString("SUPublicEDKey", bundle: bundle)
+        }
+        return hasNonEmptyString("SUFeedURL", bundle: bundle) &&
+            hasNonEmptyString("SUPublicEDKey", bundle: bundle)
     }
 
     private static func hasNonEmptyString(_ key: String, bundle: Bundle) -> Bool {
@@ -132,75 +219,214 @@ final class SparkleUpdateService: UpdateServicing {
     }
 }
 
-/// Bridges Sparkle's delegate callbacks onto `SparkleUpdateService`.
-///
-/// Sparkle's updater API is main-thread only, so every callback below arrives
-/// on the main thread and can assume main-actor isolation. Kept as a separate
-/// NSObject because both delegate protocols require NSObjectProtocol and the
-/// controller retains its delegates weakly.
-private final class SparkleDelegateAdapter: NSObject {
-    weak var service: SparkleUpdateService?
+// MARK: - SPUUserDriver (NS_SWIFT_UI_ACTOR — every callback is main-actor)
 
-    /// Sparkle error codes that are outcomes, not failures: no update found
-    /// (1001) and user-canceled installation (4007).
-    private static let ignoredErrorCodes: Set<Int> = [1001, 4007]
+extension SparkleUpdateService: SPUUserDriver {
+    func show(
+        _ request: SPUUpdatePermissionRequest,
+        reply: @escaping (SUUpdatePermissionResponse) -> Void
+    ) {
+        // Info.plist sets SUEnableAutomaticChecks explicitly, so Sparkle
+        // should never ask; answer with the current preference as a fallback.
+        reply(SUUpdatePermissionResponse(
+            automaticUpdateChecks: automaticallyChecksForUpdates,
+            sendSystemProfile: false
+        ))
+    }
 
-    private static func deliveryStage(from state: SPUUserUpdateState) -> UpdatePhase.DeliveryStage {
-        switch state.stage {
-        case .notDownloaded:
-            return .notDownloaded
-        case .downloaded:
-            return .downloaded
-        case .installing:
-            return .installing
-        @unknown default:
-            return .notDownloaded
+    func showUserInitiatedUpdateCheck(cancellation: @escaping () -> Void) {
+        checkCancellation = cancellation
+        sessionIsUserInitiated = true
+        present(.checking, activatePanel: true)
+    }
+
+    func showUpdateFound(
+        with appcastItem: SUAppcastItem,
+        state: SPUUserUpdateState,
+        reply: @escaping (SPUUserUpdateChoice) -> Void
+    ) {
+        presentUpdateFound(
+            version: appcastItem.displayVersionString,
+            userInitiated: state.userInitiated,
+            reply: reply
+        )
+    }
+
+    /// Pure-value seam for `showUpdateFound` — `SPUUserUpdateState` has no
+    /// public initializer, so tests drive this method directly.
+    func presentUpdateFound(
+        version: String,
+        userInitiated: Bool,
+        reply: @escaping (SPUUserUpdateChoice) -> Void
+    ) {
+        checkCancellation = nil
+        updateReply = reply
+        downloadVersion = version
+        sessionIsUserInitiated = userInitiated
+        if userInitiated {
+            present(.available(version: version), activatePanel: true)
+        } else {
+            // Gentle: hold the reply, no panel. The popover notice row and
+            // settings card surface the phase; clicking them runs a user
+            // check, which resumes this session via showUpdateInFocus.
+            updatePhase = .available(version: version)
         }
     }
 
-    private func onMain(_ body: @escaping @MainActor (SparkleUpdateService) -> Void) {
-        MainActor.assumeIsolated { [weak service] in
-            guard let service else { return }
-            body(service)
+    func showUpdateReleaseNotes(with downloadData: SPUDownloadData) {
+        // The panel shows the version and defers full notes to the releases
+        // page; no inline HTML rendering.
+    }
+
+    func showUpdateReleaseNotesFailedToDownloadWithError(_ error: any Error) {}
+
+    func showUpdateNotFoundWithError(_ error: any Error, acknowledgement: @escaping () -> Void) {
+        checkCancellation = nil
+        if sessionIsUserInitiated {
+            pendingAcknowledgement = acknowledgement
+            present(.upToDate(checkedAt: Date()), activatePanel: true)
+        } else {
+            // Scheduled: acknowledge immediately so the session closes.
+            acknowledgement()
+            updatePhase = .idle
         }
     }
+
+    func showUpdaterError(_ error: any Error, acknowledgement: @escaping () -> Void) {
+        checkCancellation = nil
+        downloadCancellation = nil
+        DiagnosticLog.log("Updater error: \(error.localizedDescription)")
+        if sessionIsUserInitiated {
+            pendingAcknowledgement = acknowledgement
+            present(.error(message: error.localizedDescription), activatePanel: true)
+        } else {
+            acknowledgement()
+            updatePhase = .error(message: error.localizedDescription)
+        }
+    }
+
+    func showDownloadInitiated(cancellation: @escaping () -> Void) {
+        downloadCancellation = cancellation
+        downloadReceived = 0
+        downloadExpected = 0
+        lastDownloadPublish = .distantPast
+        publishDownloadProgress(force: true)
+        if sessionIsUserInitiated {
+            presentUpdatePanel?(true)
+        }
+    }
+
+    func showDownloadDidReceiveExpectedContentLength(_ expectedContentLength: UInt64) {
+        downloadExpected = expectedContentLength
+        publishDownloadProgress(force: true)
+    }
+
+    func showDownloadDidReceiveData(ofLength length: UInt64) {
+        downloadReceived += length
+        publishDownloadProgress(force: false)
+    }
+
+    private func publishDownloadProgress(force: Bool) {
+        let now = Date()
+        guard force || now.timeIntervalSince(lastDownloadPublish) >= 0.1 else { return }
+        lastDownloadPublish = now
+        updatePhase = .downloading(
+            version: downloadVersion,
+            received: downloadReceived,
+            expected: downloadExpected
+        )
+    }
+
+    func showDownloadDidStartExtractingUpdate() {
+        downloadCancellation = nil
+        updatePhase = .extracting(progress: 0)
+    }
+
+    func showExtractionReceivedProgress(_ progress: Double) {
+        updatePhase = .extracting(progress: progress)
+    }
+
+    func showReady(toInstallAndRelaunch reply: @escaping (SPUUserUpdateChoice) -> Void) {
+        readyReply = reply
+        if sessionIsUserInitiated {
+            present(.ready(version: downloadVersion), activatePanel: true)
+        } else {
+            updatePhase = .ready(version: downloadVersion)
+        }
+    }
+
+    func showInstallingUpdate(
+        withApplicationTerminated applicationTerminated: Bool,
+        retryTerminatingApplication: @escaping () -> Void
+    ) {
+        updatePhase = .installing
+    }
+
+    func showUpdateInstalledAndRelaunched(_ relaunched: Bool, acknowledgement: @escaping () -> Void) {
+        pendingAcknowledgement = acknowledgement
+        acknowledgeUpdateResult()
+    }
+
+    /// Sparkle re-focuses an in-flight session (a repeat "Check for
+    /// Updates…" click) — re-present whatever phase is current.
+    func showUpdateInFocus() {
+        sessionIsUserInitiated = true
+        presentUpdatePanel?(true)
+    }
+
+    /// Sparkle's terminal teardown. Unconsumed replies are **discarded
+    /// without being called** — Sparkle is already aborting/finishing and no
+    /// longer expects answers; replying here can corrupt its state machine.
+    func dismissUpdateInstallation() {
+        checkCancellation = nil
+        downloadCancellation = nil
+        updateReply = nil
+        readyReply = nil
+        pendingAcknowledgement = nil
+        sessionIsUserInitiated = false
+        closeAndIdle()
+    }
+
+    #if DEBUG
+    // Test probes for reply/acknowledgement holding state.
+    var debugHasPendingAcknowledgement: Bool { pendingAcknowledgement != nil }
+    var debugHasReadyReply: Bool { readyReply != nil }
+    var debugHasUpdateReply: Bool { updateReply != nil }
+    #endif
 }
 
-extension SparkleDelegateAdapter: SPUStandardUserDriverDelegate {
-    var supportsGentleScheduledUpdateReminders: Bool { true }
+/// `SPUUpdaterDelegate` adapter. Sparkle does not guarantee main-actor
+/// delivery for updater-delegate callbacks, so this stays a small
+/// nonisolated object that only touches thread-safe state (UserDefaults) or
+/// hops to the main actor explicitly.
+final class SparkleUpdaterDelegate: NSObject, SPUUpdaterDelegate {
+    @MainActor weak var service: SparkleUpdateService?
 
-    func standardUserDriverShouldHandleShowingScheduledUpdate(
-        _ update: SUAppcastItem,
-        andInImmediateFocus immediateFocus: Bool
-    ) -> Bool {
-        // Wink handles scheduled updates gently (popover row + settings
-        // card) instead of a stock alert with no dock presence behind it.
-        false
+    static let feedURLOverrideDefaultsKey = "updateFeedURLOverride"
+
+    func feedURLString(for updater: SPUUpdater) -> String? {
+        Self.feedURLOverride(from: .standard)
     }
 
-    func standardUserDriverWillHandleShowingUpdate(
-        _ handleShowingUpdate: Bool,
-        forUpdate update: SUAppcastItem,
-        state: SPUUserUpdateState
-    ) {
-        let version = update.displayVersionString
-        let stage = Self.deliveryStage(from: state)
-        onMain { service in
-            service.handleFoundUpdate(version: version, stage: stage)
-        }
+    /// Feed override for self-hosted or local validation feeds. Only https
+    /// is accepted, plus loopback http (`http://localhost`, `http://127.0.0.1`)
+    /// for local end-to-end testing — EdDSA signatures remain the authenticity
+    /// bedrock, but a `defaults write` should not be able to point the feed
+    /// at an arbitrary insecure scheme.
+    static func feedURLOverride(from defaults: UserDefaults) -> String? {
+        sanitizedOverride(defaults.string(forKey: feedURLOverrideDefaultsKey))
     }
-}
 
-extension SparkleDelegateAdapter: SPUUpdaterDelegate {
-    func updater(
-        _ updater: SPUUpdater,
-        userDidMake choice: SPUUserUpdateChoice,
-        forUpdate updateItem: SUAppcastItem,
-        state: SPUUserUpdateState
-    ) {
-        guard choice == .skip else { return }
-        onMain { service in
-            service.handleUpdateSkipped()
+    static func sanitizedOverride(_ raw: String?) -> String? {
+        guard let raw, !raw.isEmpty, let url = URL(string: raw) else { return nil }
+        switch url.scheme?.lowercased() {
+        case "https":
+            return raw
+        case "http":
+            let host = url.host()?.lowercased()
+            return (host == "localhost" || host == "127.0.0.1") ? raw : nil
+        default:
+            return nil
         }
     }
 
@@ -209,16 +435,17 @@ extension SparkleDelegateAdapter: SPUUpdaterDelegate {
         didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
         error: (any Error)?
     ) {
-        let isUserInitiated = updateCheck == .updates
-        let errorMessage: String?
-        if let error {
-            let nsError = error as NSError
-            errorMessage = Self.ignoredErrorCodes.contains(nsError.code) ? nil : nsError.localizedDescription
-        } else {
-            errorMessage = nil
+        Task { @MainActor [weak self] in
+            self?.service?.handleUpdateCycleFinished()
         }
-        onMain { service in
-            service.handleUpdateCycleFinished(isUserInitiated: isUserInitiated, errorMessage: errorMessage)
-        }
+    }
+}
+
+/// One-shot consumption for optional callbacks: take the value and nil the
+/// storage in one step, so a reply can never be sent twice.
+private extension Optional {
+    mutating func take() -> Wrapped? {
+        defer { self = nil }
+        return self
     }
 }

--- a/Sources/Wink/Services/UpdateServicing.swift
+++ b/Sources/Wink/Services/UpdateServicing.swift
@@ -13,29 +13,33 @@ struct UpdatePresentation: Equatable {
 /// update seam keeps Sparkle out of the view layer).
 enum UpdatePhase: Equatable {
     case idle
+    /// A user-initiated check is in flight.
+    case checking
     /// A check found an update that is not downloaded yet.
     case available(version: String)
+    /// The update archive is downloading. `expected == 0` until the content
+    /// length is known.
+    case downloading(version: String, received: UInt64, expected: UInt64)
+    /// The downloaded archive is being extracted. Progress is 0...1.
+    case extracting(progress: Double)
     /// The update is downloaded or staged; it installs on quit or relaunch.
     case ready(version: String)
-    /// A scheduled background check failed (feed unreachable, bad signature).
-    /// Cleared by the next check that completes without error.
+    /// Sparkle is installing (the app is about to relaunch).
+    case installing
+    /// A user-initiated check finished with no newer version.
+    case upToDate(checkedAt: Date)
+    /// A check failed (feed unreachable, bad signature). Cleared by the next
+    /// check that completes without error.
     case error(message: String)
 
-    /// Delivery progress of a found update, mirrored from the updater.
-    enum DeliveryStage: Equatable {
-        case notDownloaded
-        case downloaded
-        case installing
-    }
-
-    /// Pure mapping used by the Sparkle delegate glue; unit-testable without
-    /// Sparkle types.
-    static func forFoundUpdate(version: String, stage: DeliveryStage) -> UpdatePhase {
-        switch stage {
-        case .notDownloaded:
-            return .available(version: version)
-        case .downloaded, .installing:
-            return .ready(version: version)
+    /// True while a session holds a Sparkle reply or is doing work — the
+    /// states the update panel should stay open for.
+    var isActiveSession: Bool {
+        switch self {
+        case .idle, .upToDate, .error:
+            return false
+        case .checking, .available, .downloading, .extracting, .ready, .installing:
+            return true
         }
     }
 }
@@ -61,4 +65,17 @@ protocol UpdateServicing: AnyObject {
     var onUpdateStateChange: (@MainActor () -> Void)? { get set }
 
     func checkForUpdates()
+
+    // MARK: - Session actions (driven by the update panel / popover)
+
+    /// available → install the found update; ready → install and relaunch.
+    func installUpdateNow()
+    /// available/ready → dismiss for now (remind on the next check).
+    func remindUpdateLater()
+    /// available → skip this version entirely.
+    func skipUpdateVersion()
+    /// checking/downloading → cancel the in-flight operation.
+    func cancelUpdateOperation()
+    /// upToDate/error → acknowledge the terminal state and return to idle.
+    func acknowledgeUpdateResult()
 }

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -237,13 +237,22 @@ struct GeneralTabView: View {
 
         // Live session state outranks the static behavior description.
         switch preferences.updatePhase {
+        case .checking:
+            return "Checking for updates…"
         case .available(let version):
             return "Version \(version) is available. Use Check for Updates… to review and install."
+        case .downloading(let version, let received, let expected):
+            let percent = expected > 0 ? " (\(Int(Double(received) / Double(expected) * 100))%)" : ""
+            return "Downloading version \(version)…\(percent)"
+        case .extracting:
+            return "Preparing the downloaded update…"
         case .ready(let version):
             return "Version \(version) is downloaded and installs when Wink quits. Use Check for Updates… to install now."
+        case .installing:
+            return "Installing the update — Wink will relaunch shortly."
         case .error(let message):
             return "The last automatic update check failed: \(message)"
-        case .idle:
+        case .idle, .upToDate:
             break
         }
 

--- a/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
+++ b/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
@@ -105,17 +105,27 @@ final class MenuBarPopoverModel {
         let subtitle: String
     }
 
-    /// Non-modal surface for scheduled update findings (gentle reminders):
-    /// clicking runs a user-initiated check, which re-focuses Sparkle's
-    /// existing session in its standard UI.
+    /// Non-modal surface for scheduled update findings (gentle sessions):
+    /// clicking runs a user-initiated check, which resumes the held session
+    /// into the Wink update panel.
     var updateNotice: UpdateNotice? {
         switch preferences.updatePhase {
-        case .idle, .error:
+        case .idle, .checking, .error, .upToDate, .installing:
             return nil
         case .available(let version):
             return UpdateNotice(
                 title: "Update available — v\(version)",
                 subtitle: "Click to review and install."
+            )
+        case .downloading(let version, _, _):
+            return UpdateNotice(
+                title: "Downloading update — v\(version)",
+                subtitle: "Click to view progress."
+            )
+        case .extracting:
+            return UpdateNotice(
+                title: "Preparing update…",
+                subtitle: "Click to view progress."
             )
         case .ready(let version):
             return UpdateNotice(

--- a/Sources/Wink/UI/UpdatePanel.swift
+++ b/Sources/Wink/UI/UpdatePanel.swift
@@ -1,0 +1,243 @@
+import AppKit
+import SwiftUI
+
+/// Hosts the Wink-owned update panel (Issue #298): a floating window that
+/// renders every `UpdatePhase` of an update session with Wink's design
+/// system, replacing Sparkle's stock windows.
+///
+/// The panel is created once and re-presented for each session; SwiftUI
+/// re-renders from the observable `AppPreferences.updatePhase` mirror. The
+/// close button routes through `handleUpdatePanelCloseRequest()` so a held
+/// Sparkle reply or acknowledgement is always consumed.
+@MainActor
+final class UpdatePanelPresenter: NSObject {
+    private var panel: NSPanel?
+    private weak var preferences: AppPreferences?
+
+    func present(preferences: AppPreferences, activate: Bool) {
+        self.preferences = preferences
+        let panel = panel ?? makePanel(preferences: preferences)
+        self.panel = panel
+
+        if activate {
+            NSApp.activate()
+            panel.makeKeyAndOrderFront(nil)
+        } else {
+            panel.orderFrontRegardless()
+        }
+    }
+
+    func dismiss() {
+        panel?.orderOut(nil)
+    }
+
+    private func makePanel(preferences: AppPreferences) -> NSPanel {
+        let hosting = NSHostingView(rootView: UpdatePanelView(preferences: preferences))
+        hosting.frame = NSRect(origin: .zero, size: hosting.fittingSize)
+
+        let panel = NSPanel(
+            contentRect: hosting.frame,
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = "Wink Update"
+        panel.titleVisibility = .hidden
+        panel.titlebarAppearsTransparent = true
+        panel.isMovableByWindowBackground = true
+        panel.level = .floating
+        panel.isReleasedWhenClosed = false
+        panel.hidesOnDeactivate = false
+        panel.delegate = self
+        panel.contentView = hosting
+        panel.center()
+        return panel
+    }
+}
+
+extension UpdatePanelPresenter: NSWindowDelegate {
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        // Let the session action drive the dismissal (it calls back into
+        // dismiss()); closing the window must never leak a Sparkle reply.
+        preferences?.handleUpdatePanelCloseRequest()
+        return false
+    }
+}
+
+struct UpdatePanelView: View {
+    let preferences: AppPreferences
+
+    var body: some View {
+        UpdatePanelContent(preferences: preferences)
+            .winkChromeRoot()
+    }
+}
+
+private struct UpdatePanelContent: View {
+    @Environment(\.winkPalette) private var palette
+
+    let preferences: AppPreferences
+
+    private static let releasesURL = URL(string: "https://github.com/xrf9268-hue/Wink/releases")!
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            header
+            body(for: preferences.updatePhase)
+        }
+        .padding(20)
+        .frame(width: 380)
+        .background(palette.windowBg)
+        .animation(.default, value: preferences.updatePhase)
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            WinkAppIcon(size: 36)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(headerTitle)
+                    .font(WinkType.tabTitle)
+                    .foregroundStyle(palette.textPrimary)
+                Text(headerSubtitle)
+                    .font(WinkType.labelSmall)
+                    .foregroundStyle(palette.textSecondary)
+            }
+        }
+    }
+
+    private var headerTitle: String {
+        switch preferences.updatePhase {
+        case .idle, .checking:
+            return "Checking for Updates"
+        case .available:
+            return "Update Available"
+        case .downloading, .extracting:
+            return "Downloading Update"
+        case .ready:
+            return "Update Ready"
+        case .installing:
+            return "Installing Update"
+        case .upToDate:
+            return "You're Up to Date"
+        case .error:
+            return "Update Check Failed"
+        }
+    }
+
+    private var headerSubtitle: String {
+        switch preferences.updatePhase {
+        case .available(let version), .ready(let version):
+            return "Wink \(version)"
+        case .downloading(let version, _, _):
+            return "Wink \(version)"
+        default:
+            return "Wink \(preferences.updatePresentation.currentVersion)"
+        }
+    }
+
+    @ViewBuilder
+    private func body(for phase: UpdatePhase) -> some View {
+        switch phase {
+        case .idle, .checking:
+            progressSection(label: "Contacting the update feed…", fraction: nil)
+            buttonRow(primary: nil, secondary: ("Cancel", { preferences.cancelUpdateOperation() }))
+
+        case .available(let version):
+            Text("Wink \(version) is available — you have \(preferences.updatePresentation.currentVersion). The update downloads in the background and installs on relaunch.")
+                .font(WinkType.bodyText)
+                .foregroundStyle(palette.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Link("View release notes", destination: Self.releasesURL)
+                .font(WinkType.labelSmall)
+                .foregroundStyle(palette.textTertiary)
+            HStack {
+                Button("Skip This Version") { preferences.skipUpdateVersion() }
+                Spacer()
+                Button("Later") { preferences.remindUpdateLater() }
+                Button("Install Update") { preferences.installUpdateNow() }
+                    .keyboardShortcut(.defaultAction)
+            }
+
+        case .downloading(_, let received, let expected):
+            progressSection(
+                label: downloadLabel(received: received, expected: expected),
+                fraction: expected > 0 ? Double(received) / Double(expected) : nil
+            )
+            buttonRow(primary: nil, secondary: ("Cancel", { preferences.cancelUpdateOperation() }))
+
+        case .extracting(let progress):
+            progressSection(label: "Preparing update…", fraction: progress)
+            buttonRow(primary: nil, secondary: nil)
+
+        case .ready(let version):
+            Text("Wink \(version) is downloaded. Relaunch now to finish installing, or keep working — it installs when Wink quits.")
+                .font(WinkType.bodyText)
+                .foregroundStyle(palette.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            buttonRow(
+                primary: ("Install and Relaunch", { preferences.installUpdateNow() }),
+                secondary: ("Later", { preferences.remindUpdateLater() })
+            )
+
+        case .installing:
+            progressSection(label: "Installing… Wink will relaunch shortly.", fraction: nil)
+            buttonRow(primary: nil, secondary: nil)
+
+        case .upToDate:
+            Text("Wink \(preferences.updatePresentation.currentVersion) is the latest version.")
+                .font(WinkType.bodyText)
+                .foregroundStyle(palette.textSecondary)
+            buttonRow(primary: ("OK", { preferences.acknowledgeUpdateResult() }), secondary: nil)
+
+        case .error(let message):
+            Text(message)
+                .font(WinkType.bodyText)
+                .foregroundStyle(palette.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            buttonRow(primary: ("OK", { preferences.acknowledgeUpdateResult() }), secondary: nil)
+        }
+    }
+
+    private func progressSection(label: String, fraction: Double?) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(label)
+                .font(WinkType.bodyText)
+                .foregroundStyle(palette.textSecondary)
+            if let fraction {
+                ProgressView(value: min(max(fraction, 0), 1))
+                    .progressViewStyle(.linear)
+            } else {
+                ProgressView()
+                    .progressViewStyle(.linear)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func buttonRow(
+        primary: (String, () -> Void)?,
+        secondary: (String, () -> Void)?
+    ) -> some View {
+        if primary != nil || secondary != nil {
+            HStack {
+                Spacer()
+                if let secondary {
+                    Button(secondary.0, action: secondary.1)
+                }
+                if let primary {
+                    Button(primary.0, action: primary.1)
+                        .keyboardShortcut(.defaultAction)
+                }
+            }
+        }
+    }
+
+    private func downloadLabel(received: UInt64, expected: UInt64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.countStyle = .file
+        let got = formatter.string(fromByteCount: Int64(received))
+        guard expected > 0 else { return "Downloading… \(got)" }
+        let total = formatter.string(fromByteCount: Int64(expected))
+        return "Downloading… \(got) of \(total)"
+    }
+}

--- a/Tests/WinkTests/AppPreferencesTests.swift
+++ b/Tests/WinkTests/AppPreferencesTests.swift
@@ -359,10 +359,44 @@ func updatePresentation_checkForUpdatesEnabledFollowsConfigurationNotCanCheckSna
 }
 
 @Test
-func updatePhaseMapping_notDownloadedIsAvailable_downloadedAndInstallingAreReady() {
-    #expect(UpdatePhase.forFoundUpdate(version: "1.2", stage: .notDownloaded) == .available(version: "1.2"))
-    #expect(UpdatePhase.forFoundUpdate(version: "1.2", stage: .downloaded) == .ready(version: "1.2"))
-    #expect(UpdatePhase.forFoundUpdate(version: "1.2", stage: .installing) == .ready(version: "1.2"))
+func updatePhase_isActiveSessionCoversWorkingAndHeldStates() {
+    #expect(UpdatePhase.checking.isActiveSession)
+    #expect(UpdatePhase.available(version: "1.2").isActiveSession)
+    #expect(UpdatePhase.downloading(version: "1.2", received: 1, expected: 2).isActiveSession)
+    #expect(UpdatePhase.extracting(progress: 0.5).isActiveSession)
+    #expect(UpdatePhase.ready(version: "1.2").isActiveSession)
+    #expect(UpdatePhase.installing.isActiveSession)
+    #expect(!UpdatePhase.idle.isActiveSession)
+    #expect(!UpdatePhase.upToDate(checkedAt: Date(timeIntervalSince1970: 0)).isActiveSession)
+    #expect(!UpdatePhase.error(message: "x").isActiveSession)
+}
+
+@Test @MainActor
+func handleUpdatePanelCloseRequest_routesToPhaseAppropriateAction() {
+    let service = FakeUpdateService(
+        isConfigured: true,
+        canCheckForUpdates: true,
+        currentVersion: "0.5.0",
+        automaticallyChecksForUpdates: true,
+        automaticallyDownloadsUpdates: true
+    )
+    let preferences = makePreferences(updateService: service)
+
+    service.simulateUpdateState(phase: .checking)
+    preferences.handleUpdatePanelCloseRequest()
+    #expect(service.recordedActions == ["cancel"])
+
+    service.simulateUpdateState(phase: .available(version: "9.9"))
+    preferences.handleUpdatePanelCloseRequest()
+    #expect(service.recordedActions == ["cancel", "later"])
+
+    service.simulateUpdateState(phase: .error(message: "offline"))
+    preferences.handleUpdatePanelCloseRequest()
+    #expect(service.recordedActions == ["cancel", "later", "acknowledge"])
+
+    service.simulateUpdateState(phase: .idle)
+    preferences.handleUpdatePanelCloseRequest()
+    #expect(service.recordedActions == ["cancel", "later", "acknowledge"])
 }
 
 @Test @MainActor
@@ -616,6 +650,14 @@ private final class FakeUpdateService: UpdateServicing {
         }
         onUpdateStateChange?()
     }
+
+    private(set) var recordedActions: [String] = []
+
+    func installUpdateNow() { recordedActions.append("install") }
+    func remindUpdateLater() { recordedActions.append("later") }
+    func skipUpdateVersion() { recordedActions.append("skip") }
+    func cancelUpdateOperation() { recordedActions.append("cancel") }
+    func acknowledgeUpdateResult() { recordedActions.append("acknowledge") }
 }
 
 private final class MutableLaunchAtLoginState: @unchecked Sendable {

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
@@ -503,6 +503,12 @@ private final class FakeUpdateService: UpdateServicing {
         }
         onUpdateStateChange?()
     }
+
+    func installUpdateNow() {}
+    func remindUpdateLater() {}
+    func skipUpdateVersion() {}
+    func cancelUpdateOperation() {}
+    func acknowledgeUpdateResult() {}
 }
 
 private final class OpenedTabsRecorder: @unchecked Sendable {

--- a/Tests/WinkTests/UpdateDriverTests.swift
+++ b/Tests/WinkTests/UpdateDriverTests.swift
@@ -1,0 +1,213 @@
+import Foundation
+import Testing
+@testable import Wink
+
+/// Reply/acknowledgement mechanics of the custom Sparkle user driver
+/// (Issue #298). The service is constructed against the test bundle (no
+/// SUFeedURL), so no real updater starts — the driver surface is exercised
+/// directly through its pure-value seams.
+///
+/// SPUUserUpdateChoice raw values (SPUUserUpdateState.h): skip=0, install=1,
+/// dismiss=2. Compared by rawValue so the tests need no Sparkle import.
+@Suite("Update driver")
+@MainActor
+struct UpdateDriverTests {
+    private func makeService() -> (SparkleUpdateService, PanelRecorder) {
+        let service = SparkleUpdateService(bundle: Bundle(for: BundleToken.self))
+        let recorder = PanelRecorder()
+        service.presentUpdatePanel = { activate in recorder.presented.append(activate) }
+        service.dismissUpdatePanel = { recorder.dismissCount += 1 }
+        return (service, recorder)
+    }
+
+    @Test
+    func scheduledFoundUpdateHoldsReplyWithoutPresentingPanel() {
+        let (service, recorder) = makeService()
+        var choices: [Int] = []
+
+        service.presentUpdateFound(version: "9.9", userInitiated: false) { choice in
+            choices.append(choice.rawValue)
+        }
+
+        #expect(service.updatePhase == .available(version: "9.9"))
+        #expect(recorder.presented.isEmpty)
+        #expect(service.debugHasUpdateReply)
+
+        service.installUpdateNow()
+        #expect(choices == [1])
+
+        // One-shot: a second install must not double-reply.
+        service.installUpdateNow()
+        #expect(choices == [1])
+        #expect(!service.debugHasUpdateReply)
+    }
+
+    @Test
+    func userInitiatedFoundUpdatePresentsPanelWithFocus() {
+        let (service, recorder) = makeService()
+
+        service.presentUpdateFound(version: "9.9", userInitiated: true) { _ in }
+
+        #expect(service.updatePhase == .available(version: "9.9"))
+        #expect(recorder.presented == [true])
+    }
+
+    @Test
+    func readyReplyOutranksStaleFoundReply() {
+        let (service, _) = makeService()
+        var foundChoices: [Int] = []
+        var readyChoices: [Int] = []
+
+        service.presentUpdateFound(version: "9.9", userInitiated: false) { choice in
+            foundChoices.append(choice.rawValue)
+        }
+        service.showReady { choice in
+            readyChoices.append(choice.rawValue)
+        }
+
+        service.installUpdateNow()
+
+        // Exactly one reply, through the newer ready callback; the stale
+        // found reply is discarded without being invoked.
+        #expect(readyChoices == [1])
+        #expect(foundChoices.isEmpty)
+        #expect(!service.debugHasUpdateReply)
+        #expect(!service.debugHasReadyReply)
+    }
+
+    @Test
+    func remindLaterDismissesAndIdles() {
+        let (service, recorder) = makeService()
+        var choices: [Int] = []
+
+        service.presentUpdateFound(version: "9.9", userInitiated: true) { choice in
+            choices.append(choice.rawValue)
+        }
+        service.remindUpdateLater()
+
+        #expect(choices == [2])
+        #expect(service.updatePhase == .idle)
+        #expect(recorder.dismissCount == 1)
+    }
+
+    @Test
+    func skipSendsSkipChoice() {
+        let (service, _) = makeService()
+        var choices: [Int] = []
+
+        service.presentUpdateFound(version: "9.9", userInitiated: false) { choice in
+            choices.append(choice.rawValue)
+        }
+        service.skipUpdateVersion()
+
+        #expect(choices == [0])
+        #expect(service.updatePhase == .idle)
+    }
+
+    @Test
+    func userInitiatedUpToDateHoldsAcknowledgementUntilConsumed() {
+        let (service, recorder) = makeService()
+        var ackCount = 0
+
+        service.showUserInitiatedUpdateCheck(cancellation: {})
+        #expect(service.updatePhase == .checking)
+        #expect(recorder.presented == [true])
+
+        service.showUpdateNotFoundWithError(TestUpdateError.sample) { ackCount += 1 }
+        guard case .upToDate = service.updatePhase else {
+            Issue.record("expected upToDate, got \(service.updatePhase)")
+            return
+        }
+        #expect(ackCount == 0)
+        #expect(service.debugHasPendingAcknowledgement)
+
+        service.acknowledgeUpdateResult()
+        #expect(ackCount == 1)
+        #expect(service.updatePhase == .idle)
+        #expect(recorder.dismissCount == 1)
+    }
+
+    @Test
+    func scheduledOutcomesAcknowledgeImmediatelySoTheSessionNeverLeaks() {
+        let (service, recorder) = makeService()
+        var ackCount = 0
+
+        service.showUpdateNotFoundWithError(TestUpdateError.sample) { ackCount += 1 }
+        #expect(ackCount == 1)
+        #expect(service.updatePhase == .idle)
+
+        service.showUpdaterError(TestUpdateError.sample) { ackCount += 1 }
+        #expect(ackCount == 2)
+        #expect(service.updatePhase == .error(message: TestUpdateError.sample.localizedDescription))
+        #expect(recorder.presented.isEmpty)
+    }
+
+    @Test
+    func closePathsConsumeAHeldAcknowledgement() {
+        let (service, _) = makeService()
+        var ackCount = 0
+
+        service.showUserInitiatedUpdateCheck(cancellation: {})
+        service.showUpdateNotFoundWithError(TestUpdateError.sample) { ackCount += 1 }
+        #expect(ackCount == 0)
+
+        // Closing through the wrong-but-adjacent action must still consume
+        // the acknowledgement — a leaked one wedges Sparkle's session for
+        // the rest of the run.
+        service.remindUpdateLater()
+        #expect(ackCount == 1)
+        #expect(!service.debugHasPendingAcknowledgement)
+    }
+
+    @Test
+    func cancelFiresHeldCancellationOnce()  {
+        let (service, _) = makeService()
+        var cancelCount = 0
+
+        service.showUserInitiatedUpdateCheck(cancellation: { cancelCount += 1 })
+        service.cancelUpdateOperation()
+        service.cancelUpdateOperation()
+
+        #expect(cancelCount == 1)
+        #expect(service.updatePhase == .idle)
+    }
+
+    @Test
+    func dismissUpdateInstallationDiscardsRepliesWithoutInvokingThem() {
+        let (service, _) = makeService()
+        var invoked = 0
+
+        service.presentUpdateFound(version: "9.9", userInitiated: false) { _ in invoked += 1 }
+        service.showReady { _ in invoked += 1 }
+        service.dismissUpdateInstallation()
+
+        #expect(invoked == 0)
+        #expect(!service.debugHasUpdateReply)
+        #expect(!service.debugHasReadyReply)
+        #expect(service.updatePhase == .idle)
+    }
+
+    @Test
+    func feedOverrideAcceptsHTTPSAndLoopbackOnly() {
+        #expect(SparkleUpdaterDelegate.sanitizedOverride("https://updates.example.com/appcast.xml") != nil)
+        #expect(SparkleUpdaterDelegate.sanitizedOverride("http://localhost:8000/appcast.xml") != nil)
+        #expect(SparkleUpdaterDelegate.sanitizedOverride("http://127.0.0.1:8000/appcast.xml") != nil)
+        #expect(SparkleUpdaterDelegate.sanitizedOverride("http://evil.example.com/appcast.xml") == nil)
+        #expect(SparkleUpdaterDelegate.sanitizedOverride("file:///tmp/appcast.xml") == nil)
+        #expect(SparkleUpdaterDelegate.sanitizedOverride("") == nil)
+        #expect(SparkleUpdaterDelegate.sanitizedOverride(nil) == nil)
+    }
+}
+
+private final class PanelRecorder {
+    var presented: [Bool] = []
+    var dismissCount = 0
+}
+
+private final class BundleToken {}
+
+private enum TestUpdateError: Error, LocalizedError {
+    case sample
+
+    var errorDescription: String? { "sample failure" }
+}

--- a/docs/signing-and-release.md
+++ b/docs/signing-and-release.md
@@ -289,6 +289,35 @@ bash scripts/package-dmg.sh
 codesign --verify --deep --strict --verbose=2 build/Wink.app
 ```
 
+### Local end-to-end update-flow validation
+
+The in-app update UI (check → available → download → extract → ready →
+install/relaunch, Issue #298) can be exercised against a fully local feed,
+no release infrastructure needed:
+
+1. Generate a throwaway EdDSA keypair under a dedicated keychain account and
+   export the private key:
+   `generate_keys --account wink-local-test && generate_keys --account wink-local-test -x /tmp/wink-test-ed.key`
+   (the tool lives under `.build/artifacts/*/bin/`).
+2. Package the app-under-test with only the public key injected
+   (`SPARKLE_PUBLIC_ED_KEY=<pubkey> bash scripts/package-app.sh`) and stash a
+   copy — the feed URL comes from the override below, so `SPARKLE_FEED_URL`
+   is not needed.
+3. Temporarily bump `CFBundleShortVersionString`/`CFBundleVersion` in
+   `Sources/Wink/Resources/Info.plist`, package again, run
+   `bash scripts/package-update-zip.sh`, then
+   `WINK_ALLOW_FIRST_RELEASE=1 SPARKLE_PUBLIC_BASE_URL="http://localhost:8000/" SPARKLE_PRIVATE_ED_KEY_FILE=/tmp/wink-test-ed.key bash scripts/generate-appcast.sh`,
+   and revert the plist.
+4. Serve the zip + `appcast.xml` with `python3 -m http.server 8000` and point
+   the app at it: `defaults write com.wink.app updateFeedURLOverride "http://localhost:8000/appcast.xml"`.
+   The override accepts https plus loopback http only
+   (`SparkleUpdaterDelegate.sanitizedOverride`).
+5. Launch the stashed lower-version copy and drive Check for Updates…
+   end-to-end; Sparkle installs the new version in place and relaunches.
+6. Clean up: delete the `updateFeedURLOverride`/`SULastCheckTime` defaults,
+   `security delete-generic-password -a wink-local-test`, and remove the
+   exported key file.
+
 Release verification:
 
 ```bash


### PR DESCRIPTION
Fixes #298

## Summary
- Replaces `SPUStandardUpdaterController` with a raw `SPUUpdater` + custom `SPUUserDriver`: every update-session state now renders in Wink-owned UI (a floating update panel built on the design system) instead of Sparkle's stock windows
- `UpdatePhase` extended (Sparkle-free): `checking`, `downloading(version:received:expected:)`, `extracting(progress:)`, `installing`, `upToDate(checkedAt:)` — the panel renders checking/progress bars, Install / Later / Skip, Install and Relaunch, and up-to-date/error acknowledgements; download publishing throttled to ~10Hz
- Session semantics: user-initiated checks present the panel with focus; **scheduled checks stay gentle** — found/ready updates hold their Sparkle reply and surface only through the popover notice row + settings card, and clicking them resumes the held session into the panel (`showUpdateInFocus`). Scheduled up-to-date/error outcomes acknowledge immediately so a session can never leak (a leaked acknowledgement wedges Sparkle's `sessionInProgress` for the rest of the run — regression-guarded by tests)
- Reply discipline per the PomoFox reference (`UpdaterService.swift:90-97, 281-288, 323-329`): one-shot `Optional.take()` consumption, ready-reply outranks a stale found-reply (background auto-download can leave both in hand), `dismissUpdateInstallation` discards without invoking; panel close routes through `handleUpdatePanelCloseRequest` so the phase-appropriate callback is always consumed
- `updateFeedURLOverride` UserDefaults override (https + loopback http only) enables fully local end-to-end validation; recipe documented in `docs/signing-and-release.md`
- Stage 1's `SPUStandardUserDriverDelegate` adapter retired (no standard driver left to delegate for); `SPUUpdaterDelegate` keeps `lastUpdateCheckDate`

## Testing
- [x] `swift test` (418 tests, 42 suites — 11 new in UpdateDriverTests: reply single-consumption, ready-precedence, gentle scheduled behavior, ack-leak guards on every close path, discard-without-invoke teardown, feed-override sanitization; plus panel-close routing via AppPreferences)
- [x] Additional validation noted below when needed
- [x] **Full end-to-end runtime validation against a local feed**: temp EdDSA keypair, `python3 -m http.server` serving a signed appcast + `Wink-0.5.1.zip`, 0.5.0 app-under-test with the loopback feed override. "Check for Updates…" presented the Wink panel: **checking → Update Available (Skip/Later/Install) → downloading (progress bar) → Update Ready (Later/Install and Relaunch)**; Install and Relaunch installed 0.5.1 in place and relaunched the app — verified by the on-disk bundle version flipping to 0.5.1 and a new pid. EdDSA signature verified against the temp key. All validation state (defaults, keychain key, server) cleaned up afterwards; user's installed app restored
- [x] Shared "Wink"-certificate TCC model held for the scratch-path test copy (`ax=true im=true` with zero re-granting)

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR). (Update seam still keeps Sparkle types out of SwiftUI; `docs/signing-and-release.md` gains the local update-flow validation recipe.)
- [x] No new references to `docs/archive/` as a current source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)