### PR TITLE
fix(ui): center Settings titlebar traffic lights on the true design position

### DIFF
--- a/Sources/Wink/WinkApp.swift
+++ b/Sources/Wink/WinkApp.swift
@@ -66,6 +66,18 @@ enum SettingsTitlebarLayout {
     /// chrome.jsx: outer flex row `height: 36`.
     static let height: CGFloat = 36
 
+    /// primitives.jsx TrafficLights: `padding: 0 16px`. AppKit's native
+    /// button inset (~13pt center) is a fixed system value that isn't this
+    /// value — now that Wink owns the traffic-light buttons (see
+    /// `installOwnedTrafficLights`), their x position is driven by this
+    /// design constant instead of wherever AppKit happened to place the
+    /// originals.
+    static let trafficLightLeadingPadding: CGFloat = 16
+    /// primitives.jsx TrafficLights: each dot `width: 12; height: 12`.
+    static let trafficLightDotSize: CGFloat = 12
+    /// primitives.jsx TrafficLights: flex `gap: 8` between dots.
+    static let trafficLightDotGap: CGFloat = 8
+
     /// chrome.jsx title overlay: `fontSize: 13; fontWeight: 500`.
     static let titleFontSize: CGFloat = 13
     /// CSS `font-weight: 500` ≈ AppKit/SwiftUI `.medium`.
@@ -73,8 +85,8 @@ enum SettingsTitlebarLayout {
 
     /// Chrome browser reference titlebar puts the sidebar toggle about 24pt to
     /// the trailing side of the zoom button, sharing the traffic-light baseline.
-    /// AppKit owns the traffic-light positions; Wink only places its own toggle
-    /// relative to the current system button frames.
+    /// Wink owns the traffic-light buttons (see `installOwnedTrafficLights`) and
+    /// places its toggle relative to the owned zoom button's frame.
     static let toggleGapFromZoomButton: CGFloat = 24
 
     /// SF Symbol `sidebar.leading` rendered at this point size matches the
@@ -97,6 +109,15 @@ enum SettingsTitlebarLayout {
     static let sidebarToggleIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarSidebarToggle")
     static let titleIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarTitle")
     static let accessoryIdentifier = NSUserInterfaceItemIdentifier("WinkSettingsTitlebarAccessory")
+
+    static func trafficLightIdentifier(for type: NSWindow.ButtonType) -> NSUserInterfaceItemIdentifier {
+        switch type {
+        case .closeButton: return NSUserInterfaceItemIdentifier("WinkSettingsTitlebarCloseLight")
+        case .miniaturizeButton: return NSUserInterfaceItemIdentifier("WinkSettingsTitlebarMiniaturizeLight")
+        case .zoomButton: return NSUserInterfaceItemIdentifier("WinkSettingsTitlebarZoomLight")
+        default: return NSUserInterfaceItemIdentifier("WinkSettingsTitlebarLight")
+        }
+    }
 }
 
 /// Minimal NSWindow surgery for the SwiftUI `Settings` scene:
@@ -112,14 +133,24 @@ enum SettingsTitlebarLayout {
 ///   3. Add an 8pt bottom `NSTitlebarAccessoryViewController` so the Settings
 ///      content starts below the design's 36pt chrome row instead of below the
 ///      native 28pt titlebar safe area.
-///   4. Add Wink's own sidebar toggle and title beside the system traffic
-///      lights without rewriting the native button frames. AppKit remains the
-///      owner of the standard close/minimize/zoom placement, and every
-///      Wink-added control shares the traffic lights' vertical centerline
-///      (`zoomButton.frame.midY`) — a single baseline, never a second one
-///      derived from the design row height (PR #239 removed traffic-light
-///      repositioning; a design-height centerline can no longer agree with
-///      the AppKit-owned buttons).
+///   4. Hide the three AppKit-placed traffic-light buttons and replace them
+///      with fresh instances from `NSWindow.standardWindowButton(_:for:)`
+///      (Apple's factory API for "a new instance of a given standard window
+///      button, sized appropriately for a given window style" — the caller
+///      owns placement). The originals stay alive (just hidden) so
+///      `performClose`/`performMiniaturize`/`performZoom`, the Mission
+///      Control "unsaved changes" dot, and full-screen widget still track
+///      real window state; Wink mirrors their `isEnabled` onto the owned
+///      buttons every pass. This avoids PR #237's mistake of repositioning
+///      the *live* AppKit-owned buttons via `setFrameOrigin`, which fights
+///      `NSTitlebarView`'s own autolayout on every relayout pass and made the
+///      buttons visibly jump (PR #239 reverted it) — a factory-created
+///      button isn't in that autolayout at all, so there's nothing to fight.
+///   5. Add Wink's own sidebar toggle and title beside the owned traffic
+///      lights. Because Wink now owns every control in the row, all four
+///      (lights, toggle, title) share one true centerline: the design row's
+///      own midpoint (36pt / 2 = 18pt from the top), not AppKit's native
+///      28pt-band center.
 private struct SettingsWindowChromeConfigurator: NSViewRepresentable {
     func makeCoordinator() -> SettingsWindowChromeCoordinator {
         SettingsWindowChromeCoordinator()
@@ -173,12 +204,35 @@ final class SettingsWindowChromeCoordinator: NSObject {
     private weak var chromeHostView: NSView?
     private let observers = NotificationObserverBag()
 
+    /// Owned replacements for the AppKit close/miniaturize/zoom buttons,
+    /// keyed by button type. Created once per window; positioned on the
+    /// design centerline instead of AppKit's native-band center.
+    private var ownedTrafficLights: [NSWindow.ButtonType: NSButton] = [:]
+    /// The AppKit-native frame of each traffic-light button, captured once
+    /// (before it's hidden) so the owned replacement can reuse the native
+    /// x/width/height and only override y. Captured once because a hidden
+    /// button's frame may no longer reflect AppKit's normal layout.
+    private var trafficLightNativeFrames: [NSWindow.ButtonType: NSRect] = [:]
+    /// Stable reference to each *true* AppKit-owned button, captured once
+    /// before any owned clone exists. `window.standardWindowButton(_:)`
+    /// does a live, type-based search of the titlebar's subviews — once a
+    /// factory-vended clone of the same private button class is also in
+    /// that hierarchy, the search can return the clone instead of the
+    /// original (confirmed empirically: `isHidden` toggles landed on the
+    /// clone, hiding it, because the "original" that later passes looked up
+    /// was actually the clone). Re-querying by type after clones exist is
+    /// unreliable, so every subsequent pass must use these cached instances.
+    private var originalTrafficLights: [NSWindow.ButtonType: NSButton] = [:]
+
     func attach(to window: NSWindow) {
         guard self.window !== window else {
             applyAll()
             return
         }
         observers.removeAll()
+        ownedTrafficLights.removeAll()
+        trafficLightNativeFrames.removeAll()
+        originalTrafficLights.removeAll()
 
         self.window = window
         applyOnce()
@@ -238,7 +292,138 @@ final class SettingsWindowChromeCoordinator: NSObject {
             window.layoutIfNeeded()
         }
         guard let titlebarView = titlebarHostView(in: window) else { return }
+        installOwnedTrafficLights(in: window, titlebarView: titlebarView)
         installOrUpdateTitlebarChrome(in: titlebarView)
+        // NSTitlebarView's own layout can re-show its canonical buttons as a
+        // side effect of *any* pass that adds/resizes sibling subviews (seen
+        // empirically: hiding them earlier in this same method didn't stick
+        // once installOrUpdateTitlebarChrome touched the hairline/toggle/
+        // title subviews below). Re-assert hidden last, after every other
+        // subview mutation in this pass, so we always get the final word.
+        reassertTrafficLightsHidden()
+    }
+
+    private func reassertTrafficLightsHidden() {
+        for (type, original) in originalTrafficLights {
+            guard ownedTrafficLights[type] != nil, !original.isHidden else { continue }
+            original.isHidden = true
+        }
+    }
+
+    /// Hides the AppKit-placed close/miniaturize/zoom buttons and maintains
+    /// fresh replacements from `NSWindow.standardWindowButton(_:for:)` on the
+    /// design centerline. See the type-level doc comment (step 4) for why
+    /// this is safer than repositioning the live buttons.
+    private func installOwnedTrafficLights(in window: NSWindow, titlebarView: NSView) {
+        let types: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
+
+        // AppKit can rebuild NSTitlebarView itself (observed after the
+        // window becomes key) without replacing the NSWindow — the same
+        // condition installOrUpdateTitlebarChrome below detects for its own
+        // subviews. A cache keyed only by button type doesn't notice its
+        // views went stale on the old host, so it would silently keep
+        // returning orphaned, invisible clones forever. Check the same
+        // condition here (before installOrUpdateTitlebarChrome updates
+        // chromeHostView for this pass) and drop the cache so fresh clones
+        // get created on the new host.
+        if chromeHostView !== titlebarView {
+            ownedTrafficLights.removeAll()
+            trafficLightNativeFrames.removeAll()
+            originalTrafficLights.removeAll()
+        }
+
+        // Capture the native frame *and a stable reference to the true
+        // AppKit button* once, before any clone exists. This must happen
+        // before hiding/cloning below: `window.standardWindowButton(_:)`
+        // does a live, type-based search of the titlebar's subviews, and
+        // once a factory-vended clone of the same private button class is
+        // also present, that search can return the clone instead of the
+        // original — confirmed empirically (a later pass's "original" was
+        // actually the clone, so this code hid the clone it had just made
+        // visible). Every subsequent read must go through
+        // `originalTrafficLights`, never back through
+        // `window.standardWindowButton(_:)`.
+        if trafficLightNativeFrames.isEmpty {
+            for type in types {
+                guard let original = window.standardWindowButton(type), !original.isHidden else { continue }
+                trafficLightNativeFrames[type] = original.frame
+                originalTrafficLights[type] = original
+            }
+        }
+
+        let centerY = chromeBaselineCenterY(in: titlebarView)
+
+        for (index, type) in types.enumerated() {
+            guard let original = originalTrafficLights[type] else { continue }
+            if !original.isHidden { original.isHidden = true }
+
+            guard let nativeFrame = trafficLightNativeFrames[type] else { continue }
+
+            let owned = ownedTrafficLights[type] ?? {
+                let button = NSWindow.standardWindowButton(type, for: window.styleMask)
+                button?.identifier = SettingsTitlebarLayout.trafficLightIdentifier(for: type)
+                // A button vended by this factory isn't the window's
+                // *registered* close/miniaturize/zoom button, so its own
+                // NSButtonCell mouse-tracking doesn't reliably send
+                // target/action on click — confirmed both by manual testing
+                // (clicks landed but performClose/performZoom never fired)
+                // and by Apple Developer Forums precedent on this exact API
+                // ("may be difficult to impossible to hack those buttons...
+                // the window is doing something"). A click gesture
+                // recognizer uses a separate, independent event path that
+                // doesn't depend on that internal tracking, so it's the
+                // reliable way to dispatch the action; native rendering
+                // (color, hover dim, active/inactive state) still comes free
+                // from the button itself.
+                if let button {
+                    titlebarView.addSubview(button)
+                    button.addGestureRecognizer(
+                        NSClickGestureRecognizer(target: self, action: #selector(ownedTrafficLightClicked(_:)))
+                    )
+                }
+                return button
+            }()
+            guard let owned else { continue }
+            ownedTrafficLights[type] = owned
+
+            if owned.isEnabled != original.isEnabled {
+                owned.isEnabled = original.isEnabled
+            }
+
+            // x comes from the design's own 16px-padding/12px-dot/8px-gap
+            // spec, not nativeFrame.minX (AppKit's native ~13pt inset) —
+            // measured on the packaged app, that native inset put the
+            // cluster ~8.5pt left of what chrome.jsx/primitives.jsx specify,
+            // and mainwindow.jsx composes the traffic lights and the
+            // sidebar's icon column on the same x-axis, so the gap between
+            // them is part of the design, not free for AppKit to decide.
+            let designCenterX = SettingsTitlebarLayout.trafficLightLeadingPadding
+                + SettingsTitlebarLayout.trafficLightDotSize / 2
+                + CGFloat(index) * (SettingsTitlebarLayout.trafficLightDotSize + SettingsTitlebarLayout.trafficLightDotGap)
+            let ownedFrame = NSRect(
+                x: designCenterX - nativeFrame.width / 2,
+                y: centerY - nativeFrame.height / 2,
+                width: nativeFrame.width,
+                height: nativeFrame.height
+            )
+            if owned.frame != ownedFrame {
+                owned.frame = ownedFrame
+            }
+        }
+    }
+
+    @objc private func ownedTrafficLightClicked(_ recognizer: NSClickGestureRecognizer) {
+        guard let button = recognizer.view as? NSButton, button.isEnabled, let window else { return }
+        switch button.identifier {
+        case SettingsTitlebarLayout.trafficLightIdentifier(for: .closeButton):
+            window.performClose(nil)
+        case SettingsTitlebarLayout.trafficLightIdentifier(for: .miniaturizeButton):
+            window.performMiniaturize(nil)
+        case SettingsTitlebarLayout.trafficLightIdentifier(for: .zoomButton):
+            window.performZoom(nil)
+        default:
+            break
+        }
     }
 
     /// Returns `true` when the accessory was added or resized and a layout
@@ -390,13 +575,17 @@ final class SettingsWindowChromeCoordinator: NSObject {
     }
 
     /// The single vertical centerline shared by every Wink-added titlebar
-    /// control: the AppKit-owned traffic lights' midY. Deriving a second
-    /// centerline from the design row height cannot agree with the buttons
-    /// (native titlebar band is 28pt; the 36pt row adds an 8pt bottom
-    /// accessory below it), so nothing else may define one.
+    /// control, expressed in `titlebarView`'s own coordinate space (origin
+    /// at the native 28pt band's bottom edge, i.e. 8pt above the true bottom
+    /// of the full 36pt design row). Wink owns every control on this row —
+    /// including the traffic lights, via `installOwnedTrafficLights` — so
+    /// this can finally be the design row's own midpoint (18pt from the top)
+    /// instead of AppKit's native-band center: `titlebarView.bounds.height`
+    /// is the native band height (28pt); subtracting the design row's half
+    /// height (18pt) converts "18pt from the row's top" into this view's
+    /// bottom-up coordinate space.
     private func chromeBaselineCenterY(in titlebarView: NSView) -> CGFloat {
-        window?.standardWindowButton(.zoomButton)?.frame.midY
-            ?? titlebarView.bounds.midY
+        titlebarView.bounds.height - SettingsTitlebarLayout.height / 2
     }
 
     private func removeInstalledChrome(from hostView: NSView) {
@@ -405,6 +594,9 @@ final class SettingsWindowChromeCoordinator: NSObject {
             SettingsTitlebarLayout.hairlineIdentifier,
             SettingsTitlebarLayout.sidebarToggleIdentifier,
             SettingsTitlebarLayout.titleIdentifier,
+            SettingsTitlebarLayout.trafficLightIdentifier(for: .closeButton),
+            SettingsTitlebarLayout.trafficLightIdentifier(for: .miniaturizeButton),
+            SettingsTitlebarLayout.trafficLightIdentifier(for: .zoomButton),
         ]
         for subview in hostView.subviews where subview.identifier.map(identifiers.contains) == true {
             subview.removeFromSuperview()
@@ -422,13 +614,15 @@ final class SettingsWindowChromeCoordinator: NSObject {
     }
 
     /// The toggle sits `toggleGapFromZoomButton` past the button cluster's
-    /// trailing edge (in reading direction), on the shared baseline. A titled
+    /// trailing edge (in reading direction), on the shared baseline. Anchors
+    /// on Wink's *owned* zoom button (not the hidden AppKit original) since
+    /// that's the one actually visible on the design centerline. A titled
     /// window always carries a zoom button alongside its close button, so
     /// `nil` (leave the current frame untouched) is a defensive fallback, not
     /// a reachable layout state.
     private func sidebarToggleFrame(in titlebarView: NSView) -> NSRect? {
         guard let window,
-              let zoomButton = window.standardWindowButton(.zoomButton) else {
+              let zoomButton = ownedTrafficLights[.zoomButton] else {
             return nil
         }
         let size = SettingsTitlebarLayout.toggleHitSize

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -623,15 +623,18 @@ struct LayoutRegressionTests {
         let topInset = window.frame.height - window.contentLayoutRect.maxY
         let accessory = try #require(window.titlebarAccessoryViewControllers.first)
         let closeButton = try #require(window.standardWindowButton(.closeButton))
-        let zoomButton = try #require(window.standardWindowButton(.zoomButton))
         let titlebarView = try #require(closeButton.superview)
+        let ownedZoomLight = try #require(titlebarView.subviews.first {
+            $0.identifier == SettingsTitlebarLayout.trafficLightIdentifier(for: .zoomButton)
+        })
         let sidebarToggle = try #require(titlebarView.subviews.first {
             $0.identifier == SettingsTitlebarLayout.sidebarToggleIdentifier
         })
         let customTitle = try #require(titlebarView.subviews.first {
             $0.identifier == SettingsTitlebarLayout.titleIdentifier
         })
-        let expectedToggleLeadingX = zoomButton.frame.maxX + SettingsTitlebarLayout.toggleGapFromZoomButton
+        let expectedToggleLeadingX = ownedZoomLight.frame.maxX + SettingsTitlebarLayout.toggleGapFromZoomButton
+        let expectedCenterY = titlebarView.bounds.height - SettingsTitlebarLayout.height / 2
 
         #expect(abs(topInset - SettingsTitlebarLayout.height) < 0.5)
         #expect(abs(titlebarView.bounds.height - SettingsTitlebarLayout.height) < 0.5)
@@ -639,13 +642,94 @@ struct LayoutRegressionTests {
         #expect(accessory.automaticallyAdjustsSize == false)
         #expect(abs(accessory.view.frame.height - SettingsTitlebarLayout.titlebarAccessoryHeight) < 0.5)
         #expect(abs(sidebarToggle.frame.minX - expectedToggleLeadingX) < 0.5)
-        // Single baseline: traffic lights, toggle, and title share the
-        // AppKit-owned button centerline. A design-height-derived second
-        // centerline is exactly the regression this guards against.
-        #expect(abs(sidebarToggle.frame.midY - zoomButton.frame.midY) < 0.5)
-        #expect(abs(customTitle.frame.midY - zoomButton.frame.midY) < 1.0)
-        #expect(abs(customTitle.frame.midY - sidebarToggle.frame.midY) < 1.0)
+        // Single baseline: owned traffic lights, toggle, and title all share
+        // the design row's own midpoint (18pt from the top of the 36pt row).
+        // Wink owns every control on the row now, so a second, AppKit-native
+        // centerline can no longer disagree with this one — that disagreement
+        // (fixed by owning the lights) is exactly the regression this guards.
+        #expect(abs(ownedZoomLight.frame.midY - expectedCenterY) < 0.5)
+        #expect(abs(sidebarToggle.frame.midY - expectedCenterY) < 0.5)
+        #expect(abs(customTitle.frame.midY - expectedCenterY) < 1.0)
         #expect(abs(customTitle.frame.midX - titlebarView.bounds.midX) < 0.5)
+    }
+
+    @Test @MainActor
+    func settingsWindowChromeOwnedTrafficLightsFollowDesignLeadingPadding() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: SettingsWindowMetrics.width, height: SettingsWindowMetrics.height),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let coordinator = SettingsWindowChromeCoordinator()
+
+        coordinator.attach(to: window)
+        window.layoutIfNeeded()
+
+        let closeButton = try #require(window.standardWindowButton(.closeButton))
+        let titlebarView = try #require(closeButton.superview)
+
+        // primitives.jsx TrafficLights: `padding: 0 16px`, 12px dots, 8px
+        // gap — AppKit's native ~13pt inset is a different, fixed system
+        // value that doesn't match this, so owning the buttons must
+        // reposition them to the design's x, not just reuse where AppKit
+        // originally put them.
+        let pitch = SettingsTitlebarLayout.trafficLightDotSize + SettingsTitlebarLayout.trafficLightDotGap
+        let expectedCenters: [NSWindow.ButtonType: CGFloat] = [
+            .closeButton: SettingsTitlebarLayout.trafficLightLeadingPadding + SettingsTitlebarLayout.trafficLightDotSize / 2,
+            .miniaturizeButton: SettingsTitlebarLayout.trafficLightLeadingPadding + SettingsTitlebarLayout.trafficLightDotSize / 2 + pitch,
+            .zoomButton: SettingsTitlebarLayout.trafficLightLeadingPadding + SettingsTitlebarLayout.trafficLightDotSize / 2 + pitch * 2,
+        ]
+        for (type, expectedCenterX) in expectedCenters {
+            let owned = try #require(titlebarView.subviews.first {
+                $0.identifier == SettingsTitlebarLayout.trafficLightIdentifier(for: type)
+            })
+            #expect(abs(owned.frame.midX - expectedCenterX) < 0.5)
+        }
+    }
+
+    @Test @MainActor
+    func settingsWindowChromeOwnsTrafficLightsAndHidesAppKitOriginals() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: SettingsWindowMetrics.width, height: SettingsWindowMetrics.height),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        // Capture the true AppKit button references *before* attach() ever
+        // runs. Once an owned clone of the same private button class exists
+        // alongside the original, window.standardWindowButton(_:) does a
+        // live, type-based hierarchy search that can return either one —
+        // confirmed empirically, this is exactly why production code caches
+        // these references instead of re-querying. Querying fresh after
+        // attach() would make this assertion meaningless (it could just as
+        // easily land on the clone, which is deliberately left visible).
+        let closeButton = try #require(window.standardWindowButton(.closeButton))
+        let minimizeButton = try #require(window.standardWindowButton(.miniaturizeButton))
+        let zoomButton = try #require(window.standardWindowButton(.zoomButton))
+        let titlebarView = try #require(closeButton.superview)
+
+        let coordinator = SettingsWindowChromeCoordinator()
+        coordinator.attach(to: window)
+        window.layoutIfNeeded()
+
+        #expect(closeButton.isHidden)
+        #expect(minimizeButton.isHidden)
+        #expect(zoomButton.isHidden)
+
+        let ownedTypes: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
+        for type in ownedTypes {
+            let owned = try #require(titlebarView.subviews.first {
+                $0.identifier == SettingsTitlebarLayout.trafficLightIdentifier(for: type)
+            } as? NSButton)
+            // Click dispatch goes through a gesture recognizer, not
+            // target/action — a factory-vended button's own mouse tracking
+            // doesn't reliably fire target/action once detached from the
+            // window's internal bookkeeping (confirmed via manual testing).
+            #expect(owned.gestureRecognizers.contains { $0 is NSClickGestureRecognizer })
+            #expect(owned.frame.width > 0)
+            #expect(owned.frame.height > 0)
+        }
     }
 
     @Test @MainActor
