### PR TITLE
Reject duplicate shortcut IDs at the persistence boundary

### DIFF
--- a/Sources/Wink/Services/PersistenceService.swift
+++ b/Sources/Wink/Services/PersistenceService.swift
@@ -13,12 +13,15 @@ struct PersistenceService: Sendable {
 
     enum SaveError: Error, LocalizedError, Sendable {
         case storageUnavailable
+        case duplicateShortcutID(path: String, id: UUID)
         case writeFailed(path: String, reason: String)
 
         var errorDescription: String? {
             switch self {
             case .storageUnavailable:
                 return "Failed to save shortcuts: path unavailable"
+            case let .duplicateShortcutID(path, id):
+                return "Failed to save shortcuts: path=\(path) schema=duplicate-shortcut-id id=\(id.uuidString)"
             case let .writeFailed(path, reason):
                 return "Failed to save shortcuts: path=\(path) reason=\(reason)"
             }
@@ -29,6 +32,7 @@ struct PersistenceService: Sendable {
         case storageUnavailable
         case fileReadFailed(path: String, reason: String)
         case decodeFailed(path: String, reason: String, preservedCopyPath: String?)
+        case duplicateShortcutID(path: String, id: UUID, preservedCopyPath: String?)
 
         var errorDescription: String? {
             switch self {
@@ -39,6 +43,9 @@ struct PersistenceService: Sendable {
             case let .decodeFailed(path, reason, preservedCopyPath):
                 let backupDescription = preservedCopyPath ?? "none"
                 return "Failed to load shortcuts: path=\(path) reason=\(reason) preservedCopyPath=\(backupDescription)"
+            case let .duplicateShortcutID(path, id, preservedCopyPath):
+                let backupDescription = preservedCopyPath ?? "none"
+                return "Failed to load shortcuts: path=\(path) schema=duplicate-shortcut-id id=\(id.uuidString) preservedCopyPath=\(backupDescription)"
             }
         }
     }
@@ -82,10 +89,11 @@ struct PersistenceService: Sendable {
             throw loadError
         }
 
+        let shortcuts: [AppShortcut]
         do {
-            return try JSONDecoder().decode([AppShortcut].self, from: data)
+            shortcuts = try JSONDecoder().decode([AppShortcut].self, from: data)
         } catch {
-            let preservedCopyPath = preserveUnreadablePayload(data, originalURL: url)
+            let preservedCopyPath = preserveRejectedPayload(data, originalURL: url)
             let loadError = LoadError.decodeFailed(
                 path: url.path,
                 reason: error.localizedDescription,
@@ -94,6 +102,19 @@ struct PersistenceService: Sendable {
             logLoadFailure(loadError)
             throw loadError
         }
+
+        if let duplicateID = firstDuplicateID(in: shortcuts) {
+            let preservedCopyPath = preserveRejectedPayload(data, originalURL: url)
+            let loadError = LoadError.duplicateShortcutID(
+                path: url.path,
+                id: duplicateID,
+                preservedCopyPath: preservedCopyPath
+            )
+            logLoadFailure(loadError)
+            throw loadError
+        }
+
+        return shortcuts
     }
 
     func save(_ shortcuts: [AppShortcut]) throws {
@@ -102,6 +123,13 @@ struct PersistenceService: Sendable {
             logSaveFailure(error)
             throw error
         }
+
+        if let duplicateID = firstDuplicateID(in: shortcuts) {
+            let error = SaveError.duplicateShortcutID(path: url.path, id: duplicateID)
+            logSaveFailure(error)
+            throw error
+        }
+
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
 
@@ -124,14 +152,22 @@ struct PersistenceService: Sendable {
         diagnosticClient.log(message)
     }
 
-    private func preserveUnreadablePayload(_ data: Data, originalURL: URL) -> String? {
+    private func firstDuplicateID(in shortcuts: [AppShortcut]) -> UUID? {
+        var seenIDs = Set<UUID>()
+        for shortcut in shortcuts where !seenIDs.insert(shortcut.id).inserted {
+            return shortcut.id
+        }
+        return nil
+    }
+
+    private func preserveRejectedPayload(_ data: Data, originalURL: URL) -> String? {
         let backupURL = backupURL(for: originalURL)
 
         do {
             try data.write(to: backupURL, options: .atomic)
             return backupURL.path
         } catch {
-            let message = "Failed to preserve unreadable shortcuts payload: path=\(originalURL.path) backupPath=\(backupURL.path) reason=\(error.localizedDescription)"
+            let message = "Failed to preserve rejected shortcuts payload: path=\(originalURL.path) backupPath=\(backupURL.path) reason=\(error.localizedDescription)"
             logger.error("\(message, privacy: .public)")
             diagnosticClient.log(message)
             return nil

--- a/Tests/WinkTests/AppControllerTests.swift
+++ b/Tests/WinkTests/AppControllerTests.swift
@@ -189,6 +189,79 @@ func startupSequenceAppliesPersistedPreferencesBeforeStartingShortcutManager() {
 }
 
 @Test @MainActor
+func duplicatePersistencePayloadNeverPublishesIntoSettingsModels() async throws {
+    let harness = TestPersistenceHarness()
+    defer { harness.cleanup() }
+    let duplicateID = UUID(uuidString: "12345678-1234-1234-1234-123456789012")!
+    let invalidPayload = try JSONEncoder().encode([
+        AppShortcut(
+            id: duplicateID,
+            appName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            keyEquivalent: "s",
+            modifierFlags: ["command"]
+        ),
+        AppShortcut(
+            id: duplicateID,
+            appName: "Notes",
+            bundleIdentifier: "com.apple.Notes",
+            keyEquivalent: "n",
+            modifierFlags: ["command", "option"]
+        ),
+    ])
+    try invalidPayload.write(to: harness.shortcutsURL)
+
+    let service = harness.makePersistenceService(backupIDProvider: { "startup-duplicate" })
+    let store = ShortcutStore()
+    var didReplaceShortcuts = false
+    var didStartShortcutManager = false
+
+    AppController.runStartupSequence(
+        startUpdateService: {},
+        loadShortcuts: { try service.load() },
+        replaceShortcuts: { shortcuts in
+            didReplaceShortcuts = true
+            store.replaceAll(with: shortcuts)
+        },
+        reapplyHyperIfNeeded: { false },
+        isHyperEnabled: { false },
+        setHyperKeyEnabled: { _ in },
+        startShortcutManager: { didStartShortcutManager = true }
+    )
+
+    #expect(didReplaceShortcuts == false)
+    #expect(didStartShortcutManager)
+    #expect(store.shortcuts.isEmpty)
+    #expect(try Data(contentsOf: harness.shortcutsURL) == invalidPayload)
+    #expect(
+        try Data(
+            contentsOf: harness.directory
+                .appendingPathComponent("shortcuts.load-failure-startup-duplicate.json")
+        ) == invalidPayload
+    )
+
+    let statusProvider = ShortcutStatusProvider(
+        client: .init(
+            applicationURL: { _ in nil },
+            runningBundleIdentifiers: { [] }
+        ),
+        workspaceNotificationCenter: NotificationCenter(),
+        appNotificationCenter: NotificationCenter()
+    )
+    statusProvider.track(store.shortcuts)
+    #expect(statusProvider.statusesByShortcutID.isEmpty)
+
+    let insights = InsightsViewModel(
+        usageTracker: EmptyUsageTracker(),
+        shortcutStore: store
+    )
+    await insights.refresh(for: .week)
+    #expect(insights.ranking.isEmpty)
+    #expect(insights.appRows.isEmpty)
+    #expect(insights.unusedShortcutNames.isEmpty)
+}
+
+@Test @MainActor
 func openPrimarySettingsWindowUsesInstalledSettingsLauncherHandler() throws {
     ensureAppKitApplication()
 
@@ -230,4 +303,14 @@ func openPrimarySettingsWindowQueuesPendingOpenUntilHandlerInstalls() throws {
 @MainActor
 private func ensureAppKitApplication() {
     _ = NSApplication.shared
+}
+
+private actor EmptyUsageTracker: UsageTracking {
+    func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] { [:] }
+    func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] { [:] }
+    func totalSwitches(days: Int, relativeTo now: Date) async -> Int { 0 }
+    func hourlyCounts(days: Int, relativeTo now: Date) async -> [HourlyUsageBucket] { [] }
+    func previousPeriodTotal(days: Int, relativeTo now: Date) async -> Int { 0 }
+    func streakDays(relativeTo now: Date) async -> Int { 0 }
+    func usageTimeZone() async -> TimeZone { .current }
 }

--- a/Tests/WinkTests/AppControllerTests.swift
+++ b/Tests/WinkTests/AppControllerTests.swift
@@ -192,23 +192,7 @@ func startupSequenceAppliesPersistedPreferencesBeforeStartingShortcutManager() {
 func duplicatePersistencePayloadNeverPublishesIntoSettingsModels() async throws {
     let harness = TestPersistenceHarness()
     defer { harness.cleanup() }
-    let duplicateID = UUID(uuidString: "12345678-1234-1234-1234-123456789012")!
-    let invalidPayload = try JSONEncoder().encode([
-        AppShortcut(
-            id: duplicateID,
-            appName: "Safari",
-            bundleIdentifier: "com.apple.Safari",
-            keyEquivalent: "s",
-            modifierFlags: ["command"]
-        ),
-        AppShortcut(
-            id: duplicateID,
-            appName: "Notes",
-            bundleIdentifier: "com.apple.Notes",
-            keyEquivalent: "n",
-            modifierFlags: ["command", "option"]
-        ),
-    ])
+    let invalidPayload = try JSONEncoder().encode(makeDuplicateShortcutIDFixture())
     try invalidPayload.write(to: harness.shortcutsURL)
 
     let service = harness.makePersistenceService(backupIDProvider: { "startup-duplicate" })

--- a/Tests/WinkTests/PersistenceServiceTests.swift
+++ b/Tests/WinkTests/PersistenceServiceTests.swift
@@ -99,24 +99,7 @@ struct PersistenceServiceDiskLoadingTests {
         let harness = TestPersistenceHarness()
         defer { harness.cleanup() }
         let diagnostics = DiagnosticRecorder()
-        let duplicateID = UUID(uuidString: "12345678-1234-1234-1234-123456789012")!
-        let invalidPayload = try JSONEncoder().encode([
-            AppShortcut(
-                id: duplicateID,
-                appName: "Safari",
-                bundleIdentifier: "com.apple.Safari",
-                keyEquivalent: "s",
-                modifierFlags: ["command"]
-            ),
-            AppShortcut(
-                id: duplicateID,
-                appName: "Notes",
-                bundleIdentifier: "com.apple.Notes",
-                keyEquivalent: "n",
-                modifierFlags: ["command", "option"],
-                isEnabled: false
-            ),
-        ])
+        let invalidPayload = try JSONEncoder().encode(makeDuplicateShortcutIDFixture())
         try invalidPayload.write(to: harness.shortcutsURL)
 
         let service = harness.makePersistenceService(
@@ -135,7 +118,7 @@ struct PersistenceServiceDiskLoadingTests {
                 return
             }
             #expect(path == harness.shortcutsURL.path)
-            #expect(id == duplicateID)
+            #expect(id == duplicateShortcutFixtureID)
             #expect(
                 preservedCopyPath
                     == harness.directory
@@ -149,7 +132,7 @@ struct PersistenceServiceDiskLoadingTests {
         #expect(try Data(contentsOf: backupURL) == invalidPayload)
         #expect(diagnostics.messages.contains {
             $0.contains("path=\(harness.shortcutsURL.path)")
-                && $0.contains(duplicateID.uuidString)
+                && $0.contains(duplicateShortcutFixtureID.uuidString)
                 && $0.contains("preservedCopyPath=\(backupURL.path)")
         })
 
@@ -173,7 +156,6 @@ struct PersistenceServiceDiskLoadingTests {
         let harness = TestPersistenceHarness()
         defer { harness.cleanup() }
         let diagnostics = DiagnosticRecorder()
-        let duplicateID = UUID(uuidString: "12345678-1234-1234-1234-123456789012")!
         let service = harness.makePersistenceService(
             diagnosticClient: .init(log: { message in
                 diagnostics.append(message)
@@ -189,23 +171,7 @@ struct PersistenceServiceDiskLoadingTests {
         ]
         try service.save(canonical)
         let canonicalPayload = try Data(contentsOf: harness.shortcutsURL)
-        let duplicateShortcuts = [
-            AppShortcut(
-                id: duplicateID,
-                appName: "Notes",
-                bundleIdentifier: "com.apple.Notes",
-                keyEquivalent: "n",
-                modifierFlags: ["command"]
-            ),
-            AppShortcut(
-                id: duplicateID,
-                appName: "Terminal",
-                bundleIdentifier: "com.apple.Terminal",
-                keyEquivalent: "t",
-                modifierFlags: ["command", "option"],
-                isEnabled: false
-            ),
-        ]
+        let duplicateShortcuts = makeDuplicateShortcutIDFixture()
 
         do {
             try service.save(duplicateShortcuts)
@@ -216,14 +182,14 @@ struct PersistenceServiceDiskLoadingTests {
                 return
             }
             #expect(path == harness.shortcutsURL.path)
-            #expect(id == duplicateID)
+            #expect(id == duplicateShortcutFixtureID)
         }
 
         #expect(try Data(contentsOf: harness.shortcutsURL) == canonicalPayload)
         #expect(try service.load() == canonical)
         #expect(diagnostics.messages.contains {
             $0.contains("path=\(harness.shortcutsURL.path)")
-                && $0.contains(duplicateID.uuidString)
+                && $0.contains(duplicateShortcutFixtureID.uuidString)
         })
     }
 

--- a/Tests/WinkTests/PersistenceServiceTests.swift
+++ b/Tests/WinkTests/PersistenceServiceTests.swift
@@ -95,6 +95,139 @@ struct PersistenceServiceDiskLoadingTests {
     }
 
     @Test
+    func duplicateIDsAreRejectedBeforeLoadReturns() throws {
+        let harness = TestPersistenceHarness()
+        defer { harness.cleanup() }
+        let diagnostics = DiagnosticRecorder()
+        let duplicateID = UUID(uuidString: "12345678-1234-1234-1234-123456789012")!
+        let invalidPayload = try JSONEncoder().encode([
+            AppShortcut(
+                id: duplicateID,
+                appName: "Safari",
+                bundleIdentifier: "com.apple.Safari",
+                keyEquivalent: "s",
+                modifierFlags: ["command"]
+            ),
+            AppShortcut(
+                id: duplicateID,
+                appName: "Notes",
+                bundleIdentifier: "com.apple.Notes",
+                keyEquivalent: "n",
+                modifierFlags: ["command", "option"],
+                isEnabled: false
+            ),
+        ])
+        try invalidPayload.write(to: harness.shortcutsURL)
+
+        let service = harness.makePersistenceService(
+            diagnosticClient: .init(log: { message in
+                diagnostics.append(message)
+            }),
+            backupIDProvider: { "duplicate-id" }
+        )
+
+        do {
+            let shortcuts = try service.load()
+            Issue.record("Expected duplicate shortcut IDs to fail loading; loaded \(shortcuts.count) shortcuts")
+        } catch let error as PersistenceService.LoadError {
+            guard case let .duplicateShortcutID(path, id, preservedCopyPath) = error else {
+                Issue.record("Expected duplicateShortcutID, got \(error)")
+                return
+            }
+            #expect(path == harness.shortcutsURL.path)
+            #expect(id == duplicateID)
+            #expect(
+                preservedCopyPath
+                    == harness.directory
+                        .appendingPathComponent("shortcuts.load-failure-duplicate-id.json")
+                        .path
+            )
+        }
+
+        let backupURL = harness.directory.appendingPathComponent("shortcuts.load-failure-duplicate-id.json")
+        #expect(try Data(contentsOf: harness.shortcutsURL) == invalidPayload)
+        #expect(try Data(contentsOf: backupURL) == invalidPayload)
+        #expect(diagnostics.messages.contains {
+            $0.contains("path=\(harness.shortcutsURL.path)")
+                && $0.contains(duplicateID.uuidString)
+                && $0.contains("preservedCopyPath=\(backupURL.path)")
+        })
+
+        let replacement = [
+            AppShortcut(
+                appName: "Terminal",
+                bundleIdentifier: "com.apple.Terminal",
+                keyEquivalent: "t",
+                modifierFlags: ["command"]
+            ),
+        ]
+        let replacementPayload = try JSONEncoder().encode(replacement)
+        try replacementPayload.write(to: harness.shortcutsURL, options: .atomic)
+
+        #expect(try service.load() == replacement)
+        #expect(try Data(contentsOf: backupURL) == invalidPayload)
+    }
+
+    @Test
+    func duplicateIDsAreRejectedBeforeSaveOverwritesCanonicalPayload() throws {
+        let harness = TestPersistenceHarness()
+        defer { harness.cleanup() }
+        let diagnostics = DiagnosticRecorder()
+        let duplicateID = UUID(uuidString: "12345678-1234-1234-1234-123456789012")!
+        let service = harness.makePersistenceService(
+            diagnosticClient: .init(log: { message in
+                diagnostics.append(message)
+            })
+        )
+        let canonical = [
+            AppShortcut(
+                appName: "Safari",
+                bundleIdentifier: "com.apple.Safari",
+                keyEquivalent: "s",
+                modifierFlags: ["command"]
+            ),
+        ]
+        try service.save(canonical)
+        let canonicalPayload = try Data(contentsOf: harness.shortcutsURL)
+        let duplicateShortcuts = [
+            AppShortcut(
+                id: duplicateID,
+                appName: "Notes",
+                bundleIdentifier: "com.apple.Notes",
+                keyEquivalent: "n",
+                modifierFlags: ["command"]
+            ),
+            AppShortcut(
+                id: duplicateID,
+                appName: "Terminal",
+                bundleIdentifier: "com.apple.Terminal",
+                keyEquivalent: "t",
+                modifierFlags: ["command", "option"],
+                isEnabled: false
+            ),
+        ]
+
+        do {
+            try service.save(duplicateShortcuts)
+            Issue.record("Expected duplicate shortcut IDs to fail saving")
+        } catch let error as PersistenceService.SaveError {
+            guard case let .duplicateShortcutID(path, id) = error else {
+                Issue.record("Expected duplicateShortcutID, got \(error)")
+                return
+            }
+            #expect(path == harness.shortcutsURL.path)
+            #expect(id == duplicateID)
+        }
+
+        #expect(try Data(contentsOf: harness.shortcutsURL) == canonicalPayload)
+        #expect(try service.load() == canonical)
+        #expect(diagnostics.messages.contains {
+            $0.contains("path=\(harness.shortcutsURL.path)")
+                && $0.contains(duplicateID.uuidString)
+        })
+    }
+
+    @Test
     func rejectsMissingIsEnabledPayloadWithoutSilentMigration() throws {
         let harness = TestPersistenceHarness()
         defer { harness.cleanup() }

--- a/Tests/WinkTests/TestSupport/TestPersistenceHarness.swift
+++ b/Tests/WinkTests/TestSupport/TestPersistenceHarness.swift
@@ -1,6 +1,28 @@
 import Foundation
 @testable import Wink
 
+let duplicateShortcutFixtureID = UUID(uuidString: "12345678-1234-1234-1234-123456789012")!
+
+func makeDuplicateShortcutIDFixture() -> [AppShortcut] {
+    [
+        AppShortcut(
+            id: duplicateShortcutFixtureID,
+            appName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            keyEquivalent: "s",
+            modifierFlags: ["command"]
+        ),
+        AppShortcut(
+            id: duplicateShortcutFixtureID,
+            appName: "Notes",
+            bundleIdentifier: "com.apple.Notes",
+            keyEquivalent: "n",
+            modifierFlags: ["command", "option"],
+            isEnabled: false
+        ),
+    ]
+}
+
 final class TestPersistenceHarness {
     let directory: URL
     let shortcutsURL: URL

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,7 +141,7 @@ Responsibilities:
 - represent versioned, human-readable shortcut recipe payloads for export/import
 - detect duplicate/conflicting bindings
 - hold in-memory state used by the event path and UI
-- persist only the current `[AppShortcut]` schema; unsupported or partially corrupted payloads are load failures, not best-effort partial recovery
+- persist only the current `[AppShortcut]` schema, whose `id` values must be unique across the entire array (including disabled entries); unsupported, duplicate-ID, or partially corrupted payloads are load failures, not best-effort partial recovery
 
 ### Event capture and matching
 - `ShortcutCaptureCoordinator`
@@ -351,7 +351,7 @@ CGEvent callback receives tapDisabledByTimeout / tapDisabledByUserInput
 - **Single Settings entry point**: `SettingsLauncher` persists the selected tab and bridges AppKit callers to the SwiftUI environment action instead of maintaining a custom `SettingsWindowController`
 - **Truthful menu bar visibility**: `Show Menu Bar Icon` is only exposed now that `menuBarIconVisible` directly controls `MenuBarExtra.isInserted`, and app reopen remains a recovery path back into Settings when no windows are visible
 - **On-demand Input Monitoring**: startup and later shortcut changes request Input Monitoring only when the enabled set needs Hyper transport or a standard Fn+F-row observer; ordinary standard-only and Fn+letter configurations stay on the Carbon/Accessibility path, and any required Input Monitoring request waits until Accessibility has been granted
-- **Strict persistence schema**: Wink currently supports only the exact `[AppShortcut]` payload it writes today; if `shortcuts.json` is malformed or missing required fields, loading fails loudly, logs `path` plus `reason`, and preserves a `shortcuts.load-failure-*.json` copy instead of silently treating the state as empty
+- **Strict persistence schema**: Wink currently supports only the exact `[AppShortcut]` payload it writes today, with a unique UUID for every entry in the full array. Malformed data, missing required fields, or duplicate UUIDs fail loading before any array is published, log the structured violation, and preserve a byte-identical `shortcuts.load-failure-*.json` copy instead of silently treating the state as empty; saving rejects the same duplicate-ID violation before overwriting the canonical file
 - **O(1) trigger index**: `ShortcutSignature` dictionary replaces linear scans in the hot path
 - **Observation-first toggle truth**: `ApplicationObservation` snapshots gate stable-state promotion from frontmost/window evidence instead of trusting `isActive` alone
 - **Single-source toggle ownership**: `ToggleSessionCoordinator` is the only mutable lifecycle owner; `AppSwitcher` derives pending/stable views from coordinator state instead of dual-writing local activation state


### PR DESCRIPTION
Fixes #322

## Summary

- Validate shortcut UUID uniqueness at the persistence boundary before a decoded array can reach Settings, status, or Insights models.
- Return structured load/save errors, preserve duplicate-ID payloads byte-for-byte on load, and reject invalid saves before overwriting canonical state.
- Add disk-backed, startup/model-safety, and ordinary round-trip coverage; document UUID uniqueness as part of the strict semantic schema.

## Acceptance mapping

- Load uniqueness before publication: `duplicateIDsAreRejectedBeforeLoadReturns` plus `duplicatePersistencePayloadNeverPublishesIntoSettingsModels`.
- Structured error and failure-copy policy: committed disk test and exact-head packaged log with `schema=duplicate-shortcut-id`.
- Save rejection: `duplicateIDsAreRejectedBeforeSaveOverwritesCanonicalPayload` proves the prior canonical bytes remain unchanged.
- Downstream safety: the startup test constructs the real `ShortcutStatusProvider` and `InsightsViewModel` from the empty post-failure store; packaged Shortcuts/Insights both open without a crash or partial row.
- Ordinary behavior: `roundTripsCurrentSchemaThroughDisk` remains green.
- Schema documentation: `docs/architecture.md` now states that UUIDs are unique across the full array, including disabled entries.

## Exact-head verification

- Base SHA: `0aabc310888d388926c4819ef7ea52dadb1014bd`
- Reviewed/source HEAD: `e497fab405b7a85ccc44635009c1408262450330`
- `swift test --disable-dependency-cache --filter 'PersistenceServiceDiskLoadingTests|duplicatePersistencePayloadNeverPublishesIntoSettingsModels'` — 10 targeted tests PASS.
- `swift test --disable-dependency-cache` — 471 tests / 44 suites PASS.
- `swift build -c release --disable-dependency-cache` — PASS.
- `bash scripts/package-app.sh` — PASS.
- `codesign --verify --deep --strict --verbose=2 build/Wink.app` — PASS.
- Standards review — PASS, zero confirmed findings after centralizing the shared duplicate fixture.
- Spec review — PASS, zero confirmed findings against the same base.

## Packaged smoke

- App: `/Users/yvan/developer/Wink/.worktrees/issue-322-reject-duplicate-shortcut-ids/build/Wink.app`
- Executable SHA-256: `700a34705e1907321692f1b5341f6ae5886ba3e32487588cf08d23847660b65d`
- Duplicate fixture SHA-256: `0f47993520d36f99ffd122dd23f3519e4a26660bf01a52d852a196fb4e9395ea`.
- Canonical before/after and generated failure copy all retained that exact hash.
- Exact packaged process stayed alive. Shortcuts showed 0 rows with no Safari/Notes partial entry; Insights opened and showed no saved-shortcut ranking row.
- Replacing only `shortcuts.json` with valid fixture SHA-256 `4758ffa3f7e24a859488951fee748ad9d6276500e0be0d04da75eb0faa4c3bcf` relaunched the same package and showed exactly one `Safari Valid Fixture` row.
- The same usage DB inode and every ordered logical row survived both launches; preference keys and non-UI values were preserved.
- Local evidence: `/Users/yvan/developer/Wink/build/validation/issue-322-e497fab405b7a85ccc44635009c1408262450330-2026-07-18/RESULTS.md`.

## State restoration

- The successful smoke used copied per-file backups; no live directory was moved.
- Post-smoke Application Support/config manifests matched their pre-smoke manifests exactly; defaults matched semantically; the user shortcut file was restored to SHA-256 `821b3cfd866445435ace749f4b711c63e7f41a8c096d8b162134bb689e764113` and the normal app was relaunched.
- Disclosure: an abandoned earlier local isolation attempt lost three transient diagnostic-log files. All six Application Support files and defaults were recovered exactly; the closest exact prior diagnostic baseline was restored. No acceptance claim uses the abandoned attempt; full details are in the local results file.

## Validation Status

- Persistence-only change; ticket-required packaged smoke complete.
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs sync check

- [x] Strict semantic-schema documentation updated.
- [x] No new archive document is used as current source of truth.
