### PR TITLE
Harden EventTap recreation ownership and teardown

### DIFF
--- a/Sources/Wink/Services/EventTapFaultInjection.swift
+++ b/Sources/Wink/Services/EventTapFaultInjection.swift
@@ -246,6 +246,7 @@ final class EventTapFaultInjectionDriver: @unchecked Sendable {
                 && restarted.sourceOwned == 1
                 && restarted.boxOwned == 1
                 && restarted.threadOwned == 1
+                && manager.validationCurrentHyperKeyEnabled
 
             let deliveriesBeforeProbe = restarted.keyCallbackDeliveries
             let tapCreatesBeforeProbe = restarted.tapCreates

--- a/Sources/Wink/Services/EventTapFaultInjection.swift
+++ b/Sources/Wink/Services/EventTapFaultInjection.swift
@@ -1,0 +1,330 @@
+#if WINK_EVENT_TAP_FAULT_INJECTION
+import AppKit
+import Foundation
+
+/// Compile-time-only packaged runtime validation profile for EventTap
+/// ownership and recovery. None of these declarations or marker strings are
+/// present in production builds.
+struct EventTapFaultInjectionConfiguration: Equatable, Sendable {
+    enum Mode: String, Sendable {
+        case replacementTapOnce = "replacement-tap-once"
+        case replacementSourceUntilDegraded = "replacement-source-until-degraded"
+        case cycle20
+    }
+
+    private static let argumentPrefix = "--validation-event-tap-fault="
+
+    let mode: Mode
+
+    init?(arguments: [String]) {
+        let values = arguments.compactMap { argument -> String? in
+            guard argument.hasPrefix(Self.argumentPrefix) else { return nil }
+            return String(argument.dropFirst(Self.argumentPrefix.count))
+        }
+        guard values.count == 1, let mode = Mode(rawValue: values[0]) else {
+            return nil
+        }
+        self.mode = mode
+    }
+}
+
+struct EventTapStoppedGenerationProbe: Sendable {
+    let generation: UInt64
+    let keyCallback: @Sendable (KeyPress) -> Void
+    let recoveryCallback: @Sendable (EventTapRecoveryAction, EventTapLifecycleSnapshot) -> Void
+    let recoverySnapshot: EventTapLifecycleSnapshot
+}
+
+/// Wraps the real EventTap factories at the two precise replacement failure
+/// points and drives the same timeout decision entry used by the C callback.
+/// The class exists only in validation-profile binaries.
+final class EventTapFaultInjectionDriver: @unchecked Sendable {
+    private let configuration: EventTapFaultInjectionConfiguration
+    private let baseRuntimeFactory: EventTapRuntimeFactory
+    private let diagnosticLog: @Sendable (String) -> Void
+    private let failureLock = NSLock()
+    private var replacementTapFailuresByGeneration: [UInt64: Int] = [:]
+    private var replacementSourceFailuresByGeneration: [UInt64: Int] = [:]
+
+    @MainActor private var scenarioScheduled = false
+    @MainActor private(set) var suppressFurtherStarts = false
+
+    init(
+        configuration: EventTapFaultInjectionConfiguration,
+        baseRuntimeFactory: EventTapRuntimeFactory,
+        diagnosticLog: @escaping @Sendable (String) -> Void = DiagnosticLog.log
+    ) {
+        self.configuration = configuration
+        self.baseRuntimeFactory = baseRuntimeFactory
+        self.diagnosticLog = diagnosticLog
+        log(event: "configured")
+    }
+
+    @MainActor
+    var runtimeFactory: EventTapRuntimeFactory {
+        let base = baseRuntimeFactory
+        return EventTapRuntimeFactory(
+            makeThread: base.makeThread,
+            makeTap: { [self] context, mask, callback, userInfo in
+                if shouldFailReplacementTap(context) {
+                    log(
+                        event: "replacement_tap_failed",
+                        details: "generation=\(context.generation) attempt=\(context.attempt)"
+                    )
+                    return nil
+                }
+                return base.makeTap(context, mask, callback, userInfo)
+            },
+            makeSource: { [self] context, tap in
+                if shouldFailReplacementSource(context) {
+                    log(
+                        event: "replacement_source_failed",
+                        details: "generation=\(context.generation) attempt=\(context.attempt)"
+                    )
+                    return nil
+                }
+                return base.makeSource(context, tap)
+            },
+            setTapEnabled: base.setTapEnabled,
+            invalidateTap: base.invalidateTap,
+            now: base.now
+        )
+    }
+
+    @MainActor
+    func scheduleScenario(
+        manager: EventTapManager,
+        handler: @escaping EventTapManager.ShortcutHandler
+    ) {
+        guard !scenarioScheduled else { return }
+        scenarioScheduled = true
+        Task { @MainActor [weak self, weak manager] in
+            guard let self, let manager else { return }
+            _ = await self.runScenario(manager: manager, handler: handler)
+        }
+    }
+
+    @MainActor
+    @discardableResult
+    func runScenario(
+        manager: EventTapManager,
+        handler: @escaping EventTapManager.ShortcutHandler
+    ) async -> Bool {
+        log(event: "scenario_started")
+        switch configuration.mode {
+        case .replacementTapOnce:
+            return await runSingleRecoveryScenario(
+                manager: manager,
+                expectRecovered: true
+            )
+        case .replacementSourceUntilDegraded:
+            let passed = await runSingleRecoveryScenario(
+                manager: manager,
+                expectRecovered: false
+            )
+            suppressFurtherStarts = true
+            return passed
+        case .cycle20:
+            let passed = await runCycleScenario(manager: manager, handler: handler)
+            suppressFurtherStarts = true
+            return passed
+        }
+    }
+
+    private func shouldFailReplacementTap(_ context: EventTapCreationContext) -> Bool {
+        guard context.phase == .replacement else { return false }
+        failureLock.lock()
+        defer { failureLock.unlock() }
+
+        let count = replacementTapFailuresByGeneration[context.generation, default: 0]
+        let shouldFail: Bool
+        switch configuration.mode {
+        case .replacementTapOnce:
+            shouldFail = replacementTapFailuresByGeneration.values.reduce(0, +) == 0
+        case .replacementSourceUntilDegraded:
+            shouldFail = false
+        case .cycle20:
+            shouldFail = count < EventTapLifecycleTracker.recreationFailuresBeforeDegraded
+        }
+        if shouldFail {
+            replacementTapFailuresByGeneration[context.generation] = count + 1
+        }
+        return shouldFail
+    }
+
+    private func shouldFailReplacementSource(_ context: EventTapCreationContext) -> Bool {
+        guard context.phase == .replacement,
+              configuration.mode == .replacementSourceUntilDegraded else {
+            return false
+        }
+        failureLock.lock()
+        defer { failureLock.unlock() }
+        let count = replacementSourceFailuresByGeneration[context.generation, default: 0]
+        guard count < EventTapLifecycleTracker.recreationFailuresBeforeDegraded else {
+            return false
+        }
+        replacementSourceFailuresByGeneration[context.generation] = count + 1
+        return true
+    }
+
+    @MainActor
+    private func runSingleRecoveryScenario(
+        manager: EventTapManager,
+        expectRecovered: Bool
+    ) async -> Bool {
+        let before = manager.ownershipSnapshot
+        let startedAt = CFAbsoluteTimeGetCurrent()
+        manager.validationTriggerTimeoutThreshold()
+        let reachedExpectedState = await waitUntil {
+            expectRecovered
+                ? manager.lifecycleState == .running
+                    && manager.ownershipSnapshot.tapCreates > before.tapCreates
+                : manager.lifecycleState == .degraded
+        }
+        let elapsedMilliseconds = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
+        let after = manager.ownershipSnapshot
+        let resourcesValid: Bool
+        if expectRecovered {
+            resourcesValid = after.ready
+                && after.ownerCount == 1
+                && after.tapOwned == 1
+                && after.sourceOwned == 1
+                && after.boxOwned == 1
+                && after.threadOwned == 1
+                && after.threadID == before.threadID
+        } else {
+            resourcesValid = !after.ready
+                && after.ownerCount == 0
+                && after.tapOwned == 0
+                && after.sourceOwned == 0
+                && after.boxOwned == 0
+                && after.threadOwned == 0
+        }
+        let passed = reachedExpectedState && elapsedMilliseconds <= 1_000 && resourcesValid
+        diagnosticLog(after.logMessage(event: "scenario_snapshot", scenario: configuration.mode.rawValue))
+        log(
+            event: "scenario_complete",
+            details: "result=\(passed ? "PASS" : "FAIL") elapsedMs=\(elapsedMilliseconds) deadlineMs=1000"
+        )
+        return passed
+    }
+
+    @MainActor
+    private func runCycleScenario(
+        manager: EventTapManager,
+        handler: @escaping EventTapManager.ShortcutHandler
+    ) async -> Bool {
+        var allPassed = true
+
+        for cycle in 1...20 {
+            guard let probe = manager.validationCaptureStoppedGenerationProbe() else {
+                log(event: "cycle_complete", details: "cycle=\(cycle) result=FAIL reason=missing_probe")
+                allPassed = false
+                break
+            }
+            let beforeFailure = manager.ownershipSnapshot
+            manager.validationTriggerTimeoutThreshold()
+            let degradedInTime = await waitUntil {
+                manager.lifecycleState == .degraded
+            }
+            let degraded = manager.ownershipSnapshot
+            let releasedFailedGeneration = degraded.ownerCount == 0
+                && degraded.tapOwned == 0
+                && degraded.sourceOwned == 0
+                && degraded.boxOwned == 0
+                && degraded.threadOwned == 0
+                && degraded.threadReleases == beforeFailure.threadReleases + 1
+
+            manager.stop()
+            manager.stop()
+            let restartResult = manager.start(onKeyPress: handler)
+            let restarted = manager.ownershipSnapshot
+            let restartedWithOneOwner = restartResult == .started
+                && restarted.ready
+                && restarted.ownerCount == 1
+                && restarted.tapOwned == 1
+                && restarted.sourceOwned == 1
+                && restarted.boxOwned == 1
+                && restarted.threadOwned == 1
+
+            let deliveriesBeforeProbe = restarted.keyCallbackDeliveries
+            let tapCreatesBeforeProbe = restarted.tapCreates
+            let sourceCreatesBeforeProbe = restarted.sourceCreates
+            let staleDiscardsBeforeProbe = restarted.staleCallbacksDiscarded
+            probe.keyCallback(KeyPress(keyCode: 0, modifiers: [.command]))
+            probe.recoveryCallback(.fullRecreation, probe.recoverySnapshot)
+            let staleCallbacksRejected = await waitUntil {
+                manager.ownershipSnapshot.staleCallbacksDiscarded
+                    >= staleDiscardsBeforeProbe + 2
+            }
+            let afterProbe = manager.ownershipSnapshot
+            let noStoppedGenerationDelivery = staleCallbacksRejected
+                && afterProbe.keyCallbackDeliveries == deliveriesBeforeProbe
+                && afterProbe.tapCreates == tapCreatesBeforeProbe
+                && afterProbe.sourceCreates == sourceCreatesBeforeProbe
+                && afterProbe.ownerCount == 1
+
+            let cyclePassed = degradedInTime
+                && releasedFailedGeneration
+                && restartedWithOneOwner
+                && noStoppedGenerationDelivery
+            allPassed = allPassed && cyclePassed
+            diagnosticLog(
+                afterProbe.logMessage(
+                    event: "cycle_snapshot_\(cycle)",
+                    scenario: configuration.mode.rawValue
+                )
+            )
+            log(
+                event: "cycle_complete",
+                details: "cycle=\(cycle) generation=\(probe.generation) previousThreadId=\(beforeFailure.threadID.map(String.init) ?? "nil") previousThreadReleased=\(releasedFailedGeneration) result=\(cyclePassed ? "PASS" : "FAIL")"
+            )
+        }
+
+        let recovered = manager.ownershipSnapshot
+        let recoveredWithOneOwner = recovered.ready
+            && recovered.ownerCount == 1
+            && recovered.tapOwned == 1
+            && recovered.sourceOwned == 1
+            && recovered.boxOwned == 1
+            && recovered.threadOwned == 1
+        diagnosticLog(recovered.logMessage(event: "cycle_recovered", scenario: configuration.mode.rawValue))
+
+        manager.stop()
+        let final = manager.ownershipSnapshot
+        let finalNetZero = final.ownerCount == 0
+            && final.tapOwned == 0
+            && final.sourceOwned == 0
+            && final.boxOwned == 0
+            && final.threadOwned == 0
+            && final.keyCallbackDeliveries == 0
+            && final.staleCallbacksDiscarded == 40
+        diagnosticLog(final.logMessage(event: "cycle_final_stop", scenario: configuration.mode.rawValue))
+
+        let passed = allPassed && recoveredWithOneOwner && finalNetZero
+        log(event: "scenario_complete", details: "result=\(passed ? "PASS" : "FAIL") cycles=20")
+        return passed
+    }
+
+    @MainActor
+    private func waitUntil(
+        timeoutMilliseconds: Int = 1_000,
+        _ predicate: @MainActor () -> Bool
+    ) async -> Bool {
+        let deadline = CFAbsoluteTimeGetCurrent() + Double(timeoutMilliseconds) / 1_000
+        while !predicate() {
+            guard CFAbsoluteTimeGetCurrent() < deadline else { return false }
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        return true
+    }
+
+    private func log(event: String, details: String? = nil) {
+        var message = "EVENT_TAP_FAULT_INJECTION mode=\(configuration.mode.rawValue) event=\(event)"
+        if let details {
+            message += " \(details)"
+        }
+        diagnosticLog(message)
+    }
+}
+#endif

--- a/Sources/Wink/Services/EventTapManager.swift
+++ b/Sources/Wink/Services/EventTapManager.swift
@@ -406,6 +406,7 @@ final class EventTapManager: EventTapManaging {
             }
         }
         box.registeredShortcuts = registeredKeyPresses
+        box.setHyperKey(enabled: hyperKeyEnabled)
         ownershipLedger.boxCreates += 1
         let session = EventTapOwnedSession(
             generation: generation,
@@ -482,9 +483,11 @@ final class EventTapManager: EventTapManaging {
     }
 
     private var registeredKeyPresses: Set<KeyPress> = []
+    private var hyperKeyEnabled = false
 
     /// Enable or disable Hyper Key (F19) interception in the event tap callback.
     func setHyperKeyEnabled(_ enabled: Bool) {
+        hyperKeyEnabled = enabled
         owner?.box.setHyperKey(enabled: enabled)
     }
 
@@ -758,6 +761,10 @@ final class EventTapManager: EventTapManaging {
             recoveryCallback: recoveryCallback,
             recoverySnapshot: snapshot
         )
+    }
+
+    var validationCurrentHyperKeyEnabled: Bool {
+        owner?.box.hyperKeyEnabled == true
     }
     #endif
 }

