### PR TITLE
release: prepare v0.6.1 (CHANGELOG, version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ Newest first. One `## X.Y.Z` section per release, written by hand **before** run
 `scripts/bump-version.sh X.Y.Z`. `scripts/release-notes.sh X.Y.Z` extracts a section as the
 GitHub Release body; the release workflow fails if the tagged version has no section here.
 
+## 0.6.1
+
+Accessibility, a false-positive warning fix, and interface polish.
+
+- **"Couldn't find its login item configuration" was a false alarm** — Settings
+  no longer shows this as a packaging error the first time Wink sees a
+  correctly installed copy; the warning now only appears if turning Launch at
+  Login on actually fails.
+- **Traffic lights work with VoiceOver and keyboard-only navigation again** —
+  closing, minimizing, and zooming the Settings window via assistive
+  technology was silently broken since the titlebar realignment in 0.6.0.
+- **Interface polish across Settings and the menu bar** — corrected colors,
+  spacing, and typography against the design system in the Shortcuts,
+  Insights, and General tabs and the menu bar popover, including a clearer
+  usage heatmap and a fixed keyboard-navigation bug when choosing a target
+  app.
+
 ## 0.6.0
 
 In-app updates and interface polish.

--- a/Sources/Wink/Resources/Info.plist
+++ b/Sources/Wink/Resources/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Release prep for v0.6.1, following #301's precedent.

## Summary
- CHANGELOG 0.6.1 section: login-item false-positive fix, VoiceOver/Full Keyboard Access regression fix, interface polish (#308-#312)
- `scripts/bump-version.sh 0.6.1`: CFBundleShortVersionString 0.6.0 → 0.6.1, CFBundleVersion 7 → 8
- No WhatsNewCatalog entry — this release is fixes/polish only, no new user-facing features to highlight in the post-update panel

## Test plan
- [x] `swift test` — 421/421 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)