### PR TITLE
polish: align Insights tab visuals with tab-insights.jsx

### DIFF
--- a/Sources/Wink/UI/DesignSystem/DesignTokens.swift
+++ b/Sources/Wink/UI/DesignSystem/DesignTokens.swift
@@ -43,6 +43,7 @@ enum WinkPalette {
         let controlBorder: Color
         let fieldBg: Color
         let fieldBorder: Color
+        let progressTrackBg: Color
 
         // Accents
         let accent: Color
@@ -60,7 +61,7 @@ enum WinkPalette {
         let amberBgSoft: Color
 
         // Misc
-        let heatmapBase: Color
+        let heatmapEmpty: Color
         let focusRing: Color
     }
 
@@ -92,6 +93,7 @@ enum WinkPalette {
         controlBorder:  .winkBlack(0.14),
         fieldBg:        .winkSRGB(0xFF, 0xFF, 0xFF),
         fieldBorder:    .winkBlack(0.10),
+        progressTrackBg: .winkBlack(0.04),
 
         accent:           .winkSRGB(0x00, 0x64, 0xE0),
         accentHover:      .winkSRGB(0x00, 0x4F, 0xC2),
@@ -107,7 +109,7 @@ enum WinkPalette {
         amber:            .winkSRGB(0xC7, 0x78, 0x00),
         amberBgSoft:      .winkSRGB(0xC7, 0x78, 0x00, 0.10),
 
-        heatmapBase:    .winkSRGB(0x00, 0x64, 0xE0, 0.10),
+        heatmapEmpty:   .winkBlack(0.04),
         focusRing:      .winkSRGB(0x00, 0x64, 0xE0, 0.35)
     )
 
@@ -139,6 +141,7 @@ enum WinkPalette {
         controlBorder:  .winkWhite(0.10),
         fieldBg:        .winkSRGB(0x2A, 0x2A, 0x2C),
         fieldBorder:    .winkWhite(0.08),
+        progressTrackBg: .winkWhite(0.05),
 
         accent:           .winkSRGB(0x2A, 0x8F, 0xFF),
         accentHover:      .winkSRGB(0x4A, 0xA0, 0xFF),
@@ -154,7 +157,7 @@ enum WinkPalette {
         amber:            .winkSRGB(0xF5, 0xB5, 0x3F),
         amberBgSoft:      .winkSRGB(0xF5, 0xB5, 0x3F, 0.14),
 
-        heatmapBase:    .winkSRGB(0x2A, 0x8F, 0xFF, 0.20),
+        heatmapEmpty:   .winkWhite(0.04),
         focusRing:      .winkSRGB(0x2A, 0x8F, 0xFF, 0.45)
     )
 

--- a/Sources/Wink/UI/DesignSystem/WinkPrimitives.swift
+++ b/Sources/Wink/UI/DesignSystem/WinkPrimitives.swift
@@ -66,27 +66,32 @@ struct WinkBanner<Trailing: View>: View {
     let kind: WinkBannerKind
     let title: String
     let message: String?
+    var icon: String?
     @ViewBuilder var trailing: () -> Trailing
 
     init(
         kind: WinkBannerKind,
         title: String,
         message: String? = nil,
+        icon: String? = nil,
         @ViewBuilder trailing: @escaping () -> Trailing
     ) {
         self.kind = kind
         self.title = title
         self.message = message
+        self.icon = icon
         self.trailing = trailing
     }
 
     private var style: (background: Color, foreground: Color, systemImage: String) {
+        let base: (background: Color, foreground: Color, systemImage: String)
         switch kind {
-        case .success: return (palette.greenSoft,    palette.green, "checkmark.circle.fill")
-        case .info:    return (palette.accentBgSoft, palette.accent, "info.circle.fill")
-        case .warn:    return (palette.amberBgSoft,  palette.amber, "exclamationmark.triangle.fill")
-        case .error:   return (palette.redBgSoft,    palette.red,   "exclamationmark.octagon.fill")
+        case .success: base = (palette.greenSoft,    palette.green, "checkmark.circle.fill")
+        case .info:    base = (palette.accentBgSoft, palette.accent, "info.circle.fill")
+        case .warn:    base = (palette.amberBgSoft,  palette.amber, "exclamationmark.triangle.fill")
+        case .error:   base = (palette.redBgSoft,    palette.red,   "exclamationmark.octagon.fill")
         }
+        return (base.background, base.foreground, icon ?? base.systemImage)
     }
 
     var body: some View {
@@ -123,8 +128,8 @@ struct WinkBanner<Trailing: View>: View {
 
 /// Convenience initializer for banners without a trailing accessory.
 extension WinkBanner where Trailing == EmptyView {
-    init(kind: WinkBannerKind, title: String, message: String? = nil) {
-        self.init(kind: kind, title: title, message: message) { EmptyView() }
+    init(kind: WinkBannerKind, title: String, message: String? = nil, icon: String? = nil) {
+        self.init(kind: kind, title: title, message: message, icon: icon) { EmptyView() }
     }
 }
 

--- a/Sources/Wink/UI/Insights/InsightsAppRow.swift
+++ b/Sources/Wink/UI/Insights/InsightsAppRow.swift
@@ -7,7 +7,7 @@ private enum InsightsAppRowLayout {
     static let progressCornerRadius: CGFloat = 3
     static let sparklineWidth: CGFloat = 80
     static let sparklineHeight: CGFloat = 24
-    static let countMinWidth: CGFloat = 32
+    static let countMinWidth: CGFloat = 28
 }
 
 struct InsightsAppRow: View {
@@ -44,12 +44,13 @@ struct InsightsAppRow: View {
                 WinkSparkline(
                     points: item.sparklinePoints,
                     stroke: item.count == 0 ? palette.textTertiary : palette.accent,
-                    fill: item.count == 0 ? .clear : palette.accent.opacity(0.1)
+                    fill: item.count == 0 ? .clear : palette.accentBgSoft
                 )
                 .frame(width: InsightsAppRowLayout.sparklineWidth, height: InsightsAppRowLayout.sparklineHeight)
 
                 Text(item.count.formatted(.number.grouping(.automatic)))
-                    .font(WinkType.monoBadge)
+                    .font(.system(size: 13, weight: .semibold))
+                    .monospacedDigit()
                     .foregroundStyle(palette.textPrimary)
                     .frame(minWidth: InsightsAppRowLayout.countMinWidth, alignment: .trailing)
             }
@@ -60,7 +61,6 @@ struct InsightsAppRow: View {
             if showsDivider {
                 Divider()
                     .overlay(palette.hairline)
-                    .padding(.leading, 56)
             }
         }
     }
@@ -69,7 +69,7 @@ struct InsightsAppRow: View {
         GeometryReader { geometry in
             ZStack(alignment: .leading) {
                 RoundedRectangle(cornerRadius: InsightsAppRowLayout.progressCornerRadius, style: .continuous)
-                    .fill(palette.controlBgRest)
+                    .fill(palette.progressTrackBg)
 
                 if item.count > 0 {
                     RoundedRectangle(cornerRadius: InsightsAppRowLayout.progressCornerRadius, style: .continuous)
@@ -101,9 +101,9 @@ private struct InsightsInlineChangeLabel: View {
     private var systemImage: String {
         switch change.tone {
         case .positive:
-            return "arrow.up.right"
+            return "arrow.up"
         case .negative:
-            return "arrow.down.right"
+            return "arrow.down"
         case .neutral:
             return "minus"
         }
@@ -119,9 +119,9 @@ private struct InsightsInlineChangeLabel: View {
     var body: some View {
         HStack(spacing: 3) {
             Image(systemName: systemImage)
-                .font(.system(size: 9, weight: .semibold))
+                .font(.system(size: 10.5, weight: .semibold))
             Text(displayText)
-                .font(WinkType.labelSmall.weight(.semibold))
+                .font(.system(size: 10.5, weight: .semibold))
         }
         .foregroundStyle(foreground)
         .lineLimit(1)

--- a/Sources/Wink/UI/Insights/InsightsHourlyHeatmap.swift
+++ b/Sources/Wink/UI/Insights/InsightsHourlyHeatmap.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 private enum InsightsHeatmapLayout {
-    static let dayLabelWidth: CGFloat = 32
+    static let dayLabelWidth: CGFloat = 24
     static let labelGridSpacing: CGFloat = 8
     static let columnSpacing: CGFloat = 2
     static let rowSpacing: CGFloat = 3
@@ -50,9 +50,8 @@ struct InsightsHourlyHeatmap: View {
                     ForEach(groupedRows, id: \.date) { row in
                         HStack(spacing: InsightsHeatmapLayout.labelGridSpacing) {
                             Text(dayLabel(for: row.date))
-                                .font(WinkType.labelSmall)
+                                .font(.system(size: 10, weight: .regular))
                                 .foregroundStyle(palette.textTertiary)
-                                .textCase(.uppercase)
                                 .lineLimit(1)
                                 .fixedSize(horizontal: true, vertical: false)
                                 .frame(width: InsightsHeatmapLayout.dayLabelWidth, alignment: .leading)
@@ -99,7 +98,7 @@ struct InsightsHourlyHeatmap: View {
 
     private func fill(for count: Int) -> Color {
         guard count > 0 else {
-            return palette.heatmapBase
+            return palette.heatmapEmpty
         }
 
         let normalized = Double(count) / Double(maxCount)

--- a/Sources/Wink/UI/Insights/InsightsKpiSection.swift
+++ b/Sources/Wink/UI/Insights/InsightsKpiSection.swift
@@ -93,13 +93,13 @@ struct InsightsKpiSection: View {
                 subtitle: "vs previous period",
                 help: InsightsKpiFormatter.activationSubtitle(change: activationDelta),
                 badge: {
-                    InsightsChangeBadge(change: activationDelta)
+                    InsightsKpiDelta(change: activationDelta)
                 },
                 bottom: {
                     WinkSparkline(
                         points: sparklinePoints,
                         stroke: palette.accent,
-                        fill: palette.accent.opacity(0.12)
+                        fill: palette.accentBgSoft
                     )
                 }
             )
@@ -143,12 +143,13 @@ struct InsightsKpiSection: View {
         WinkCard {
             VStack(alignment: .leading, spacing: 0) {
                 Text(title)
-                    .font(WinkType.labelSmall)
-                    .foregroundStyle(palette.textTertiary)
+                    .font(WinkType.labelSmall.weight(.medium))
+                    .foregroundStyle(palette.textSecondary)
 
                 HStack(alignment: .firstTextBaseline, spacing: 6) {
                     Text(value)
-                        .font(.system(size: 28, weight: .semibold))
+                        .font(WinkType.kpiValue)
+                        .tracking(-0.6)
                         .foregroundStyle(palette.textPrimary)
                         .lineLimit(1)
                         .minimumScaleFactor(0.85)
@@ -159,7 +160,7 @@ struct InsightsKpiSection: View {
 
                 Text(subtitle)
                     .font(WinkType.labelSmall)
-                    .foregroundStyle(palette.textSecondary)
+                    .foregroundStyle(palette.textTertiary)
                     .lineLimit(1)
                     .help(help)
                     .padding(.top, 4)
@@ -178,6 +179,33 @@ struct InsightsKpiSection: View {
     }
 }
 
+/// Plain-text delta used for the headline Activations KPI, matching
+/// tab-insights.jsx's unadorned `{delta}` span (no icon, no capsule).
+struct InsightsKpiDelta: View {
+    @Environment(\.winkPalette) private var palette
+
+    let change: InsightsChange
+
+    private var foreground: Color {
+        switch change.tone {
+        case .positive:
+            return palette.green
+        case .negative:
+            return palette.red
+        case .neutral:
+            return palette.textSecondary
+        }
+    }
+
+    var body: some View {
+        Text(change.text)
+            .font(WinkType.captionStrong)
+            .foregroundStyle(foreground)
+    }
+}
+
+/// Pill-style change badge. Not currently used by the Insights KPI row
+/// (see `InsightsKpiDelta`) — kept for other, explicitly-designed badge uses.
 struct InsightsChangeBadge: View {
     @Environment(\.winkPalette) private var palette
 

--- a/Sources/Wink/UI/Insights/InsightsUnusedNudge.swift
+++ b/Sources/Wink/UI/Insights/InsightsUnusedNudge.swift
@@ -2,14 +2,18 @@ import SwiftUI
 
 struct InsightsUnusedNudge: View {
     let appNames: [String]
+    var onReview: () -> Void = {}
 
     var body: some View {
         if !appNames.isEmpty {
             WinkBanner(
                 kind: .info,
                 title: "Unused shortcuts this week",
-                message: Self.message(for: appNames)
-            )
+                message: Self.message(for: appNames),
+                icon: WinkIcon.sparkles.systemName
+            ) {
+                WinkButton("Review", action: onReview)
+            }
         }
     }
 

--- a/Sources/Wink/UI/InsightsTabView.swift
+++ b/Sources/Wink/UI/InsightsTabView.swift
@@ -26,10 +26,8 @@ struct InsightsTabView: View {
     @Bindable var viewModel: InsightsViewModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 16) {
             header
-
-            InsightsUnusedNudge(appNames: viewModel.unusedShortcutNames)
 
             InsightsKpiSection(
                 totalCount: viewModel.totalCount,
@@ -41,15 +39,18 @@ struct InsightsTabView: View {
             InsightsHourlyHeatmap(buckets: viewModel.heatmapBuckets)
 
             mostUsedCard
+
+            InsightsUnusedNudge(appNames: viewModel.unusedShortcutNames)
         }
+        .padding(.top, 18)
+        .padding(.bottom, 22)
         .padding(.horizontal, 22)
-        .padding(.vertical, 18)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(palette.windowBg)
     }
 
     private var header: some View {
-        HStack(alignment: .bottom, spacing: 12) {
+        HStack(alignment: .center, spacing: 12) {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Insights")
                     .font(WinkType.tabTitle)
@@ -61,14 +62,11 @@ struct InsightsTabView: View {
 
             Spacer(minLength: 8)
 
-            Picker("", selection: $viewModel.period) {
-                ForEach(InsightsPeriod.allCases, id: \.self) { period in
-                    Text(period.rawValue).tag(period)
-                }
-            }
-            .pickerStyle(.segmented)
-            .frame(width: 120)
-            .labelsHidden()
+            WinkSegmented(
+                options: InsightsPeriod.allCases.map { (label: $0.rawValue, value: $0) },
+                selection: $viewModel.period,
+                accessibilityLabel: "Insights period"
+            )
         }
     }
 


### PR DESCRIPTION
Fixes #306.

## Summary
14 visual-fidelity findings fixed against `docs/design/reference/tab-insights.jsx`:
- Heatmap "no activity" cells now use a neutral tint instead of accent-blue (added `WinkPalette.heatmapEmpty`, replacing the unused-for-its-original-purpose `heatmapBase`).
- KPI card label/subtitle color-weight hierarchy was inverted — fixed.
- KPI value now uses the existing `WinkType.kpiValue` token instead of a hardcoded size.
- New plain-text `InsightsKpiDelta` view for the Activations card (design specifies plain bold text, not an icon pill).
- Sparkline fill opacity now uses the theme-aware `accentBgSoft` token.
- Heatmap day-label column width and casing corrected; per-app activation count font corrected.
- Unused-shortcut nudge gained its designed "Review" button + sparkles icon, and moved to its correct position (after the KPI/heatmap/list, not before).
- Insights header now uses the app's own `WinkSegmented` control instead of the native segmented `Picker`.

## Test plan
- [x] `swift test` — full suite passing (verified both in this branch's isolated worktree and again after integration-merging with #303/#304/#305/#307, including a resolved token-naming conflict against #305's own DesignTokens.swift additions)
- [x] `swift build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)