### PR TITLE
fix(ui): Shortcuts tab design-fidelity drift + AppPickerPopover arrow-key nav

### DIFF
--- a/Sources/Wink/UI/AppPickerPopover.swift
+++ b/Sources/Wink/UI/AppPickerPopover.swift
@@ -37,6 +37,8 @@ struct AppPickerHighlightState {
 }
 
 struct AppPickerPopover: View {
+    @Environment(\.winkPalette) private var palette
+
     @Bindable var appListProvider: AppListProvider
     let onSelect: (AppEntry) -> Void
     let onBrowse: () -> Void
@@ -69,95 +71,97 @@ struct AppPickerPopover: View {
 
     var body: some View {
         let sections = computeSections()
-        return VStack(spacing: 0) {
-            // Search field
-            HStack(spacing: 6) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
-                    .font(.system(size: 12))
-                TextField("Search apps...", text: $searchText)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 13))
-                    .onSubmit { selectHighlighted(in: sections) }
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
 
-            Divider()
+        // `ScrollViewReader` wraps the whole popover (not just the list) so the
+        // arrow-key handlers can live on the outer VStack, an ancestor of both
+        // the search TextField and the list — `.onKeyPress` only fires when the
+        // modified view or a descendant holds focus, and a TextField sibling
+        // doesn't qualify.
+        return ScrollViewReader { proxy in
+            VStack(spacing: 0) {
+                HStack(spacing: 6) {
+                    WinkIcon.search.image(size: 12)
+                        .foregroundStyle(palette.textTertiary)
+                    TextField("Search apps...", text: $searchText)
+                        .textFieldStyle(.plain)
+                        .font(WinkType.bodyText)
+                        .foregroundStyle(palette.textPrimary)
+                        .onSubmit { selectHighlighted(in: sections) }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
 
-            // Scrollable list with keyboard nav
-            ScrollViewReader { proxy in
+                Divider().overlay(palette.hairline)
+
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         if searchText.isEmpty {
                             if !sections.recent.isEmpty {
-                                sectionHeader("Recently Used")
+                                WinkSectionLabel("Recently Used")
+                                    .padding(.horizontal, 14)
+                                    .padding(.top, 8)
+                                    .padding(.bottom, 4)
                                 ForEach(Array(sections.recent.enumerated()), id: \.element.id) { index, entry in
-                                    appRow(entry, index: index, proxy: proxy)
+                                    appRow(entry, index: index)
                                 }
                             }
 
                             if !sections.nonRecent.isEmpty {
-                                sectionHeader("All Apps")
+                                WinkSectionLabel("All Apps")
+                                    .padding(.horizontal, 14)
+                                    .padding(.top, 8)
+                                    .padding(.bottom, 4)
                                 ForEach(Array(sections.nonRecent.enumerated()), id: \.element.id) { i, entry in
                                     let index = sections.recent.count + i
-                                    appRow(entry, index: index, proxy: proxy)
+                                    appRow(entry, index: index)
                                 }
                             }
                         } else {
                             ForEach(Array(sections.all.enumerated()), id: \.element.id) { index, entry in
-                                appRow(entry, index: index, proxy: proxy)
+                                appRow(entry, index: index)
                             }
                         }
                     }
                 }
-                .onKeyPress(.upArrow) { moveHighlight(-1, proxy: proxy, in: sections); return .handled }
-                .onKeyPress(.downArrow) { moveHighlight(1, proxy: proxy, in: sections); return .handled }
+                // `.onSubmit` on the search TextField already handles Return
+                // while typing; keep this scoped to the list so a highlighted
+                // row doesn't fire selection twice.
                 .onKeyPress(.return) { selectHighlighted(in: sections); return .handled }
-            }
 
-            Divider()
+                Divider().overlay(palette.hairline)
 
-            // Browse fallback
-            Button {
-                onBrowse()
-                dismiss()
-            } label: {
-                HStack {
-                    Image(systemName: "folder")
-                    Text("Browse...")
+                Button {
+                    onBrowse()
+                    dismiss()
+                } label: {
+                    HStack {
+                        Image(systemName: "folder")
+                        Text("Browse...")
+                    }
+                    .font(WinkType.labelSmall)
+                    .foregroundStyle(palette.textSecondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 6)
                 }
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 6)
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
+            .frame(width: 320, height: 400)
+            .onAppear {
+                appListProvider.refreshIfNeeded()
+                highlight.reset()
+            }
+            .onChange(of: searchText) {
+                highlight.searchTextChanged()
+            }
+            .onKeyPress(.upArrow) { moveHighlight(-1, proxy: proxy, in: sections); return .handled }
+            .onKeyPress(.downArrow) { moveHighlight(1, proxy: proxy, in: sections); return .handled }
+            .onKeyPress(.escape) { dismiss(); return .handled }
         }
-        .frame(width: 320, height: 400)
-        .onAppear {
-            appListProvider.refreshIfNeeded()
-            highlight.reset()
-        }
-        .onChange(of: searchText) {
-            highlight.searchTextChanged()
-        }
-        .onKeyPress(.escape) { dismiss(); return .handled }
     }
 
     // MARK: - Subviews
 
-    private func sectionHeader(_ title: String) -> some View {
-        Text(title.uppercased())
-            .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(.secondary)
-            .tracking(0.5)
-            .padding(.horizontal, 14)
-            .padding(.top, 8)
-            .padding(.bottom, 4)
-    }
-
-    private func appRow(_ entry: AppEntry, index: Int, proxy: ScrollViewProxy) -> some View {
+    private func appRow(_ entry: AppEntry, index: Int) -> some View {
         Button {
             select(entry)
         } label: {
@@ -165,16 +169,17 @@ struct AppPickerPopover: View {
                 AppIconView(bundleIdentifier: entry.bundleIdentifier, size: 28)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(entry.name)
-                        .font(.system(size: 13, weight: highlightedIndex == index ? .medium : .regular))
+                        .font(highlightedIndex == index ? WinkType.bodyMedium : WinkType.bodyText)
+                        .foregroundStyle(palette.textPrimary)
                     Text(entry.bundleIdentifier)
                         .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(palette.textTertiary)
                 }
                 Spacer()
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
-            .background(highlightedIndex == index ? Color.accentColor.opacity(0.15) : Color.clear)
+            .background(highlightedIndex == index ? palette.accentBgSoft : Color.clear)
             .clipShape(RoundedRectangle(cornerRadius: 6))
             .contentShape(Rectangle())
         }

--- a/Sources/Wink/UI/DesignSystem/DesignTokens.swift
+++ b/Sources/Wink/UI/DesignSystem/DesignTokens.swift
@@ -62,6 +62,11 @@ enum WinkPalette {
         // Misc
         let heatmapBase: Color
         let focusRing: Color
+
+        /// Fixed neutral grey for the "no app chosen" placeholder swatch.
+        /// A deliberately fixed hue rather than a translucent control token —
+        /// mirrors tab-shortcuts.jsx:66's literal `#D8D8D8`/`#5A5A5C`.
+        let appPlaceholderSwatchBg: Color
     }
 
     static let light = Tokens(
@@ -108,7 +113,9 @@ enum WinkPalette {
         amberBgSoft:      .winkSRGB(0xC7, 0x78, 0x00, 0.10),
 
         heatmapBase:    .winkSRGB(0x00, 0x64, 0xE0, 0.10),
-        focusRing:      .winkSRGB(0x00, 0x64, 0xE0, 0.35)
+        focusRing:      .winkSRGB(0x00, 0x64, 0xE0, 0.35),
+
+        appPlaceholderSwatchBg: .winkSRGB(0xD8, 0xD8, 0xD8)
     )
 
     static let dark = Tokens(
@@ -155,7 +162,9 @@ enum WinkPalette {
         amberBgSoft:      .winkSRGB(0xF5, 0xB5, 0x3F, 0.14),
 
         heatmapBase:    .winkSRGB(0x2A, 0x8F, 0xFF, 0.20),
-        focusRing:      .winkSRGB(0x2A, 0x8F, 0xFF, 0.45)
+        focusRing:      .winkSRGB(0x2A, 0x8F, 0xFF, 0.45),
+
+        appPlaceholderSwatchBg: .winkSRGB(0x5A, 0x5A, 0x5C)
     )
 
     static func tokens(for scheme: ColorScheme) -> Tokens {
@@ -232,6 +241,7 @@ enum WinkType {
     static let sectionLabel = Font.system(size: 11, weight: .semibold)
     static let cardTitle    = Font.system(size: 12, weight: .semibold)
     static let tabTitle     = Font.system(size: 20, weight: .semibold)
+    static let tabSubtitle  = Font.system(size: 12, weight: .regular)
     static let bodyText     = Font.system(size: 13, weight: .regular)
     static let bodyMedium   = Font.system(size: 13, weight: .medium)
     static let labelSmall   = Font.system(size: 11, weight: .regular)

--- a/Sources/Wink/UI/DesignSystem/WinkPrimitives.swift
+++ b/Sources/Wink/UI/DesignSystem/WinkPrimitives.swift
@@ -91,7 +91,7 @@ struct WinkBanner<Trailing: View>: View {
 
     var body: some View {
         let s = style
-        HStack(alignment: .top, spacing: 12) {
+        HStack(alignment: .top, spacing: 10) {
             Image(systemName: s.systemImage)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(s.foreground)
@@ -206,12 +206,16 @@ struct WinkStatusDot: View {
     var size: CGFloat = 6
 
     var body: some View {
+        // Mirrors the CSS spread box-shadow `0 0 0 2px ${color}22`, which sits
+        // entirely outside the dot's box — a stroke on the dot's own edge
+        // would halve the halo instead of extending past it.
         Circle()
-            .fill(color)
-            .frame(width: size, height: size)
+            .fill(color.opacity(0.13))
+            .frame(width: size + 4, height: size + 4)
             .overlay(
                 Circle()
-                    .stroke(color.opacity(0.13), lineWidth: 2)
+                    .fill(color)
+                    .frame(width: size, height: size)
             )
     }
 }

--- a/Sources/Wink/UI/SharedComponents.swift
+++ b/Sources/Wink/UI/SharedComponents.swift
@@ -18,29 +18,20 @@ struct SettingsTabHeader<Trailing: View>: View {
     }
 
     var body: some View {
-        HStack(alignment: .bottom, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
+        HStack(alignment: .bottom, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(WinkType.tabTitle)
+                    .tracking(-0.3)
                     .foregroundStyle(palette.textPrimary)
                 Text(subtitle)
-                    .font(WinkType.bodyText)
+                    .font(WinkType.tabSubtitle)
                     .foregroundStyle(palette.textSecondary)
             }
 
             Spacer(minLength: 8)
             trailing()
         }
-    }
-}
-
-// MARK: - Alternating row background
-
-extension View {
-    func alternatingRowBackground(index: Int) -> some View {
-        self.background(index.isMultiple(of: 2)
-            ? Color.clear
-            : Color.primary.opacity(0.03))
     }
 }
 

--- a/Sources/Wink/UI/ShortcutRecorderView.swift
+++ b/Sources/Wink/UI/ShortcutRecorderView.swift
@@ -1,64 +1,125 @@
 import AppKit
 import SwiftUI
 
-struct ShortcutRecorderView: NSViewRepresentable {
+/// The active-recording composer field. Renders the dashed accent-blue
+/// control from tab-shortcuts.jsx:80-94 in SwiftUI, backed by an invisible
+/// `RecorderField` (NSView) that owns keyboard capture.
+struct ShortcutRecorderView: View {
+    @Environment(\.winkPalette) private var palette
+
     @Binding var recordedShortcut: RecordedShortcut?
     @Binding var isRecording: Bool
 
+    @State private var liveModifierLabels: [String] = []
+    @State private var errorMessage: String?
+
+    private var tint: Color {
+        errorMessage == nil ? palette.accent : palette.amber
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            WinkIcon.record.image(size: 11)
+                .foregroundStyle(tint)
+            Text(errorMessage ?? "Recording…")
+                .font(WinkType.bodyText)
+                .fontWeight(.medium)
+                .foregroundStyle(tint)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Spacer(minLength: 6)
+
+            if errorMessage == nil, !liveModifierLabels.isEmpty {
+                ShortcutKeycapStrip(labels: liveModifierLabels, size: .small)
+            }
+        }
+        .padding(.horizontal, 8)
+        .frame(maxWidth: .infinity, minHeight: 28)
+        .background(palette.fieldBg)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(
+                    palette.accentBorderSoft,
+                    style: StrokeStyle(lineWidth: 1, dash: ShortcutRecorderIdleField.dashPattern)
+                )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .background(
+            RecorderKeyCaptureRepresentable(
+                isRecording: isRecording,
+                onCapture: { shortcut in
+                    recordedShortcut = shortcut
+                    isRecording = false
+                },
+                onRecordingChange: { recording in
+                    isRecording = recording
+                },
+                onCancel: {
+                    isRecording = false
+                },
+                onLiveModifiersChange: { modifiers in
+                    liveModifierLabels = modifiers.map(ModifierFormatting.symbol(for:))
+                },
+                onErrorChange: { message in
+                    errorMessage = message
+                }
+            )
+        )
+    }
+}
+
+private struct RecorderKeyCaptureRepresentable: NSViewRepresentable {
+    let isRecording: Bool
+    let onCapture: (RecordedShortcut) -> Void
+    let onRecordingChange: (Bool) -> Void
+    let onCancel: () -> Void
+    let onLiveModifiersChange: ([String]) -> Void
+    let onErrorChange: (String?) -> Void
+
     func makeNSView(context: Context) -> RecorderField {
         let field = RecorderField()
-        field.onCapture = { shortcut in
-            recordedShortcut = shortcut
-            isRecording = false
-        }
-        field.onRecordingChange = { recording in
-            isRecording = recording
-        }
-        field.onCancel = {
-            isRecording = false
-        }
+        updateCallbacks(on: field)
         return field
     }
 
     func updateNSView(_ nsView: RecorderField, context: Context) {
-        nsView.updateRecordingState(isRecording: isRecording, shortcut: recordedShortcut)
+        updateCallbacks(on: nsView)
+        nsView.updateRecordingState(isRecording: isRecording)
+    }
+
+    private func updateCallbacks(on field: RecorderField) {
+        field.onCapture = onCapture
+        field.onRecordingChange = onRecordingChange
+        field.onCancel = onCancel
+        field.onLiveModifiersChange = onLiveModifiersChange
+        field.onErrorChange = onErrorChange
     }
 }
 
-final class RecorderField: NSTextField {
+/// Invisible key-capture surface for the recording composer. Owns no visible
+/// chrome — `ShortcutRecorderView` draws the designed dashed control on top —
+/// but still needs real `NSView` first-responder status to receive
+/// `keyDown`/`flagsChanged` events.
+final class RecorderField: NSView {
     var onCapture: ((RecordedShortcut) -> Void)?
     var onRecordingChange: ((Bool) -> Void)?
     var onCancel: (() -> Void)?
+    var onLiveModifiersChange: (([String]) -> Void)?
+    var onErrorChange: ((String?) -> Void)?
+
     private let keySymbolMapper = KeySymbolMapper()
     private var isRecording = false
 
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        isEditable = false
-        isBordered = true
-        isBezeled = true
-        focusRingType = .default
-        placeholderString = "Click to record shortcut"
-    }
+    override var acceptsFirstResponder: Bool { true }
 
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    func updateRecordingState(isRecording: Bool, shortcut: RecordedShortcut?) {
+    func updateRecordingState(isRecording: Bool) {
         self.isRecording = isRecording
-        if isRecording {
-            placeholderString = "Press shortcut (Esc to cancel)"
-            stringValue = ""
-            textColor = .controlAccentColor
-        } else {
-            placeholderString = "Click to record shortcut"
-            stringValue = shortcut?.displayText ?? ""
-            textColor = .labelColor
+        if !isRecording {
+            onLiveModifiersChange?([])
+            onErrorChange?(nil)
         }
     }
-
-    override var acceptsFirstResponder: Bool { true }
 
     override func mouseDown(with event: NSEvent) {
         window?.makeFirstResponder(self)
@@ -78,21 +139,26 @@ final class RecorderField: NSTextField {
         let keyEquivalent = keySymbolMapper.keyEquivalent(for: CGKeyCode(event.keyCode))
 
         if modifiers.isEmpty {
-            stringValue = "Requires at least one modifier (⌘⌥⌃⇧)"
-            textColor = .systemOrange
+            onErrorChange?("Requires at least one modifier (⌘⌥⌃⇧)")
             return
         }
 
         guard let keyEquivalent else {
-            stringValue = "Unsupported key — try a letter, number, or F-key"
-            textColor = .systemOrange
+            onErrorChange?("Unsupported key — try a letter, number, or F-key")
             return
         }
 
-        let shortcut = RecordedShortcut(keyEquivalent: keyEquivalent, modifierFlags: modifiers)
-        onCapture?(shortcut)
-        stringValue = shortcut.displayText
-        textColor = .labelColor
+        onErrorChange?(nil)
+        onCapture?(RecordedShortcut(keyEquivalent: keyEquivalent, modifierFlags: modifiers))
+    }
+
+    override func flagsChanged(with event: NSEvent) {
+        guard isRecording else {
+            super.flagsChanged(with: event)
+            return
+        }
+        onLiveModifiersChange?(normalizedModifiers(from: event.modifierFlags))
+        super.flagsChanged(with: event)
     }
 
     override func resignFirstResponder() -> Bool {

--- a/Sources/Wink/UI/ShortcutsTabView.swift
+++ b/Sources/Wink/UI/ShortcutsTabView.swift
@@ -3,7 +3,7 @@ import Combine
 import SwiftUI
 
 private enum ShortcutRowMetrics {
-    static let spacing: CGFloat = 12
+    static let spacing: CGFloat = 10
     static let gripColumnWidth: CGFloat = 24
     static let gripHitHeight: CGFloat = 24
     static let iconSize: CGFloat = 30
@@ -16,7 +16,7 @@ private enum ShortcutRowMetrics {
     static let shortcutColumnWidth: CGFloat = 112
     static let switchColumnWidth: CGFloat = 36
     static let actionButtonSize: CGFloat = 22
-    static let accessorySpacing: CGFloat = 8
+    static let accessorySpacing: CGFloat = 10
 
     static var accessoryGroupWidth: CGFloat {
         hyperBadgeColumnWidth + shortcutColumnWidth + switchColumnWidth + actionButtonSize + accessorySpacing * 3
@@ -330,12 +330,12 @@ struct ShortcutsTabView: View {
                             } label: {
                                 HStack(spacing: 8) {
                                     if editor.selectedBundleIdentifier.isEmpty {
-                                        RoundedRectangle(cornerRadius: 4, style: .continuous)
-                                            .fill(palette.controlBgRest)
-                                            .frame(width: 20, height: 20)
+                                        RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                            .fill(palette.appPlaceholderSwatchBg)
+                                            .frame(width: 18, height: 18)
                                             .overlay {
-                                                WinkIcon.app.image(size: 11)
-                                                    .foregroundStyle(palette.textTertiary)
+                                                WinkIcon.plus.image(size: 10)
+                                                    .foregroundStyle(.white)
                                             }
 
                                         Text("Choose an app…")
@@ -568,7 +568,6 @@ struct ShortcutsTabView: View {
                                 reorderableRow(shortcut, index: index, canReorder: canReorder)
                                 if index < filteredShortcuts.count - 1 {
                                     Divider().overlay(palette.hairline)
-                                        .padding(.leading, 58)
                                 }
                             }
                         }
@@ -820,6 +819,9 @@ struct ShortcutsListRow: View {
     let onRemove: @MainActor () -> Void
     let reorderHandlers: ShortcutRowReorderHandlers?
 
+    @State private var isRowHovering = false
+    @State private var isMenuButtonHovering = false
+
     private var presentation: ShortcutsListRowPresentation {
         ShortcutsListRowPresentation(
             shortcut: shortcut,
@@ -914,7 +916,8 @@ struct ShortcutsListRow: View {
         .padding(.horizontal, 14)
         .padding(.vertical, ShortcutRowMetrics.verticalPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .alternatingRowBackground(index: index)
+        .background(isRowHovering ? Color.primary.opacity(0.035) : Color.clear)
+        .onHover { isRowHovering = $0 }
         .opacity(presentation.contentOpacity)
         .animation(statusAnimation, value: statusAnimationKey)
     }
@@ -948,6 +951,24 @@ struct ShortcutsListRow: View {
         }
     }
 
+    // The row badge is one unified pill holding the whole chord string, unlike
+    // the composer's live-record preview which shows discrete Keycap chips
+    // per modifier (tab-shortcuts.jsx:143-151 vs. :91-93).
+    private var shortcutBadge: some View {
+        Text(shortcut.displayText)
+            .font(WinkType.monoBadge)
+            .tracking(0.5)
+            .foregroundStyle(palette.textPrimary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(palette.controlBgRest)
+            .overlay(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .stroke(palette.controlBorder, lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+    }
+
     private var shortcutAccessoryGroup: some View {
         HStack(spacing: ShortcutRowMetrics.accessorySpacing) {
             Group {
@@ -960,7 +981,7 @@ struct ShortcutsListRow: View {
             }
             .frame(width: ShortcutRowMetrics.hyperBadgeColumnWidth, alignment: .trailing)
 
-            ShortcutKeycapStrip(shortcut: shortcut)
+            shortcutBadge
                 .frame(width: ShortcutRowMetrics.shortcutColumnWidth, alignment: .trailing)
 
             WinkSwitch(isOn: Binding(
@@ -974,7 +995,7 @@ struct ShortcutsListRow: View {
                 Button("Delete Shortcut", role: .destructive, action: onRemove)
             } label: {
                 RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .fill(Color.clear)
+                    .fill(isMenuButtonHovering ? palette.controlBgRest : Color.clear)
                     .frame(width: ShortcutRowMetrics.actionButtonSize, height: ShortcutRowMetrics.actionButtonSize)
                     .overlay {
                         WinkIcon.more.image(size: 12)
@@ -984,6 +1005,7 @@ struct ShortcutsListRow: View {
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .frame(width: ShortcutRowMetrics.actionButtonSize, height: ShortcutRowMetrics.actionButtonSize)
+            .onHover { isMenuButtonHovering = $0 }
             .disabled(importPreviewActive)
         }
         .frame(width: ShortcutRowMetrics.accessoryGroupWidth, alignment: .trailing)


### PR DESCRIPTION
Fixes #305.

## Summary
10 findings fixed against `docs/design/reference/tab-shortcuts.jsx`:
- **Bug**: arrow-key navigation in `AppPickerPopover` was dead while the search field had focus (`.onKeyPress` sat on a sibling of the TextField, not an ancestor) — moved onto the outer VStack alongside `.onKeyPress(.escape)`, which already worked from anywhere.
- Active shortcut recording now renders as the designed dashed accent-blue composer (record glyph, "Recording…" label, live keycap chips) instead of a plain native `NSTextField` — that was the one state the design explicitly mocked up and the one that had abandoned the app's visual language.
- List-row shortcut badge is now one unified pill (matching the design) instead of separate bordered keycap chiclets.
- Fixed the "Choose an app…" placeholder swatch (wrong icon — app-grid instead of plus — wrong near-invisible color, wrong size).
- Normalized spacing, row hover feedback, edge-to-edge separators, and `AppPickerPopover`'s token usage against the rest of the design system.

## Test plan
- [x] `swift test` — full suite passing (verified both in this branch's isolated worktree and again after integration-merging with #303/#304/#306/#307)
- [x] `swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)