--- a/Sources/Wink/Services/EventTapManager.swift
+++ b/Sources/Wink/Services/EventTapManager.swift
@@ -300,32 +300,88 @@ final class EventTapManager: EventTapManaging {
     /// `MatchedShortcutDelivery`, so the handler runs there directly.
     typealias ShortcutHandler = @MainActor (KeyPress) -> Bool
 
-    private var eventTap: CFMachPort?
-    private var runLoopSource: CFRunLoopSource?
-    private var retainedBox: Unmanaged<EventTapBox>?
+    private let runtimeFactory: EventTapRuntimeFactory
+    #if WINK_EVENT_TAP_FAULT_INJECTION
+    private let validationDriver: EventTapFaultInjectionDriver?
+    #endif
+    private var owner: EventTapOwnedSession?
+    private var generationCounter: UInt64 = 0
+    private var ownershipLedger = EventTapOwnershipLedger()
+    private(set) var lifecycleState: EventTapLifecycleState = .stopped
     // internal for @testable access
     var onKeyPress: ShortcutHandler?
-    private var backgroundThread: BackgroundRunLoopThread?
 
     /// Debounce: minimum interval between triggers for the same shortcut (seconds).
     private let debounceInterval: TimeInterval = 0.2  // safety net behind Layer 1 autorepeat filter
     private var lastTriggerTime: CFAbsoluteTime = 0
     private var lastTriggerKeyPress: KeyPress?
 
-    var isRunning: Bool { eventTap != nil }
+    init(runtimeFactory: EventTapRuntimeFactory? = nil) {
+        #if WINK_EVENT_TAP_FAULT_INJECTION
+        if let runtimeFactory {
+            self.runtimeFactory = runtimeFactory
+            validationDriver = nil
+        } else if let configuration = EventTapFaultInjectionConfiguration(
+            arguments: ProcessInfo.processInfo.arguments
+        ) {
+            let driver = EventTapFaultInjectionDriver(
+                configuration: configuration,
+                baseRuntimeFactory: .live
+            )
+            self.runtimeFactory = driver.runtimeFactory
+            validationDriver = driver
+        } else {
+            self.runtimeFactory = .live
+            validationDriver = nil
+        }
+        #else
+        self.runtimeFactory = runtimeFactory ?? .live
+        #endif
+    }
+
+    var isRunning: Bool {
+        lifecycleState == .running
+            && owner?.tap != nil
+            && owner?.source != nil
+            && owner?.thread.isAlive == true
+    }
+
+    var ownershipSnapshot: EventTapOwnershipSnapshot {
+        ownershipLedger.snapshot(
+            generation: owner?.generation ?? generationCounter,
+            lifecycleState: lifecycleState,
+            owner: owner,
+            ready: isRunning
+        )
+    }
 
     func start(onKeyPress: @escaping ShortcutHandler) -> EventTapStartResult {
+        #if WINK_EVENT_TAP_FAULT_INJECTION
+        if validationDriver?.suppressFurtherStarts == true {
+            DiagnosticLog.log("EVENT_TAP_FAULT_INJECTION event=post_scenario_restart_blocked")
+            return .failedToCreateTap
+        }
+        #endif
+
         if isRunning {
             self.onKeyPress = onKeyPress
             return .started
         }
 
+        if owner != nil || lifecycleState != .stopped {
+            tearDownOwnedSession(finalState: .stopped, event: "start_preflight_teardown")
+        }
+
         self.onKeyPress = onKeyPress
 
+        generationCounter &+= 1
+        let generation = generationCounter
+        lifecycleState = .starting
+
         // Create dedicated background thread for the event tap RunLoop
-        let thread = BackgroundRunLoopThread()
+        let thread = runtimeFactory.makeThread(generation)
+        ownershipLedger.threadCreates += 1
         thread.start()
-        backgroundThread = thread
 
         let mask = (1 << CGEventType.keyDown.rawValue)
                   | (1 << CGEventType.keyUp.rawValue)
@@ -333,7 +389,7 @@ final class EventTapManager: EventTapManaging {
 
         let box = EventTapBox()
         box.onKeyPress = MatchedShortcutDelivery.makeHandler { [weak self] keyPress in
-            self?.handleAsync(keyPress)
+            self?.handleAsync(keyPress, generation: generation)
         }
         box.onTapDisabled = { snapshot in
             DispatchQueue.global(qos: .utility).async {
@@ -342,96 +398,105 @@ final class EventTapManager: EventTapManaging {
         }
         box.onRecoveryNeeded = { [weak self] action, lifecycleSnapshot in
             Task { @MainActor in
-                self?.handleRecoveryAction(action, snapshot: lifecycleSnapshot)
+                self?.handleRecoveryAction(
+                    action,
+                    snapshot: lifecycleSnapshot,
+                    generation: generation
+                )
             }
         }
         box.registeredShortcuts = registeredKeyPresses
-        let retained = Unmanaged.passRetained(box)
-        let userInfo = UnsafeMutableRawPointer(retained.toOpaque())
+        ownershipLedger.boxCreates += 1
+        let session = EventTapOwnedSession(
+            generation: generation,
+            thread: thread,
+            box: box
+        )
+        owner = session
+        let userInfo = session.userInfo
+        let context = EventTapCreationContext(
+            generation: generation,
+            phase: .initial,
+            attempt: 1
+        )
 
         #if DEBUG
         logger.debug("tapCreate: AXIsProcessTrusted=\(AXIsProcessTrusted()), CGPreflightListenEventAccess=\(CGPreflightListenEventAccess()), trying .defaultTap")
         #endif
-        guard let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .headInsertEventTap,
-            options: .defaultTap,
-            eventsOfInterest: CGEventMask(mask),
-            callback: eventTapCallback,
-            userInfo: userInfo
+        guard let tap = runtimeFactory.makeTap(
+            context,
+            CGEventMask(mask),
+            eventTapCallback,
+            userInfo
         ) else {
-            retained.release()
-            backgroundThread?.cancel()
-            backgroundThread = nil
             logger.error("tapCreate: .defaultTap failed — active event tap could not be created")
             DiagnosticLog.log("tapCreate: .defaultTap failed")
+            tearDownOwnedSession(finalState: .stopped, event: "initial_tap_create_failed")
             return .failedToCreateTap
         }
+        session.tap = tap
+        ownershipLedger.tapCreates += 1
         logger.info("tapCreate: SUCCESS, tap created")
         DiagnosticLog.log("tapCreate: SUCCESS, tap created")
 
-        box.tap = tap
+        box.installTap(tap)
 
-        guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
-            retained.release()
-            backgroundThread?.cancel()
-            backgroundThread = nil
+        guard let source = runtimeFactory.makeSource(context, tap) else {
             logger.error("runLoopSourceCreate: failed for active event tap")
             DiagnosticLog.log("runLoopSourceCreate: failed for active event tap")
+            tearDownOwnedSession(finalState: .stopped, event: "initial_source_create_failed")
             return .failedToCreateTap
         }
+        session.source = source
+        ownershipLedger.sourceCreates += 1
 
         // Add source to background thread's RunLoop instead of main RunLoop
         thread.addSource(source)
 
-        CGEvent.tapEnable(tap: tap, enable: true)
+        runtimeFactory.setTapEnabled(tap, true)
 
-        retainedBox = retained
-        eventTap = tap
-        runLoopSource = source
+        lifecycleState = .running
         emitLifecycleLog("EVENT_TAP_STARTED")
+        emitOwnershipLog(event: "started")
         logger.info("Event tap started (background thread)")
         DiagnosticLog.log("Event tap started (background thread)")
+        #if WINK_EVENT_TAP_FAULT_INJECTION
+        validationDriver?.scheduleScenario(manager: self, handler: onKeyPress)
+        #endif
         return .started
     }
 
     func stop() {
-        guard isRunning else { return }
-
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
+        let shouldLog = owner != nil || lifecycleState != .stopped
+        tearDownOwnedSession(finalState: .stopped, event: "stop")
+        if shouldLog {
+            logger.info("Event tap stopped")
+            DiagnosticLog.log("Event tap stopped")
         }
-        if let source = runLoopSource, let thread = backgroundThread {
-            thread.removeSource(source)
-        }
-        backgroundThread?.cancel()
-        backgroundThread = nil
-        retainedBox?.release()
-        retainedBox = nil
-        eventTap = nil
-        runLoopSource = nil
-        onKeyPress = nil
-        lastTriggerTime = 0
-        lastTriggerKeyPress = nil
-        logger.info("Event tap stopped")
-        DiagnosticLog.log("Event tap stopped")
     }
 
     /// Update the set of registered shortcuts for synchronous event swallowing.
     func updateRegisteredShortcuts(_ keyPresses: Set<KeyPress>) {
         registeredKeyPresses = keyPresses
-        if let box = retainedBox?.takeUnretainedValue() {
-            box.registeredShortcuts = keyPresses
-        }
+        owner?.box.registeredShortcuts = keyPresses
     }
 
     private var registeredKeyPresses: Set<KeyPress> = []
 
     /// Enable or disable Hyper Key (F19) interception in the event tap callback.
     func setHyperKeyEnabled(_ enabled: Bool) {
-        if let box = retainedBox?.takeUnretainedValue() {
-            box.setHyperKey(enabled: enabled)
+        owner?.box.setHyperKey(enabled: enabled)
+    }
+
+    /// Called on main thread from async dispatch. Applies debounce then calls handler.
+    private func handleAsync(_ keyPress: KeyPress, generation: UInt64) {
+        guard owner?.generation == generation, lifecycleState == .running else {
+            ownershipLedger.staleCallbacksDiscarded += 1
+            emitOwnershipLog(event: "stale_key_callback_discarded")
+            return
         }
+        ownershipLedger.keyCallbackDeliveries += 1
+        handleAsync(keyPress)
     }
 
     /// Called on main thread from async dispatch. Applies debounce then calls handler.
@@ -457,94 +522,135 @@ final class EventTapManager: EventTapManaging {
 
     // MARK: - Lifecycle recovery
 
-    private func handleRecoveryAction(_ action: EventTapRecoveryAction, snapshot: EventTapLifecycleSnapshot) {
+    private func handleRecoveryAction(
+        _ action: EventTapRecoveryAction,
+        snapshot: EventTapLifecycleSnapshot,
+        generation: UInt64
+    ) {
+        guard owner?.generation == generation else {
+            ownershipLedger.staleCallbacksDiscarded += 1
+            emitOwnershipLog(event: "stale_recovery_callback_discarded")
+            return
+        }
+
         switch action {
         case .reenableInPlace:
             emitLifecycleLog("EVENT_TAP_REENABLED", snapshot: snapshot)
         case .fullRecreation:
-            recreateEventTap()
+            // A burst can enqueue more timeout callbacks while the first
+            // recreation is pending on the main actor. Only the threshold
+            // crossing owns the recreation; later snapshots from that burst
+            // become stale once the tracker is reset by a successful retry.
+            guard lifecycleState == .running,
+                  snapshot.rollingTimeoutCount == EventTapLifecycleTracker.timeoutsBeforeRecreation else {
+                ownershipLedger.staleCallbacksDiscarded += 1
+                emitOwnershipLog(event: "duplicate_recovery_callback_discarded")
+                return
+            }
+            recreateEventTap(generation: generation)
         case .markDegraded:
-            // The decision was already recorded by the box's tracker in the
-            // callback; just emit the log with the snapshot that was captured.
             emitLifecycleLog("EVENT_TAP_DEGRADED", snapshot: snapshot)
+            tearDownOwnedSession(finalState: .degraded, event: "callback_marked_degraded")
         }
     }
 
-    /// Record a recreation failure through the box, emit logs, and escalate to
-    /// degraded if the threshold is reached.
-    private func recordRecreationFailure() {
-        guard let box = retainedBox?.takeUnretainedValue() else { return }
-        let now = CFAbsoluteTimeGetCurrent()
-        let (action, snapshot) = box.recordRecreationFailureAndSnapshot(at: now, threadIdentity: "main")
+    /// Record a recreation failure through the current owner's tracker. The
+    /// returned action must be executed by the caller; in particular, the
+    /// first `.fullRecreation` is an actual retry rather than a log-only state.
+    private func recordRecreationFailure(
+        for session: EventTapOwnedSession
+    ) -> (EventTapRecoveryAction, EventTapLifecycleSnapshot) {
+        let now = runtimeFactory.now()
+        let (action, snapshot) = session.box.recordRecreationFailureAndSnapshot(
+            at: now,
+            threadIdentity: session.thread.identity
+        )
         emitLifecycleLog("EVENT_TAP_RECREATION_FAILED", snapshot: snapshot)
-        if action == .markDegraded {
-            emitLifecycleLog("EVENT_TAP_DEGRADED", snapshot: snapshot)
-        }
+        emitOwnershipLog(event: "recreation_failed")
+        return (action, snapshot)
     }
 
     /// Tear down and recreate the event tap on the existing background thread.
     /// Follows ordered sequence: remove source → disable/invalidate → release
     /// → create new tap → create new source → add source → enable.
-    private func recreateEventTap() {
-        guard let thread = backgroundThread else { return }
+    private func recreateEventTap(generation: UInt64) {
+        guard let session = owner, session.generation == generation else {
+            ownershipLedger.staleCallbacksDiscarded += 1
+            emitOwnershipLog(event: "recreation_without_current_owner_discarded")
+            return
+        }
 
-        if let source = runLoopSource {
-            thread.removeSource(source)
-        }
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
-            CFMachPortInvalidate(tap)
-        }
-        runLoopSource = nil
-        eventTap = nil
-        // retainedBox is kept alive — the box is reused across recreation
+        lifecycleState = .recovering
+        releaseTapAndSource(from: session)
 
         let mask = (1 << CGEventType.keyDown.rawValue)
                   | (1 << CGEventType.keyUp.rawValue)
                   | (1 << CGEventType.flagsChanged.rawValue)
 
-        guard let box = retainedBox?.takeUnretainedValue() else {
-            recordRecreationFailure()
+        var attempt = 1
+        while owner === session, lifecycleState == .recovering {
+            let userInfo = session.userInfo
+            let context = EventTapCreationContext(
+                generation: generation,
+                phase: .replacement,
+                attempt: attempt
+            )
+
+            guard let newTap = runtimeFactory.makeTap(
+                context,
+                CGEventMask(mask),
+                eventTapCallback,
+                userInfo
+            ) else {
+                let (action, snapshot) = recordRecreationFailure(for: session)
+                if action == .fullRecreation {
+                    attempt += 1
+                    continue
+                }
+                emitLifecycleLog("EVENT_TAP_DEGRADED", snapshot: snapshot)
+                tearDownOwnedSession(finalState: .degraded, event: "replacement_tap_retry_limit")
+                return
+            }
+            session.tap = newTap
+            session.box.installTap(newTap)
+            ownershipLedger.tapCreates += 1
+
+            guard let newSource = runtimeFactory.makeSource(context, newTap) else {
+                releaseTapAndSource(from: session)
+                let (action, snapshot) = recordRecreationFailure(for: session)
+                if action == .fullRecreation {
+                    attempt += 1
+                    continue
+                }
+                emitLifecycleLog("EVENT_TAP_DEGRADED", snapshot: snapshot)
+                tearDownOwnedSession(finalState: .degraded, event: "replacement_source_retry_limit")
+                return
+            }
+            session.source = newSource
+            ownershipLedger.sourceCreates += 1
+            session.thread.addSource(newSource)
+            runtimeFactory.setTapEnabled(newTap, true)
+
+            let snapshot = session.box.recordRecreationSuccessAndSnapshot(
+                at: runtimeFactory.now(),
+                threadIdentity: session.thread.identity
+            )
+            lifecycleState = .running
+            emitLifecycleLog("EVENT_TAP_RECREATED", snapshot: snapshot)
+            emitOwnershipLog(event: "recreated")
             return
         }
-        let userInfo = UnsafeMutableRawPointer(Unmanaged.passUnretained(box).toOpaque())
-
-        guard let newTap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .headInsertEventTap,
-            options: .defaultTap,
-            eventsOfInterest: CGEventMask(mask),
-            callback: eventTapCallback,
-            userInfo: userInfo
-        ) else {
-            recordRecreationFailure()
-            return
-        }
-
-        box.tap = newTap
-
-        guard let newSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, newTap, 0) else {
-            recordRecreationFailure()
-            return
-        }
-
-        thread.addSource(newSource)
-        CGEvent.tapEnable(tap: newTap, enable: true)
-
-        eventTap = newTap
-        runLoopSource = newSource
-
-        let now = CFAbsoluteTimeGetCurrent()
-        let snapshot = box.recordRecreationSuccessAndSnapshot(at: now, threadIdentity: "bg-runloop")
-        emitLifecycleLog("EVENT_TAP_RECREATED", snapshot: snapshot)
     }
 
     private func emitLifecycleLog(_ event: String, snapshot: EventTapLifecycleSnapshot? = nil) {
         let resolvedSnapshot: EventTapLifecycleSnapshot
         if let snapshot = snapshot {
             resolvedSnapshot = snapshot
-        } else if let box = retainedBox?.takeUnretainedValue() {
-            resolvedSnapshot = box.captureLifecycleSnapshot(at: CFAbsoluteTimeGetCurrent(), threadIdentity: "main")
+        } else if let session = owner {
+            resolvedSnapshot = session.box.captureLifecycleSnapshot(
+                at: runtimeFactory.now(),
+                threadIdentity: session.thread.identity
+            )
         } else {
             return
         }
@@ -554,6 +660,106 @@ final class EventTapManager: EventTapManaging {
             DiagnosticLog.log(entry.logMessage)
         }
     }
+
+    private func releaseTapAndSource(from session: EventTapOwnedSession) {
+        if let source = session.source {
+            session.thread.removeSource(source)
+            session.source = nil
+            ownershipLedger.sourceReleases += 1
+        }
+        if let tap = session.tap {
+            let clearedBoxTap = session.box.tearDownTap { ownedTap in
+                runtimeFactory.setTapEnabled(ownedTap, false)
+                runtimeFactory.invalidateTap(ownedTap)
+            }
+            if !clearedBoxTap {
+                runtimeFactory.setTapEnabled(tap, false)
+                runtimeFactory.invalidateTap(tap)
+            }
+            session.tap = nil
+            ownershipLedger.tapReleases += 1
+        }
+    }
+
+    /// Unconditionally tears down every resource owned by the current
+    /// generation. This remains safe after partial creation and on repeated
+    /// calls, so `stop()` never uses readiness as an ownership proxy.
+    private func tearDownOwnedSession(
+        finalState: EventTapLifecycleState,
+        event: String
+    ) {
+        if let session = owner {
+            releaseTapAndSource(from: session)
+            session.thread.cancelAndWait()
+            ownershipLedger.threadReleases += 1
+
+            // The join above is the lifetime boundary: no tap callback can
+            // still be reading these fields when session ownership is released.
+            session.box.onKeyPress = nil
+            session.box.onTapDisabled = nil
+            session.box.onRecoveryNeeded = nil
+            session.box.reenableTap = nil
+            ownershipLedger.boxReleases += 1
+            owner = nil
+        }
+
+        onKeyPress = nil
+        lastTriggerTime = 0
+        lastTriggerKeyPress = nil
+        lifecycleState = finalState
+        emitOwnershipLog(event: event)
+    }
+
+    private func emitOwnershipLog(event: String) {
+        let message = ownershipSnapshot.logMessage(event: event)
+        logger.info("\(message)")
+        DispatchQueue.global(qos: .utility).async {
+            DiagnosticLog.log(message)
+        }
+    }
+
+    #if WINK_EVENT_TAP_FAULT_INJECTION
+    /// Validation-only timeout driver. It records decisions through the same
+    /// EventTapBox tracker and dispatches through the same recovery closure as
+    /// a real `.tapDisabledByTimeout` callback.
+    func validationTriggerTimeoutThreshold() {
+        guard let session = owner, lifecycleState == .running else { return }
+        let startedAt = runtimeFactory.now()
+        for offset in 0..<EventTapLifecycleTracker.timeoutsBeforeRecreation {
+            session.box.reenableTapIfNeeded()
+            let (action, snapshot) = session.box.recordTimeoutAndDecide(
+                at: startedAt + Double(offset) / 1_000,
+                threadIdentity: session.thread.identity
+            )
+            if action == .fullRecreation || action == .markDegraded {
+                session.box.onRecoveryNeeded?(action, snapshot)
+            }
+        }
+    }
+
+    func validationCaptureStoppedGenerationProbe() -> EventTapStoppedGenerationProbe? {
+        guard let session = owner,
+              let keyCallback = session.box.onKeyPress,
+              let recoveryCallback = session.box.onRecoveryNeeded else {
+            return nil
+        }
+        let snapshot = EventTapLifecycleSnapshot(
+            rollingTimeoutCount: EventTapLifecycleTracker.timeoutsBeforeRecreation,
+            recreationFailureCount: 0,
+            timeSinceLastTimeout: 0,
+            lifecycleState: .recovering,
+            recoveryMode: "recreated",
+            threadIdentity: session.thread.identity,
+            readinessState: "recovering"
+        )
+        return EventTapStoppedGenerationProbe(
+            generation: session.generation,
+            keyCallback: keyCallback,
+            recoveryCallback: recoveryCallback,
+            recoverySnapshot: snapshot
+        )
+    }
+    #endif
 }
 
 // MARK: - Background RunLoop Thread
@@ -563,14 +769,18 @@ final class EventTapManager: EventTapManaging {
 /// Uses an NSCondition-based readiness mechanism instead of a one-shot semaphore
 /// so that the same thread supports repeated add/remove/recreate cycles.
 /// internal for @testable access
-final class BackgroundRunLoopThread: Thread {
+final class BackgroundRunLoopThread: Thread, EventTapRunLoopThread {
     private var threadRunLoop: CFRunLoop?
     private let readyCondition = NSCondition()
     private var isReady = false
     private var didExit = false
+    private var recordedThreadID: UInt64?
 
     override func main() {
         readyCondition.lock()
+        var currentThreadID: UInt64 = 0
+        pthread_threadid_np(nil, &currentThreadID)
+        recordedThreadID = currentThreadID
         threadRunLoop = CFRunLoopGetCurrent()
         isReady = true
         readyCondition.broadcast()
@@ -597,6 +807,22 @@ final class BackgroundRunLoopThread: Thread {
         readyCondition.lock()
         defer { readyCondition.unlock() }
         return didExit
+    }
+
+    var identity: String {
+        name ?? "event-tap-\(ObjectIdentifier(self))"
+    }
+
+    var threadID: UInt64? {
+        readyCondition.lock()
+        defer { readyCondition.unlock() }
+        return recordedThreadID
+    }
+
+    var isAlive: Bool {
+        readyCondition.lock()
+        defer { readyCondition.unlock() }
+        return isReady && !didExit
     }
 
     /// Wait for the run loop to become ready and return it.
@@ -644,6 +870,10 @@ final class BackgroundRunLoopThread: Thread {
             }
         }
         readyCondition.unlock()
+    }
+
+    func cancelAndWait() {
+        cancel()
     }
 }
 
@@ -781,17 +1011,16 @@ struct EventTapLifecycleTracker: Sendable {
     }
 }
 
-// Boxes the EventTapManager reference for the C callback's userInfo pointer.
-// Lifetime is explicitly managed: retained in start(), released in stop().
-// Also holds the CFMachPort so the callback can re-enable a disabled tap.
+// Boxes the EventTapManager callback state for the C callback's userInfo
+// pointer. EventTapOwnedSession strongly owns it until tap invalidation and the
+// background-thread join have completed. Also holds the CFMachPort so the
+// callback can re-enable a disabled tap.
 //
-// Thread safety: `tap` and `onKeyPress` are written before the event tap is
-// enabled and only read from the callback — no lock needed.
-// `registeredShortcuts`, `hyperKeyEnabled`, and `isHyperHeld` are read from
-// the background callback thread and written from the main thread, so they
-// are protected by an os_unfair_lock.
-final class EventTapBox {
-    var tap: CFMachPort?
+// Thread safety: the tap, registered shortcuts, Hyper state, diagnostics, and
+// lifecycle tracker are protected by an os_unfair_lock. Callback closures are
+// installed before the tap is enabled and cleared only after the thread join.
+final class EventTapBox: @unchecked Sendable {
+    private var _tap: CFMachPort?
     var reenableTap: (@Sendable () -> Void)?
     /// Background-safe closure that hops to the main actor before invoking app logic.
     var onKeyPress: (@Sendable (KeyPress) -> Void)?
@@ -901,12 +1130,41 @@ final class EventTapBox {
     }
 
     /// Re-enable the tap using the custom closure or the tap reference directly.
-    func reenableTapIfNeeded() {
-        if let reenableTap = reenableTap {
-            reenableTap()
-        } else if let tap = tap {
+    func reenableTapIfNeeded(
+        enableTap: (CFMachPort) -> Void = { tap in
             CGEvent.tapEnable(tap: tap, enable: true)
         }
+    ) {
+        if let reenableTap = reenableTap {
+            reenableTap()
+        } else {
+            withLock {
+                if let tap = _tap {
+                    enableTap(tap)
+                }
+            }
+        }
+    }
+
+    func installTap(_ tap: CFMachPort) {
+        withLock {
+            _tap = tap
+        }
+    }
+
+    /// Serializes invalidation with callback-side re-enable so teardown can
+    /// never race an in-flight timeout callback's access to the owned tap.
+    @discardableResult
+    func tearDownTap(_ body: (CFMachPort) -> Void) -> Bool {
+        let tap = withLock { () -> CFMachPort? in
+            defer { _tap = nil }
+            return _tap
+        }
+        guard let tap else { return false }
+        // System calls stay outside the lock. Taking the tap waited for any
+        // earlier re-enable to finish, and future re-enables now see nil.
+        body(tap)
+        return true
     }
 
     /// Record a timeout event and return the recovery action decided by the

--- a/Sources/Wink/Services/EventTapRuntime.swift
+++ b/Sources/Wink/Services/EventTapRuntime.swift
@@ -1,0 +1,163 @@
+import ApplicationServices
+import Foundation
+
+enum EventTapCreationPhase: String, Equatable, Sendable {
+    case initial
+    case replacement
+}
+
+struct EventTapCreationContext: Equatable, Sendable {
+    let generation: UInt64
+    let phase: EventTapCreationPhase
+    let attempt: Int
+}
+
+protocol EventTapRunLoopThread: AnyObject {
+    var identity: String { get }
+    var threadID: UInt64? { get }
+    var hasExited: Bool { get }
+    var isAlive: Bool { get }
+
+    func start()
+    func addSource(_ source: CFRunLoopSource)
+    func removeSource(_ source: CFRunLoopSource)
+    func cancelAndWait()
+}
+
+struct EventTapRuntimeFactory {
+    let makeThread: (UInt64) -> any EventTapRunLoopThread
+    let makeTap: (
+        EventTapCreationContext,
+        CGEventMask,
+        CGEventTapCallBack,
+        UnsafeMutableRawPointer
+    ) -> CFMachPort?
+    let makeSource: (EventTapCreationContext, CFMachPort) -> CFRunLoopSource?
+    let setTapEnabled: (CFMachPort, Bool) -> Void
+    let invalidateTap: (CFMachPort) -> Void
+    let now: () -> CFAbsoluteTime
+
+    @MainActor static let live = EventTapRuntimeFactory(
+        makeThread: { generation in
+            let thread = BackgroundRunLoopThread()
+            thread.name = "Wink Hyper Event Tap g\(generation)"
+            return thread
+        },
+        makeTap: { _, mask, callback, userInfo in
+            CGEvent.tapCreate(
+                tap: .cgSessionEventTap,
+                place: .headInsertEventTap,
+                options: .defaultTap,
+                eventsOfInterest: mask,
+                callback: callback,
+                userInfo: userInfo
+            )
+        },
+        makeSource: { _, tap in
+            CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        },
+        setTapEnabled: { tap, enabled in
+            CGEvent.tapEnable(tap: tap, enable: enabled)
+        },
+        invalidateTap: { tap in
+            CFMachPortInvalidate(tap)
+        },
+        now: { CFAbsoluteTimeGetCurrent() }
+    )
+}
+
+final class EventTapOwnedSession {
+    let generation: UInt64
+    let thread: any EventTapRunLoopThread
+    let box: EventTapBox
+    var tap: CFMachPort?
+    var source: CFRunLoopSource?
+
+    init(
+        generation: UInt64,
+        thread: any EventTapRunLoopThread,
+        box: EventTapBox
+    ) {
+        self.generation = generation
+        self.thread = thread
+        self.box = box
+    }
+
+    var userInfo: UnsafeMutableRawPointer {
+        UnsafeMutableRawPointer(Unmanaged.passUnretained(box).toOpaque())
+    }
+}
+
+struct EventTapOwnershipSnapshot: Equatable, Sendable {
+    let generation: UInt64
+    let lifecycleState: EventTapLifecycleState
+    let ownerCount: Int
+    let ready: Bool
+    let threadIdentity: String?
+    let threadID: UInt64?
+    let threadAlive: Bool
+    let tapCreates: Int
+    let tapReleases: Int
+    let tapOwned: Int
+    let sourceCreates: Int
+    let sourceReleases: Int
+    let sourceOwned: Int
+    let boxCreates: Int
+    let boxReleases: Int
+    let boxOwned: Int
+    let threadCreates: Int
+    let threadReleases: Int
+    let threadOwned: Int
+    let keyCallbackDeliveries: Int
+    let staleCallbacksDiscarded: Int
+
+    func logMessage(event: String, scenario: String = "production") -> String {
+        let threadIDText = threadID.map(String.init) ?? "nil"
+        let threadIdentityText = threadIdentity ?? "nil"
+        return "EVENT_TAP_OWNERSHIP scenario=\(scenario) event=\(event) generation=\(generation) ownerCount=\(ownerCount) ready=\(ready) threadId=\(threadIDText) threadIdentity=\(threadIdentityText) threadAlive=\(threadAlive) activeThreads=\(threadOwned) tapCreates=\(tapCreates) tapReleases=\(tapReleases) tapOwned=\(tapOwned) sourceCreates=\(sourceCreates) sourceReleases=\(sourceReleases) sourceOwned=\(sourceOwned) boxCreates=\(boxCreates) boxReleases=\(boxReleases) boxOwned=\(boxOwned) keyCallbackDeliveries=\(keyCallbackDeliveries) staleCallbacksDiscarded=\(staleCallbacksDiscarded)"
+    }
+}
+
+struct EventTapOwnershipLedger {
+    var tapCreates = 0
+    var tapReleases = 0
+    var sourceCreates = 0
+    var sourceReleases = 0
+    var boxCreates = 0
+    var boxReleases = 0
+    var threadCreates = 0
+    var threadReleases = 0
+    var keyCallbackDeliveries = 0
+    var staleCallbacksDiscarded = 0
+
+    func snapshot(
+        generation: UInt64,
+        lifecycleState: EventTapLifecycleState,
+        owner: EventTapOwnedSession?,
+        ready: Bool
+    ) -> EventTapOwnershipSnapshot {
+        EventTapOwnershipSnapshot(
+            generation: generation,
+            lifecycleState: lifecycleState,
+            ownerCount: owner == nil ? 0 : 1,
+            ready: ready,
+            threadIdentity: owner?.thread.identity,
+            threadID: owner?.thread.threadID,
+            threadAlive: owner?.thread.isAlive == true,
+            tapCreates: tapCreates,
+            tapReleases: tapReleases,
+            tapOwned: tapCreates - tapReleases,
+            sourceCreates: sourceCreates,
+            sourceReleases: sourceReleases,
+            sourceOwned: sourceCreates - sourceReleases,
+            boxCreates: boxCreates,
+            boxReleases: boxReleases,
+            boxOwned: boxCreates - boxReleases,
+            threadCreates: threadCreates,
+            threadReleases: threadReleases,
+            threadOwned: threadCreates - threadReleases,
+            keyCallbackDeliveries: keyCallbackDeliveries,
+            staleCallbacksDiscarded: staleCallbacksDiscarded
+        )
+    }
+}

--- a/Tests/WinkTests/EventTapFaultInjectionTests.swift
+++ b/Tests/WinkTests/EventTapFaultInjectionTests.swift
@@ -84,6 +84,7 @@ struct EventTapFaultInjectionTests {
         let manager = EventTapManager(runtimeFactory: driver.runtimeFactory)
 
         #expect(manager.start { _ in true } == .started)
+        manager.setHyperKeyEnabled(true)
         let passed = await driver.runScenario(manager: manager) { _ in true }
         let degraded = manager.ownershipSnapshot
 
@@ -116,6 +117,7 @@ struct EventTapFaultInjectionTests {
         let manager = EventTapManager(runtimeFactory: driver.runtimeFactory)
 
         #expect(manager.start { _ in true } == .started)
+        manager.setHyperKeyEnabled(true)
         let passed = await driver.runScenario(manager: manager) { _ in true }
         let final = manager.ownershipSnapshot
 

--- a/Tests/WinkTests/EventTapFaultInjectionTests.swift
+++ b/Tests/WinkTests/EventTapFaultInjectionTests.swift
@@ -1,0 +1,188 @@
+#if WINK_EVENT_TAP_FAULT_INJECTION
+import AppKit
+import Foundation
+import Testing
+@testable import Wink
+
+@Suite("EventTap fault injection")
+struct EventTapFaultInjectionTests {
+    @Test
+    func configurationRequiresOneExactValidationArgument() {
+        #expect(EventTapFaultInjectionConfiguration(arguments: ["Wink"]) == nil)
+        #expect(EventTapFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-event-tap-fault=unknown"
+        ]) == nil)
+        #expect(EventTapFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-event-tap-fault=replacement-tap-once",
+            "--validation-event-tap-fault=cycle20"
+        ]) == nil)
+
+        let tap = EventTapFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-event-tap-fault=replacement-tap-once"
+        ])
+        #expect(tap?.mode == .replacementTapOnce)
+
+        let source = EventTapFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-event-tap-fault=replacement-source-until-degraded"
+        ])
+        #expect(source?.mode == .replacementSourceUntilDegraded)
+
+        let cycle = EventTapFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-event-tap-fault=cycle20"
+        ])
+        #expect(cycle?.mode == .cycle20)
+    }
+
+    @Test @MainActor
+    func replacementTapModeFailsOnceThenRecoversOnTheSameThread() async {
+        let runtime = FaultInjectionTestRuntime()
+        let diagnostics = LockedValue<[String]>([])
+        let configuration = EventTapFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-event-tap-fault=replacement-tap-once"
+        ])!
+        let driver = EventTapFaultInjectionDriver(
+            configuration: configuration,
+            baseRuntimeFactory: runtime.factory,
+            diagnosticLog: { diagnostics.value.append($0) }
+        )
+        let manager = EventTapManager(runtimeFactory: driver.runtimeFactory)
+
+        #expect(manager.start { _ in true } == .started)
+        let originalThreadID = manager.ownershipSnapshot.threadID
+        let passed = await driver.runScenario(manager: manager) { _ in true }
+
+        #expect(passed)
+        #expect(manager.lifecycleState == .running)
+        #expect(manager.isRunning)
+        #expect(manager.ownershipSnapshot.ownerCount == 1)
+        #expect(manager.ownershipSnapshot.threadID == originalThreadID)
+        #expect(diagnostics.value.contains {
+            $0.contains("mode=replacement-tap-once") && $0.contains("event=scenario_complete")
+        })
+        manager.stop()
+    }
+
+    @Test @MainActor
+    func replacementSourceModeReachesDegradedWithNoOwnedResources() async {
+        let runtime = FaultInjectionTestRuntime()
+        let diagnostics = LockedValue<[String]>([])
+        let configuration = EventTapFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-event-tap-fault=replacement-source-until-degraded"
+        ])!
+        let driver = EventTapFaultInjectionDriver(
+            configuration: configuration,
+            baseRuntimeFactory: runtime.factory,
+            diagnosticLog: { diagnostics.value.append($0) }
+        )
+        let manager = EventTapManager(runtimeFactory: driver.runtimeFactory)
+
+        #expect(manager.start { _ in true } == .started)
+        let passed = await driver.runScenario(manager: manager) { _ in true }
+        let degraded = manager.ownershipSnapshot
+
+        #expect(passed)
+        #expect(manager.lifecycleState == .degraded)
+        #expect(manager.isRunning == false)
+        #expect(degraded.ownerCount == 0)
+        #expect(degraded.tapCreates == degraded.tapReleases)
+        #expect(degraded.sourceCreates == degraded.sourceReleases)
+        #expect(degraded.boxCreates == degraded.boxReleases)
+        #expect(degraded.threadCreates == degraded.threadReleases)
+        #expect(diagnostics.value.contains {
+            $0.contains("mode=replacement-source-until-degraded") && $0.contains("event=scenario_complete")
+        })
+    }
+
+    @Test @MainActor
+    func cycle20ModeReleasesEveryGenerationAndRejectsStoppedCallbacks() async {
+        let runtime = FaultInjectionTestRuntime()
+        let diagnostics = LockedValue<[String]>([])
+        let configuration = EventTapFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-event-tap-fault=cycle20"
+        ])!
+        let driver = EventTapFaultInjectionDriver(
+            configuration: configuration,
+            baseRuntimeFactory: runtime.factory,
+            diagnosticLog: { diagnostics.value.append($0) }
+        )
+        let manager = EventTapManager(runtimeFactory: driver.runtimeFactory)
+
+        #expect(manager.start { _ in true } == .started)
+        let passed = await driver.runScenario(manager: manager) { _ in true }
+        let final = manager.ownershipSnapshot
+
+        #expect(passed)
+        #expect(final.lifecycleState == .stopped)
+        #expect(final.ownerCount == 0)
+        #expect(final.tapCreates == final.tapReleases)
+        #expect(final.sourceCreates == final.sourceReleases)
+        #expect(final.boxCreates == final.boxReleases)
+        #expect(final.threadCreates == final.threadReleases)
+        #expect(final.keyCallbackDeliveries == 0)
+        #expect(final.staleCallbacksDiscarded == 40)
+        #expect(diagnostics.value.filter { $0.contains("event=cycle_complete") }.count == 20)
+        #expect(diagnostics.value.contains {
+            $0.contains("mode=cycle20") && $0.contains("event=scenario_complete")
+        })
+    }
+}
+
+@MainActor
+private final class FaultInjectionTestRuntime {
+    private(set) var threads: [FaultInjectionTestThread] = []
+
+    lazy var factory = EventTapRuntimeFactory(
+        makeThread: { [unowned self] generation in
+            let thread = FaultInjectionTestThread(generation: generation)
+            threads.append(thread)
+            return thread
+        },
+        makeTap: { _, _, _, _ in makeFaultInjectionTestingMachPort() },
+        makeSource: { _, tap in
+            CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        },
+        setTapEnabled: { _, _ in },
+        invalidateTap: { CFMachPortInvalidate($0) },
+        now: { CFAbsoluteTimeGetCurrent() }
+    )
+}
+
+private final class FaultInjectionTestThread: EventTapRunLoopThread {
+    let identity: String
+    let threadID: UInt64?
+    private(set) var hasExited = false
+    private(set) var isAlive = false
+
+    init(generation: UInt64) {
+        identity = "fault-injection-test-\(generation)"
+        threadID = generation
+    }
+
+    func start() { isAlive = true }
+    func addSource(_ source: CFRunLoopSource) {}
+    func removeSource(_ source: CFRunLoopSource) {}
+    func cancelAndWait() {
+        isAlive = false
+        hasExited = true
+    }
+}
+
+private func makeFaultInjectionTestingMachPort() -> CFMachPort {
+    var context = CFMachPortContext(
+        version: 0,
+        info: nil,
+        retain: nil,
+        release: nil,
+        copyDescription: nil
+    )
+    return CFMachPortCreate(kCFAllocatorDefault, nil, &context, nil)!
+}
+#endif

