### PR TITLE
release: prepare v0.6.0 (CHANGELOG + What's New catalog + version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ Newest first. One `## X.Y.Z` section per release, written by hand **before** run
 `scripts/bump-version.sh X.Y.Z`. `scripts/release-notes.sh X.Y.Z` extracts a section as the
 GitHub Release body; the release workflow fails if the tagged version has no section here.
 
+## 0.6.0
+
+In-app updates and interface polish.
+
+- **Updates now live inside Wink** — checking, download progress, and
+  install/relaunch happen in a native Wink panel instead of separate Sparkle
+  dialogs. Scheduled checks stay quiet: a new version appears as a menu bar
+  notice and in Settings, never as a surprise popup.
+- **The Automatic Updates switch is real** — turn background update checks
+  and downloads on or off from Settings → General, which also shows live
+  update status and when Wink last checked.
+- **What's New after updating** — a one-time panel summarizes the highlights
+  after an update installs.
+- **Snappier shortcuts** — redundant window queries and scheduling hops were
+  removed from the keypress-to-activation path, including when restoring
+  minimized windows.
+- **Settings titlebar aligned** — the traffic lights, sidebar toggle, and
+  window title finally share one centerline.
+
 ## 0.5.0
 
 First public release.

--- a/Sources/Wink/Resources/Info.plist
+++ b/Sources/Wink/Resources/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.5.0</string>
+	<string>0.6.0</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSUIElement</key>

--- a/Sources/Wink/Services/LaunchGates.swift
+++ b/Sources/Wink/Services/LaunchGates.swift
@@ -38,6 +38,23 @@ struct WhatsNewNote: Equatable, Sendable {
 /// authoritative prose is CHANGELOG.md.
 enum WhatsNewCatalog {
     static let entries: [String: [WhatsNewNote]] = [
+        "0.6.0": [
+            WhatsNewNote(
+                symbolName: "arrow.down.circle",
+                title: "Updates, the Wink way",
+                detail: "Checking, download progress, and installs now happen right here — no more separate update dialogs."
+            ),
+            WhatsNewNote(
+                symbolName: "switch.2",
+                title: "Automatic updates, your call",
+                detail: "The Settings toggle is live: background checks and downloads, on or off."
+            ),
+            WhatsNewNote(
+                symbolName: "bolt",
+                title: "Snappier shortcuts",
+                detail: "Less work between keypress and app switch, especially with minimized windows."
+            ),
+        ],
         "0.5.0": [
             WhatsNewNote(
                 symbolName: "keyboard",


### PR DESCRIPTION
Fixes #300

## Summary
- `## 0.6.0` CHANGELOG section covering everything merged since v0.5.0: in-app update experience (#289/#298), functional Automatic Updates switch (#287), post-update What's New (#290), shortcut hot-path latency work (#288), settings titlebar alignment (#286)
- `WhatsNewCatalog` entry for 0.6.0 (release discipline from #290): users upgrading from 0.5.0 see the panel once after the update installs
- `./scripts/bump-version.sh 0.6.0`: `CFBundleShortVersionString` 0.5.0 → 0.6.0, `CFBundleVersion` 6 → 7 — the release feed gate requires strictly greater than the live appcast's 6

After merge: `git tag v0.6.0 && git push origin v0.6.0` triggers the Release workflow (GitHub Release + R2 zip/appcast upload).

## Testing
- [x] `swift test` (418 tests, 42 suites)
- [x] Additional validation noted below when needed
- [x] The Info.plist change is the version bump only (`CFBundleShortVersionString`/`CFBundleVersion` via `bump-version.sh`, same flow as v0.5.0's #285); packaging exercised locally throughout today's sessions and the live appcast confirmed at 0.5.0/build 6 so the feed gate accepts build 7

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)