@@ -676,12 +760,15 @@ struct LayoutRegressionTests {
             backing: .buffered,
             defer: false
         )
-        let coordinator = SettingsWindowChromeCoordinator()
-
-        coordinator.attach(to: window)
+        // Capture references before attach() — see the comment in
+        // settingsWindowChromeOwnsTrafficLightsAndHidesAppKitOriginals for
+        // why a post-attach lookup is ambiguous once a clone exists.
         let closeButton = try #require(window.standardWindowButton(.closeButton))
         let minimizeButton = try #require(window.standardWindowButton(.miniaturizeButton))
         let zoomButton = try #require(window.standardWindowButton(.zoomButton))
+
+        let coordinator = SettingsWindowChromeCoordinator()
+        coordinator.attach(to: window)
         let appKitOwnedOrigins = [
             closeButton: closeButton.frame.origin.offsetBy(dx: -8, dy: -4),
             minimizeButton: minimizeButton.frame.origin.offsetBy(dx: -8, dy: -4),


### PR DESCRIPTION
## Summary
- Own the three close/miniaturize/zoom traffic-light buttons (via `NSWindow.standardWindowButton(_:for:)`) instead of only positioning controls around AppKit's native-placed ones, so the whole cluster can finally sit on the design's true position — vertically at the row's 18pt center (not AppKit's ~14pt native band) and horizontally at `chrome.jsx`/`primitives.jsx`'s 16px-padding/12px-dot/8px-gap spec (not AppKit's ~13pt native inset).
- Click dispatch goes through `NSClickGestureRecognizer` rather than the factory button's own target/action, which doesn't reliably fire once the button is detached from the window's internal bookkeeping (confirmed via manual testing and Apple Developer Forums precedent on this API).
- Fixes three bugs only found via live packaged-app testing (invisible in a single static screenshot or in `swift test` alone): a two-pass `isHidden` convergence where later subview changes re-showed the AppKit originals; `window.standardWindowButton(_:)` becoming an ambiguous live search once a same-class clone exists in the titlebar view hierarchy; and `NSTitlebarView` occasionally rebuilding itself (orphaning cached clones) without the owning `NSWindow` being replaced.

## Test plan
- [x] `swift test` — 420/420 passing, including two new regression tests (`settingsWindowChromeOwnsTrafficLightsAndHidesAppKitOriginals`, `settingsWindowChromeOwnedTrafficLightsFollowDesignLeadingPadding`)
- [x] `swift build -c release` + `scripts/package-app.sh`
- [x] Verified on the packaged app via pixel measurement: traffic-light dot centers land at (21.5, 41.5, 61.5) on the x-axis and ~17.5–18 on the y-axis, matching the design spec (22/42/62, 18)
- [x] Verified live click dispatch: clicking the owned close button closes the real packaged-app window
- [x] Verified no duplicate/flickering lights across repeated `applyAll()` passes and after the window becomes key

🤖 Generated with [Claude Code](https://claude.com/claude-code)