--- a/Tests/WinkTests/EventTapManagerOwnershipTests.swift
+++ b/Tests/WinkTests/EventTapManagerOwnershipTests.swift
@@ -1,0 +1,442 @@
+import AppKit
+import Carbon.HIToolbox
+import Foundation
+import Testing
+@testable import Wink
+
+@Suite("EventTapManager owned-session lifecycle")
+struct EventTapManagerOwnedSessionTests {
+    @Test @MainActor
+    func replacementTapFailureExecutesRetryDegradesAndStopsIdempotently() async {
+        let runtime = RecordingEventTapRuntime(replacementTapFailuresPerGeneration: 2)
+        let manager = EventTapManager(runtimeFactory: runtime.factory)
+
+        #expect(manager.start { _ in true } == .started)
+        let running = manager.ownershipSnapshot
+        #expect(running.lifecycleState == .running)
+        #expect(running.ownerCount == 1)
+        #expect(running.tapOwned == 1)
+        #expect(running.sourceOwned == 1)
+        #expect(running.boxOwned == 1)
+        #expect(running.threadOwned == 1)
+
+        await runtime.triggerRecreationThreshold()
+
+        #expect(runtime.replacementTapAttempts == 2)
+        #expect(manager.lifecycleState == .degraded)
+        #expect(manager.isRunning == false)
+
+        manager.stop()
+        let stoppedOnce = manager.ownershipSnapshot
+        #expect(stoppedOnce.lifecycleState == .stopped)
+        #expect(stoppedOnce.ownerCount == 0)
+        #expect(stoppedOnce.tapCreates == stoppedOnce.tapReleases)
+        #expect(stoppedOnce.sourceCreates == stoppedOnce.sourceReleases)
+        #expect(stoppedOnce.boxCreates == stoppedOnce.boxReleases)
+        #expect(stoppedOnce.threadCreates == stoppedOnce.threadReleases)
+        let allThreadsExited = runtime.threads.allSatisfy { $0.hasExited }
+        #expect(allThreadsExited)
+
+        manager.stop()
+        #expect(manager.ownershipSnapshot == stoppedOnce)
+    }
+
+    @Test @MainActor
+    func replacementSourceFailureReleasesEachTapAndDegrades() async {
+        let runtime = RecordingEventTapRuntime(replacementSourceFailuresPerGeneration: 2)
+        let manager = EventTapManager(runtimeFactory: runtime.factory)
+
+        #expect(manager.start { _ in true } == .started)
+        await runtime.triggerRecreationThreshold()
+
+        #expect(runtime.replacementTapAttempts == 2)
+        #expect(runtime.replacementSourceAttempts == 2)
+        #expect(manager.lifecycleState == .degraded)
+        #expect(manager.isRunning == false)
+
+        let degraded = manager.ownershipSnapshot
+        #expect(degraded.ownerCount == 0)
+        #expect(degraded.tapCreates == degraded.tapReleases)
+        #expect(degraded.sourceCreates == degraded.sourceReleases)
+        #expect(degraded.boxCreates == degraded.boxReleases)
+        #expect(degraded.threadCreates == degraded.threadReleases)
+
+        manager.stop()
+        manager.stop()
+        let stopped = manager.ownershipSnapshot
+        #expect(stopped.lifecycleState == .stopped)
+        #expect(stopped.tapCreates == stopped.tapReleases)
+        #expect(stopped.sourceCreates == stopped.sourceReleases)
+    }
+
+    @Test @MainActor
+    func replacementTapFailureRetriesThenRecoversWithOneOwner() async {
+        let runtime = RecordingEventTapRuntime(replacementTapFailuresPerGeneration: 1)
+        let manager = EventTapManager(runtimeFactory: runtime.factory)
+
+        #expect(manager.start { _ in true } == .started)
+        await runtime.triggerRecreationThreshold()
+
+        let recovered = manager.ownershipSnapshot
+        #expect(runtime.replacementTapAttempts == 2)
+        #expect(manager.lifecycleState == .running)
+        #expect(manager.isRunning)
+        #expect(recovered.ownerCount == 1)
+        #expect(recovered.tapOwned == 1)
+        #expect(recovered.sourceOwned == 1)
+        #expect(recovered.boxOwned == 1)
+        #expect(recovered.threadOwned == 1)
+
+        manager.stop()
+        let stopped = manager.ownershipSnapshot
+        #expect(stopped.tapCreates == stopped.tapReleases)
+        #expect(stopped.sourceCreates == stopped.sourceReleases)
+        #expect(stopped.boxCreates == stopped.boxReleases)
+        #expect(stopped.threadCreates == stopped.threadReleases)
+    }
+
+    @Test @MainActor
+    func initialTapFailureStopsTwiceWithoutLeakingPartialOwner() {
+        let runtime = RecordingEventTapRuntime(initialTapFailures: 1)
+        let manager = EventTapManager(runtimeFactory: runtime.factory)
+
+        #expect(manager.start { _ in true } == .failedToCreateTap)
+        let failed = manager.ownershipSnapshot
+        #expect(failed.lifecycleState == .stopped)
+        #expect(failed.ownerCount == 0)
+        #expect(failed.tapCreates == failed.tapReleases)
+        #expect(failed.sourceCreates == failed.sourceReleases)
+        #expect(failed.boxCreates == failed.boxReleases)
+        #expect(failed.threadCreates == failed.threadReleases)
+
+        manager.stop()
+        manager.stop()
+        #expect(manager.ownershipSnapshot == failed)
+    }
+
+    @Test @MainActor
+    func initialSourceFailureStopsTwiceAndReleasesCreatedTap() {
+        let runtime = RecordingEventTapRuntime(initialSourceFailures: 1)
+        let manager = EventTapManager(runtimeFactory: runtime.factory)
+
+        #expect(manager.start { _ in true } == .failedToCreateTap)
+        let failed = manager.ownershipSnapshot
+        #expect(failed.lifecycleState == .stopped)
+        #expect(failed.ownerCount == 0)
+        #expect(failed.tapCreates == 1)
+        #expect(failed.tapCreates == failed.tapReleases)
+        #expect(failed.sourceCreates == failed.sourceReleases)
+        #expect(failed.boxCreates == failed.boxReleases)
+        #expect(failed.threadCreates == failed.threadReleases)
+
+        manager.stop()
+        manager.stop()
+        #expect(manager.ownershipSnapshot == failed)
+    }
+
+    @Test @MainActor
+    func twentyFailStopRestartCyclesKeepExactlyOneOwnerAndReleaseAllPriorGenerations() async {
+        let runtime = RecordingEventTapRuntime(replacementTapFailuresPerGeneration: 2)
+        let manager = EventTapManager(runtimeFactory: runtime.factory)
+
+        #expect(manager.start { _ in true } == .started)
+        for _ in 1...20 {
+            let failedThread = runtime.threads.last
+            await runtime.triggerRecreationThreshold()
+
+            #expect(manager.lifecycleState == .degraded)
+            #expect(manager.isRunning == false)
+            #expect(failedThread?.hasExited == true)
+
+            manager.stop()
+            manager.stop()
+            #expect(manager.lifecycleState == .stopped)
+            #expect(manager.start { _ in true } == .started)
+
+            let recovered = manager.ownershipSnapshot
+            #expect(recovered.ownerCount == 1)
+            #expect(recovered.ready)
+            #expect(recovered.tapOwned == 1)
+            #expect(recovered.sourceOwned == 1)
+            #expect(recovered.boxOwned == 1)
+            #expect(recovered.threadOwned == 1)
+            let priorThreadsExited = runtime.threads.dropLast().allSatisfy { $0.hasExited }
+            #expect(priorThreadsExited)
+            let priorBoxesReleased = runtime.boxes.dropLast().allSatisfy { $0.value == nil }
+            #expect(priorBoxesReleased)
+        }
+
+        manager.stop()
+        let final = manager.ownershipSnapshot
+        #expect(final.ownerCount == 0)
+        #expect(final.tapCreates == final.tapReleases)
+        #expect(final.sourceCreates == final.sourceReleases)
+        #expect(final.boxCreates == final.boxReleases)
+        #expect(final.threadCreates == final.threadReleases)
+        #expect(final.keyCallbackDeliveries == 0)
+        let allThreadsExited = runtime.threads.allSatisfy { $0.hasExited }
+        #expect(allThreadsExited)
+        let allBoxesReleased = runtime.boxes.allSatisfy { $0.value == nil }
+        #expect(allBoxesReleased)
+    }
+
+    @Test @MainActor
+    func callbacksCapturedFromStoppedGenerationCannotReachRestartedOwner() async {
+        let runtime = RecordingEventTapRuntime()
+        let manager = EventTapManager(runtimeFactory: runtime.factory)
+        var handledCount = 0
+
+        #expect(manager.start { _ in
+            handledCount += 1
+            return true
+        } == .started)
+        let oldBox = try! #require(runtime.boxes.last?.value)
+        let staleKeyCallback = try! #require(oldBox.onKeyPress)
+        let staleRecoveryCallback = try! #require(oldBox.onRecoveryNeeded)
+        var pendingRecovery: (EventTapRecoveryAction, EventTapLifecycleSnapshot)?
+        for now in [1000.0, 1001.0, 1002.0] {
+            let decision = oldBox.recordTimeoutAndDecide(
+                at: now,
+                threadIdentity: "stopped-generation"
+            )
+            if decision.0 == .fullRecreation {
+                pendingRecovery = decision
+            }
+        }
+        let recovery = try! #require(pendingRecovery)
+
+        manager.stop()
+        #expect(manager.start { _ in
+            handledCount += 1
+            return true
+        } == .started)
+        let beforeStaleCallbacks = manager.ownershipSnapshot
+
+        staleKeyCallback(
+            KeyPress(keyCode: CGKeyCode(kVK_ANSI_A), modifiers: [.command])
+        )
+        staleRecoveryCallback(recovery.0, recovery.1)
+        await Task.yield()
+        await Task.yield()
+        await Task.yield()
+
+        let afterStaleCallbacks = manager.ownershipSnapshot
+        #expect(handledCount == 0)
+        #expect(afterStaleCallbacks.generation == beforeStaleCallbacks.generation)
+        #expect(afterStaleCallbacks.ownerCount == 1)
+        #expect(afterStaleCallbacks.tapCreates == beforeStaleCallbacks.tapCreates)
+        #expect(afterStaleCallbacks.sourceCreates == beforeStaleCallbacks.sourceCreates)
+        #expect(afterStaleCallbacks.keyCallbackDeliveries == beforeStaleCallbacks.keyCallbackDeliveries)
+        #expect(afterStaleCallbacks.staleCallbacksDiscarded == 2)
+
+        manager.stop()
+    }
+
+    @Test @MainActor
+    func directRestartTearsDownPartialOwnerBeforePublishingNewGeneration() {
+        let runtime = RecordingEventTapRuntime()
+        let manager = EventTapManager(runtimeFactory: runtime.factory)
+
+        #expect(manager.start { _ in true } == .started)
+        let firstThread = runtime.threads[0]
+        let firstBox = runtime.boxes[0]
+        firstThread.simulateUnexpectedExit()
+        #expect(manager.isRunning == false)
+
+        #expect(manager.start { _ in true } == .started)
+        let restarted = manager.ownershipSnapshot
+        #expect(firstThread.hasExited)
+        #expect(firstBox.value == nil)
+        #expect(restarted.generation == 2)
+        #expect(restarted.ownerCount == 1)
+        #expect(restarted.threadCreates == 2)
+        #expect(restarted.threadReleases == 1)
+        #expect(restarted.boxCreates == 2)
+        #expect(restarted.boxReleases == 1)
+        #expect(restarted.tapOwned == 1)
+        #expect(restarted.sourceOwned == 1)
+        #expect(restarted.boxOwned == 1)
+        #expect(restarted.threadOwned == 1)
+
+        manager.stop()
+    }
+
+    @Test
+    func inFlightReenableAndTapTeardownAreSerialized() {
+        let box = EventTapBox()
+        box.installTap(makeTestingMachPort())
+        let reenableEntered = DispatchSemaphore(value: 0)
+        let allowReenableToFinish = DispatchSemaphore(value: 0)
+        let reenableFinished = DispatchSemaphore(value: 0)
+        let teardownFinished = DispatchSemaphore(value: 0)
+        let events = LockedValue<[String]>([])
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            box.reenableTapIfNeeded { _ in
+                events.value.append("reenable-begin")
+                reenableEntered.signal()
+                allowReenableToFinish.wait()
+                events.value.append("reenable-end")
+            }
+            reenableFinished.signal()
+        }
+        let entered = reenableEntered.wait(timeout: .now() + 1)
+        #expect(entered == .success)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = box.tearDownTap { tap in
+                events.value.append("teardown")
+                CFMachPortInvalidate(tap)
+            }
+            teardownFinished.signal()
+        }
+        let teardownWhileReenableBlocked = teardownFinished.wait(timeout: .now() + 0.05)
+        #expect(teardownWhileReenableBlocked == .timedOut)
+
+        allowReenableToFinish.signal()
+        let reenableCompleted = reenableFinished.wait(timeout: .now() + 1)
+        let teardownCompleted = teardownFinished.wait(timeout: .now() + 1)
+        #expect(reenableCompleted == .success)
+        #expect(teardownCompleted == .success)
+        #expect(events.value == ["reenable-begin", "reenable-end", "teardown"])
+        #expect(box.tearDownTap { _ in } == false)
+    }
+}
+
+@MainActor
+private final class RecordingEventTapRuntime {
+    private let replacementTapFailuresPerGeneration: Int
+    private let replacementSourceFailuresPerGeneration: Int
+    private var initialTapFailuresRemaining: Int
+    private var initialSourceFailuresRemaining: Int
+    private var replacementTapFailures: [UInt64: Int] = [:]
+    private var replacementSourceFailures: [UInt64: Int] = [:]
+    private(set) var replacementTapAttempts = 0
+    private(set) var replacementSourceAttempts = 0
+    private(set) var boxes: [WeakEventTapBox] = []
+    private(set) var threads: [RecordingEventTapRunLoopThread] = []
+
+    init(
+        initialTapFailures: Int = 0,
+        initialSourceFailures: Int = 0,
+        replacementTapFailuresPerGeneration: Int = 0,
+        replacementSourceFailuresPerGeneration: Int = 0
+    ) {
+        initialTapFailuresRemaining = initialTapFailures
+        initialSourceFailuresRemaining = initialSourceFailures
+        self.replacementTapFailuresPerGeneration = replacementTapFailuresPerGeneration
+        self.replacementSourceFailuresPerGeneration = replacementSourceFailuresPerGeneration
+    }
+
+    lazy var factory = EventTapRuntimeFactory(
+        makeThread: { [unowned self] generation in
+            let thread = RecordingEventTapRunLoopThread(generation: generation)
+            threads.append(thread)
+            return thread
+        },
+        makeTap: { [unowned self] context, _, _, userInfo in
+            let box = Unmanaged<EventTapBox>.fromOpaque(userInfo).takeUnretainedValue()
+            if boxes.last?.value !== box {
+                boxes.append(WeakEventTapBox(box))
+            }
+            if context.phase == .initial, initialTapFailuresRemaining > 0 {
+                initialTapFailuresRemaining -= 1
+                return nil
+            }
+            if context.phase == .replacement {
+                replacementTapAttempts += 1
+                let failures = replacementTapFailures[context.generation, default: 0]
+                if failures < replacementTapFailuresPerGeneration {
+                    replacementTapFailures[context.generation] = failures + 1
+                    return nil
+                }
+            }
+            return makeTestingMachPort()
+        },
+        makeSource: { [unowned self] context, tap in
+            if context.phase == .initial, initialSourceFailuresRemaining > 0 {
+                initialSourceFailuresRemaining -= 1
+                return nil
+            }
+            if context.phase == .replacement {
+                replacementSourceAttempts += 1
+                let failures = replacementSourceFailures[context.generation, default: 0]
+                if failures < replacementSourceFailuresPerGeneration {
+                    replacementSourceFailures[context.generation] = failures + 1
+                    return nil
+                }
+            }
+            return CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        },
+        setTapEnabled: { _, _ in },
+        invalidateTap: { tap in CFMachPortInvalidate(tap) },
+        now: { CFAbsoluteTimeGetCurrent() }
+    )
+
+    func triggerRecreationThreshold() async {
+        guard let box = boxes.last?.value else {
+            Issue.record("expected the current EventTapBox owner")
+            return
+        }
+        for now in [1000.0, 1001.0, 1002.0] {
+            let (action, snapshot) = box.recordTimeoutAndDecide(
+                at: now,
+                threadIdentity: "recording-thread"
+            )
+            if action == .fullRecreation || action == .markDegraded {
+                box.onRecoveryNeeded?(action, snapshot)
+            }
+        }
+        await Task.yield()
+        await Task.yield()
+    }
+}
+
+private final class WeakEventTapBox {
+    weak var value: EventTapBox?
+
+    init(_ value: EventTapBox) {
+        self.value = value
+    }
+}
+
+private final class RecordingEventTapRunLoopThread: EventTapRunLoopThread {
+    let identity: String
+    let threadID: UInt64?
+    private(set) var hasExited = false
+    private(set) var isAlive = false
+
+    init(generation: UInt64) {
+        identity = "recording-event-tap-\(generation)"
+        threadID = generation
+    }
+
+    func start() {
+        isAlive = true
+    }
+
+    func addSource(_ source: CFRunLoopSource) {}
+
+    func removeSource(_ source: CFRunLoopSource) {}
+
+    func cancelAndWait() {
+        isAlive = false
+        hasExited = true
+    }
+
+    func simulateUnexpectedExit() {
+        isAlive = false
+        hasExited = true
+    }
+}
+
+private func makeTestingMachPort() -> CFMachPort {
+    var context = CFMachPortContext(
+        version: 0,
+        info: nil,
+        retain: nil,
+        release: nil,
+        copyDescription: nil
+    )
+    return CFMachPortCreate(kCFAllocatorDefault, nil, &context, nil)!
+}

--- a/Tests/WinkTests/EventTapManagerOwnershipTests.swift
+++ b/Tests/WinkTests/EventTapManagerOwnershipTests.swift
@@ -238,6 +238,7 @@ struct EventTapManagerOwnedSessionTests {
         let manager = EventTapManager(runtimeFactory: runtime.factory)
 
         #expect(manager.start { _ in true } == .started)
+        manager.setHyperKeyEnabled(true)
         let firstThread = runtime.threads[0]
         let firstBox = runtime.boxes[0]
         firstThread.simulateUnexpectedExit()
@@ -257,6 +258,7 @@ struct EventTapManagerOwnedSessionTests {
         #expect(restarted.sourceOwned == 1)
         #expect(restarted.boxOwned == 1)
         #expect(restarted.threadOwned == 1)
+        #expect(runtime.boxes[1].value?.hyperKeyEnabled == true)
 
         manager.stop()
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -177,7 +177,9 @@ Responsibilities:
   - first timeout -> in-place re-enable
   - 3 timeouts within 30 seconds -> full recreation
   - 2 recreation failures within 120 seconds -> degraded readiness state
-- recreate the tap on the same background thread using a reusable readiness mechanism instead of a one-shot startup handshake
+- own the Hyper tap, source, callback box, and RunLoop thread as one generation-scoped session; readiness never substitutes for ownership during stop/restart teardown
+- recreate the tap on the same background thread using a reusable readiness mechanism instead of a one-shot startup handshake; a failed first replacement executes its retry, while the retry limit tears down the complete session before reporting degraded readiness
+- reject queued key/recovery callbacks whose generation no longer matches the current session, and join the old RunLoop thread before releasing its callback box or publishing a replacement owner
 
 ### Activation and toggle logic
 - `AppSwitcher`

--- a/docs/signing-and-release.md
+++ b/docs/signing-and-release.md
@@ -102,6 +102,40 @@ validation argument nor `LAUNCH_FAULT_INJECTION` marker; verify those properties
 on the exact executable used for normal-path E2E. Never distribute the injected
 bundle.
 
+### EventTap lifecycle fault validation package
+
+The EventTap failure factories and scenario driver are also compile-time-only.
+Build that packaged validation profile explicitly:
+
+```bash
+WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION=1 bash scripts/package-app.sh
+```
+
+The resulting bundle carries
+`WinkRuntimeValidationProfile=event-tap-fault-injection` and accepts exactly one
+of these arguments:
+
+```text
+--validation-event-tap-fault=replacement-tap-once
+--validation-event-tap-fault=replacement-source-until-degraded
+--validation-event-tap-fault=cycle20
+```
+
+The first mode fails one replacement-tap creation and requires the configured
+retry to recover on the same thread within one second. The second fails two
+replacement-source creations, requires degraded readiness, and proves that each
+created tap plus the complete owned session is released. `cycle20` runs twenty
+fail/stop-twice/restart generations, probes stopped-generation callbacks, proves
+one owner after each restart, and finishes with all owned-resource counters at
+zero.
+
+The launch and EventTap injection profiles are mutually exclusive. Preserve
+each injected bundle at a separate absolute path, then rebuild production from
+the same 40-character Git head. The clean executable must have no runtime
+validation profile, validation argument, `LAUNCH_FAULT_INJECTION`, or
+`EVENT_TAP_FAULT_INJECTION` marker before normal-path E2E. Never distribute an
+injected bundle.
+
 ### Local development signing identity ("Wink")
 
 `SIGN_IDENTITY` defaults to `Wink`. Keep a self-signed code-signing

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # Default packaging is production-only. For the compile-time validation build:
 #   WINK_VALIDATION_LAUNCH_FAULT_INJECTION=1 ./scripts/package-app.sh
+#   WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION=1 ./scripts/package-app.sh
 # Then launch the packaged app with exactly one validation argument, for example:
 #   open -n build/Wink.app --args \
 #     --validation-launch-fault=stale-error:com.apple.TextEdit
+#   open -n build/Wink.app --args \
+#     --validation-event-tap-fault=replacement-tap-once
 set -euo pipefail
 
 APP_NAME="Wink"
@@ -27,21 +30,34 @@ REQUIRE_SIGN_IDENTITY="${REQUIRE_SIGN_IDENTITY:-0}"
 SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-}"
 SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY:-}"
 WINK_VALIDATION_LAUNCH_FAULT_INJECTION="${WINK_VALIDATION_LAUNCH_FAULT_INJECTION:-0}"
+WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION="${WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION:-0}"
 
 case "$WINK_VALIDATION_LAUNCH_FAULT_INJECTION" in
-    0)
-        PACKAGE_PROFILE="production"
-        BUILD_SCRATCH_PATH="$PROJECT_DIR/.build"
-        ;;
-    1)
-        PACKAGE_PROFILE="launch-fault-injection"
-        BUILD_SCRATCH_PATH="$PROJECT_DIR/.build"
-        ;;
+    0|1) ;;
     *)
         echo "Error: WINK_VALIDATION_LAUNCH_FAULT_INJECTION must be 0 or 1" >&2
         exit 1
         ;;
 esac
+
+case "$WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION" in
+    0|1) ;;
+    *)
+        echo "Error: WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION must be 0 or 1" >&2
+        exit 1
+        ;;
+esac
+
+case "$WINK_VALIDATION_LAUNCH_FAULT_INJECTION:$WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION" in
+    0:0) PACKAGE_PROFILE="production" ;;
+    1:0) PACKAGE_PROFILE="launch-fault-injection" ;;
+    0:1) PACKAGE_PROFILE="event-tap-fault-injection" ;;
+    1:1)
+        echo "Error: launch and EventTap fault-injection profiles are mutually exclusive" >&2
+        exit 1
+        ;;
+esac
+BUILD_SCRATCH_PATH="$PROJECT_DIR/.build"
 
 SWIFT_BUILD_FLAGS=(
     -c release
@@ -50,6 +66,8 @@ SWIFT_BUILD_FLAGS=(
 )
 if [ "$PACKAGE_PROFILE" = "launch-fault-injection" ]; then
     SWIFT_BUILD_FLAGS+=(-Xswiftc -DWINK_LAUNCH_FAULT_INJECTION)
+elif [ "$PACKAGE_PROFILE" = "event-tap-fault-injection" ]; then
+    SWIFT_BUILD_FLAGS+=(-Xswiftc -DWINK_EVENT_TAP_FAULT_INJECTION)
 fi
 
 clean_package_products() {
@@ -63,12 +81,13 @@ clean_package_products() {
 # removes the previous profile's objects explicitly. This keeps the shared
 # dependency checkout/cache while preventing an injected object from entering
 # a production bundle (or vice versa).
-if [ "$PACKAGE_PROFILE" = "launch-fault-injection" ]; then
+if [ "$PACKAGE_PROFILE" != "production" ]; then
     echo "==> Cleaning package products before validation-profile build..."
     clean_package_products
 elif [ -f "$BUILD_SCRATCH_PATH/release/${APP_NAME}" ] \
-    && LC_ALL=C grep -aFq 'LAUNCH_FAULT_INJECTION' "$BUILD_SCRATCH_PATH/release/${APP_NAME}"; then
-    echo "==> Removing launch-fault-injection products before production build..."
+    && { LC_ALL=C grep -aFq 'LAUNCH_FAULT_INJECTION' "$BUILD_SCRATCH_PATH/release/${APP_NAME}" \
+        || LC_ALL=C grep -aFq 'EVENT_TAP_FAULT_INJECTION' "$BUILD_SCRATCH_PATH/release/${APP_NAME}"; }; then
+    echo "==> Removing fault-injection products before production build..."
     clean_package_products
 fi
 
@@ -129,7 +148,7 @@ apply_sparkle_info_overrides() {
 apply_validation_profile() {
     local plist_path="$1"
 
-    if [ "$PACKAGE_PROFILE" = "launch-fault-injection" ]; then
+    if [ "$PACKAGE_PROFILE" != "production" ]; then
         plutil -replace WinkRuntimeValidationProfile -string "$PACKAGE_PROFILE" "$plist_path" 2>/dev/null \
             || plutil -insert WinkRuntimeValidationProfile -string "$PACKAGE_PROFILE" "$plist_path"
     else


### PR DESCRIPTION
Fixes #316

## Summary

- Replace the EventTap manager's implicit `eventTap != nil` lifetime model with an explicit generation-scoped owned session for the run-loop thread, callback box, tap, and source.
- Execute the retry/degraded action returned by recreation failure tracking, and tear down every partial owner unconditionally before restart.
- Reject key and recovery callbacks captured from stopped generations, serialize tap re-enable/teardown, and preserve the desired Hyper state across direct manager restarts.
- Add injectable tap/source/thread factories, ownership accounting, and a compile-time-only packaged fault-injection profile for exact replacement failure and 20-cycle runtime proof.

## Exact reviewed revision

- Head: `98634c60f99d54dcdafc46005d6cffbcd236965b`
- Review base: `e2c17ac5730467a46fae28534ff13f60b8b3742e`
- Standards review: PASS against the fixed base and exact head
- Spec review: PASS against the fixed base and exact head

## Testing

- [x] `swift test`
- [x] Additional validation noted below when needed

```text
swift test --no-parallel --filter EventTapManagerOwnershipTests
PASS: 9 tests

swift test --no-parallel -Xswiftc -DWINK_EVENT_TAP_FAULT_INJECTION --filter EventTapFaultInjectionTests
PASS: 4 tests

swift test --no-parallel
PASS: 456 tests, 44 suites

swift build -c release
PASS

WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION=1 bash scripts/package-app.sh
PASS

bash scripts/package-app.sh
PASS
```

## Validation Status

- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Acceptance map

- Explicit lifecycle without an active tap: `EventTapLifecycleState` and `EventTapOwnedSession` retain generation-scoped ownership independent of tap presence; initial and replacement tap/source failure tests prove the state remains tear-downable.
- Retry/degraded action executed: replacement tap failure tests and packaged `replacement-tap-once` prove the first `.fullRecreation` is executed; replacement source failure proves the second failure reaches degraded and complete teardown.
- Unconditional idempotent stop: every failure-point test calls `stop()` twice; the 20-cycle packaged run also performs double stop every cycle and finishes net zero.
- Restart ownership safety: start first tears down any partial/live owner; tests prove the prior callback box deinitializes and prior thread exits before a new generation publishes.
- Injectable factories: committed tap/source/thread factories cover initial/replacement tap failure, initial/replacement source failure, retry, degraded, stop, direct restart, unexpected thread exit, and concurrent re-enable/teardown.
- Stopped generations: committed tests and the packaged cycle driver invoke captured stale key/recovery callbacks; all 40 packaged probes are discarded with zero delivery or owner mutation.
- No passive fallback: active capture remains `.defaultTap`; no `.listenOnly` path was added.
- Production seam isolation: the parser, driver, validation entrypoints, structured ownership logs, and marker are compiled only with `WINK_EVENT_TAP_FAULT_INJECTION`; the clean executable contains no profile, argument, EventTap marker, or launch-injection marker.
- Runtime gates: both injected and clean bundles were built from the same exact 40-character head; standard-only Carbon and mixed Carbon+Hyper clean E2E pass, plus automated and physical held/repeat checks produce one action without a loop.

## macOS runtime validation complete

Evidence root:

`/Users/yvan/developer/Wink/build/validation/issue-316-98634c60f99d54dcdafc46005d6cffbcd236965b`

Injected bundle:

- Path: `/Users/yvan/developer/Wink/build/validation/issue-316-98634c60f99d54dcdafc46005d6cffbcd236965b/bundles/injected/Wink.app`
- `Contents/MacOS/Wink` SHA-256: `b52612cafc0bc9162c1801e3b497fa60e82c0bd77db964758c647c10f34a5a86`
- Profile: `WinkRuntimeValidationProfile=event-tap-fault-injection`
- Strict deep codesign: PASS

Clean production bundle:

- Path: `/Users/yvan/developer/Wink/build/validation/issue-316-98634c60f99d54dcdafc46005d6cffbcd236965b/bundles/clean/Wink.app`
- `Contents/MacOS/Wink` SHA-256: `09738b656034dbd0f628888bc3e9594484cb180af11397492c8ff1ba23f5bbf0`
- Validation profile, validation argument, EventTap marker, and launch marker: absent
- Strict deep codesign: PASS

Injected packaged runtime:

```text
replacement-tap-once:
  one replacement failure at attempt 1
  same-thread recovery: threadId=7723009
  elapsedMs=2, deadlineMs=1000
  owner/thread/tap/source/box net=1 after recovery
  PASS

replacement-source-until-degraded:
  replacement source failures at attempts 1 and 2
  elapsedMs=3, deadlineMs=1000
  degraded readiness=false
  owner/thread/tap/source/box net=0
  PASS

cycle20:
  20/20 fail -> stop twice -> restart cycles PASS
  20 distinct prior thread IDs, each previousThreadReleased=true
  one owner/thread/tap/source/box after every restart
  stopped-generation callback discards=40, deliveries=0
  final tap=21/21 source=21/21 box=21/21 activeThreads=0 owner=0
  PASS

no validation argument:
  injection seam did not activate
  relaunch had exactly one active owner
  graceful exit returned all nets to zero
  PASS
```

Clean packaged runtime:

```text
standard-only fixture:
  carbon=true eventTap=false standardFnObserverRequired=false
  full E2E 6/6, 0 FAIL, 1 expected no-Hyper warning

mixed fixture:
  ax=true im=true carbon=true eventTap=true
  full E2E 6/6, 0 FAIL, 0 warnings

automated held/repeat:
  one initial Hyper+G plus 12 autorepeat frames
  exactly one match, injection, swallow, and action
  Chess reached frontmost; no degraded or loop signature

physical held/repeat:
  user held physical Caps Lock + G on the exact clean package
  exactly one F19 down/up, match, injection, swallow, and action
  Chess reached stable frontmost state
  zero additional match/action, degraded, blocked, failure, or loop signatures
```

No Accessibility, Input Monitoring, TCC, or privacy setting was changed. The original 20-shortcut payload was restored byte-for-byte (SHA-256 `821b3cfd866445435ace749f4b711c63e7f41a8c096d8b162134bb689e764113`), original preferences were restored semantically, and the user's ordinary app was relaunched ready.

## Docs Sync Check (issue #230)

- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes

- `docs/architecture.md` now documents the single-generation owned-session lifecycle and stale-callback guards.
- `docs/signing-and-release.md` documents the compile-time-only EventTap validation package and same-SHA clean rebuild rule.
- Fresh CI, PR Metadata, Review Gate, current-head approval, and unresolved-thread state will be followed through before merge.
