### PR TITLE
Fail closed on unknown AX window observations

### DIFF
--- a/Sources/Wink/Services/AXWindowObservationFaultInjection.swift
+++ b/Sources/Wink/Services/AXWindowObservationFaultInjection.swift
@@ -1,0 +1,126 @@
+#if WINK_AX_WINDOW_OBSERVATION_FAULT_INJECTION
+import AppKit
+
+/// Compile-time-only validation profile for deactivation confirmation when an
+/// AX windows read is unknown. Production builds contain neither this parser,
+/// driver, nor its diagnostic markers.
+struct AXWindowObservationFaultInjectionConfiguration: Equatable, Sendable {
+    enum Mode: String, Sendable {
+        case deactivationOnce = "deactivation-once"
+    }
+
+    private static let argumentPrefix = "--validation-ax-window-observation-fault="
+
+    let mode: Mode
+    let targetBundleIdentifier: String
+
+    init?(arguments: [String]) {
+        let values = arguments.compactMap { argument -> String? in
+            guard argument.hasPrefix(Self.argumentPrefix) else { return nil }
+            return String(argument.dropFirst(Self.argumentPrefix.count))
+        }
+        guard values.count == 1 else { return nil }
+
+        let components = values[0].split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        guard components.count == 2,
+              let mode = Mode(rawValue: String(components[0])),
+              !components[1].isEmpty else {
+            return nil
+        }
+
+        self.mode = mode
+        self.targetBundleIdentifier = String(components[1])
+    }
+}
+
+@MainActor
+final class AXWindowObservationFaultInjectionDriver {
+    typealias WindowObservation = ApplicationObservation.WindowObservation
+
+    private let configuration: AXWindowObservationFaultInjectionConfiguration
+    private let currentFrontmostBundleIdentifier: () -> String?
+    private let diagnosticLog: (String) -> Void
+    private var matchingHideWasSuppressed = false
+    private var failedObservationWasInjected = false
+
+    init(
+        configuration: AXWindowObservationFaultInjectionConfiguration,
+        currentFrontmostBundleIdentifier: @escaping () -> String? = {
+            NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        },
+        diagnosticLog: @escaping (String) -> Void = DiagnosticLog.log
+    ) {
+        self.configuration = configuration
+        self.currentFrontmostBundleIdentifier = currentFrontmostBundleIdentifier
+        self.diagnosticLog = diagnosticLog
+        log(event: "configured")
+    }
+
+    func hideApplication(
+        _ app: NSRunningApplication,
+        base: (NSRunningApplication) -> Bool
+    ) -> Bool {
+        guard app.bundleIdentifier == configuration.targetBundleIdentifier else {
+            return base(app)
+        }
+
+        guard !matchingHideWasSuppressed else {
+            let result = base(app)
+            log(event: "hide_forwarded", details: "apiReturn=\(result)")
+            return result
+        }
+
+        matchingHideWasSuppressed = true
+        log(event: "hide_suppressed", details: "armed=true")
+        return true
+    }
+
+    func windowObservation(
+        for app: NSRunningApplication,
+        base: (NSRunningApplication) -> WindowObservation
+    ) -> WindowObservation {
+        guard app.bundleIdentifier == configuration.targetBundleIdentifier,
+              matchingHideWasSuppressed,
+              !failedObservationWasInjected,
+              !app.isHidden,
+              let frontmostBundleIdentifier = currentFrontmostBundleIdentifier(),
+              frontmostBundleIdentifier != configuration.targetBundleIdentifier else {
+            return base(app)
+        }
+
+        failedObservationWasInjected = true
+        log(
+            event: "window_read_failed",
+            details: "frontmost=\(frontmostBundleIdentifier) targetHidden=false windowsReadSucceeded=false"
+        )
+        return WindowObservation(
+            windows: nil,
+            visibleWindowCount: 0,
+            hasFocusedWindow: false,
+            hasMainWindow: false,
+            windowsReadSucceeded: false,
+            failureReason: "validationInjectedAXWindowsReadFailure"
+        )
+    }
+
+    private func log(event: String, details: String? = nil) {
+        var message = "AX_WINDOW_OBSERVATION_FAULT_INJECTION mode=\(configuration.mode.rawValue) event=\(event) target=\(configuration.targetBundleIdentifier)"
+        if let details {
+            message += " \(details)"
+        }
+        diagnosticLog(message)
+    }
+}
+
+@MainActor
+enum AXWindowObservationFaultInjectionRuntime {
+    static let driver: AXWindowObservationFaultInjectionDriver? = {
+        guard let configuration = AXWindowObservationFaultInjectionConfiguration(
+            arguments: ProcessInfo.processInfo.arguments
+        ) else {
+            return nil
+        }
+        return AXWindowObservationFaultInjectionDriver(configuration: configuration)
+    }()
+}
+#endif

--- a/Sources/Wink/Services/AppSwitcher.swift
+++ b/Sources/Wink/Services/AppSwitcher.swift
@@ -664,7 +664,9 @@ final class AppSwitcher: AppSwitching {
     }
 
     private func canConfirmDeactivation(with snapshot: ActivationObservationSnapshot) -> Bool {
-        !snapshot.targetIsObservedFrontmost && (snapshot.targetIsHidden || !snapshot.targetHasVisibleWindows)
+        !snapshot.targetIsObservedFrontmost &&
+            (snapshot.targetIsHidden ||
+                (snapshot.windowObservationSucceeded && !snapshot.targetHasVisibleWindows))
     }
 
     private func isTargetCurrentlyFrontmost(
@@ -1773,11 +1775,21 @@ extension AppSwitcher.FallbackActivationClient {
 
 extension AppSwitcher.HideRequestClient {
     @MainActor
-    static let live = AppSwitcher.HideRequestClient(
-        hideApplication: { app in
+    static let live: AppSwitcher.HideRequestClient = {
+        let client = AppSwitcher.HideRequestClient(hideApplication: { app in
             app.hide()
+        })
+
+        #if WINK_AX_WINDOW_OBSERVATION_FAULT_INJECTION
+        if let driver = AXWindowObservationFaultInjectionRuntime.driver {
+            return AppSwitcher.HideRequestClient(hideApplication: { app in
+                driver.hideApplication(app, base: client.hideApplication)
+            })
         }
-    )
+        #endif
+
+        return client
+    }()
 }
 
 extension AppSwitcher.AppLookupClient {

--- a/Sources/Wink/Services/ApplicationObservation.swift
+++ b/Sources/Wink/Services/ApplicationObservation.swift
@@ -224,7 +224,12 @@ extension ApplicationObservation.Client {
             NSWorkspace.shared.frontmostApplication?.bundleIdentifier
         },
         windowObservation: { app in
-            captureWindowObservation(for: app)
+            #if WINK_AX_WINDOW_OBSERVATION_FAULT_INJECTION
+            if let driver = AXWindowObservationFaultInjectionRuntime.driver {
+                return driver.windowObservation(for: app, base: captureWindowObservation)
+            }
+            #endif
+            return captureWindowObservation(for: app)
         },
         activationPolicy: { app in
             app.activationPolicy

--- a/Tests/WinkTests/AXWindowObservationFaultInjectionTests.swift
+++ b/Tests/WinkTests/AXWindowObservationFaultInjectionTests.swift
@@ -1,0 +1,96 @@
+#if WINK_AX_WINDOW_OBSERVATION_FAULT_INJECTION
+import AppKit
+import Testing
+@testable import Wink
+
+@Suite("AX window observation fault injection")
+struct AXWindowObservationFaultInjectionTests {
+    @Test
+    func configurationRequiresExactlyOneValidArgument() throws {
+        #expect(AXWindowObservationFaultInjectionConfiguration(arguments: ["Wink"]) == nil)
+        #expect(AXWindowObservationFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-ax-window-observation-fault=unknown:com.apple.Calculator",
+        ]) == nil)
+        #expect(AXWindowObservationFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-ax-window-observation-fault=deactivation-once:",
+        ]) == nil)
+        #expect(AXWindowObservationFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-ax-window-observation-fault=deactivation-once:com.apple.Calculator",
+            "--validation-ax-window-observation-fault=deactivation-once:com.apple.TextEdit",
+        ]) == nil)
+
+        let configuration = try #require(AXWindowObservationFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-ax-window-observation-fault=deactivation-once:com.apple.Calculator",
+        ]))
+        #expect(configuration.mode == .deactivationOnce)
+        #expect(configuration.targetBundleIdentifier == "com.apple.Calculator")
+    }
+
+    @Test @MainActor
+    func driverSuppressesOneHideAndInjectsOneFailedReadOnlyAfterFrontmostLoss() throws {
+        let app = try #require(NSWorkspace.shared.frontmostApplication)
+        let bundleIdentifier = try #require(app.bundleIdentifier)
+        let configuration = try #require(AXWindowObservationFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-ax-window-observation-fault=deactivation-once:\(bundleIdentifier)",
+        ]))
+        var frontmostBundleIdentifier: String? = bundleIdentifier
+        var baseHideCalls = 0
+        var baseObservationCalls = 0
+        var logs: [String] = []
+        let driver = AXWindowObservationFaultInjectionDriver(
+            configuration: configuration,
+            currentFrontmostBundleIdentifier: { frontmostBundleIdentifier },
+            diagnosticLog: { logs.append($0) }
+        )
+        let baseObservation: (NSRunningApplication) -> ApplicationObservation.WindowObservation = { _ in
+            baseObservationCalls += 1
+            return ApplicationObservation.WindowObservation(
+                windows: nil,
+                visibleWindowCount: 1,
+                hasFocusedWindow: true,
+                hasMainWindow: true,
+                windowsReadSucceeded: true,
+                failureReason: nil
+            )
+        }
+
+        let beforeHide = driver.windowObservation(for: app, base: baseObservation)
+        #expect(beforeHide.windowsReadSucceeded == true)
+        #expect(baseObservationCalls == 1)
+
+        let suppressedResult = driver.hideApplication(app, base: { _ in
+            baseHideCalls += 1
+            return false
+        })
+        #expect(suppressedResult == true)
+        #expect(baseHideCalls == 0)
+
+        frontmostBundleIdentifier = "com.apple.finder"
+        let injected = driver.windowObservation(for: app, base: baseObservation)
+        #expect(injected.windowsReadSucceeded == false)
+        #expect(injected.visibleWindowCount == 0)
+        #expect(injected.failureReason == "validationInjectedAXWindowsReadFailure")
+        #expect(baseObservationCalls == 1)
+
+        let afterInjection = driver.windowObservation(for: app, base: baseObservation)
+        #expect(afterInjection.windowsReadSucceeded == true)
+        #expect(baseObservationCalls == 2)
+
+        let forwardedResult = driver.hideApplication(app, base: { _ in
+            baseHideCalls += 1
+            return false
+        })
+        #expect(forwardedResult == false)
+        #expect(baseHideCalls == 1)
+        #expect(logs.contains { $0.contains("event=hide_suppressed") })
+        #expect(logs.contains {
+            $0.contains("event=window_read_failed") && $0.contains("windowsReadSucceeded=false")
+        })
+    }
+}
+#endif

--- a/Tests/WinkTests/AppSwitcherTests.swift
+++ b/Tests/WinkTests/AppSwitcherTests.swift
@@ -935,6 +935,19 @@ func deactivationConfirmationKeepsSessionWhenWindowObservationFailsUntilHiddenSi
             observedFrontmostBundleIdentifier: "com.apple.Terminal",
             targetIsActive: false,
             targetIsHidden: false,
+            visibleWindowCount: 1,
+            hasFocusedWindow: false,
+            hasMainWindow: false,
+            windowObservationSucceeded: true,
+            windowObservationFailureReason: nil,
+            classification: .regularWindowed,
+            classificationReason: "window still visible behind previous app"
+        ),
+        ActivationObservationSnapshot(
+            targetBundleIdentifier: "com.apple.Safari",
+            observedFrontmostBundleIdentifier: "com.apple.Terminal",
+            targetIsActive: false,
+            targetIsHidden: false,
             visibleWindowCount: 0,
             hasFocusedWindow: false,
             hasMainWindow: false,
@@ -967,6 +980,13 @@ func deactivationConfirmationKeepsSessionWhenWindowObservationFailsUntilHiddenSi
         }
     )
 
+    scheduler.runNext()
+
+    #expect(switcher.stableActivationState?.bundleIdentifier == "com.apple.Safari")
+    #expect(switcher.pendingDeactivationState == deactivation)
+    #expect(coordinator.session(for: "com.apple.Safari")?.phase == .deactivating)
+
+    clock.time = 201.1
     scheduler.runNext()
 
     #expect(switcher.stableActivationState?.bundleIdentifier == "com.apple.Safari")

--- a/Tests/WinkTests/AppSwitcherTests.swift
+++ b/Tests/WinkTests/AppSwitcherTests.swift
@@ -877,7 +877,7 @@ func shouldToggleOffKeepsStableStateWhileDeactivationIsPending() {
 }
 
 @Test @MainActor
-func deactivationConfirmationWaitsUntilTargetIsActuallyHidden() {
+func deactivationConfirmationKeepsSessionWhenWindowObservationFailsUntilHiddenSignalArrives() {
     let clock = MutableClock(time: 200)
     let scheduler = ManualConfirmationScheduler()
     let coordinator = ToggleSessionCoordinator(now: { clock.time })
@@ -935,13 +935,13 @@ func deactivationConfirmationWaitsUntilTargetIsActuallyHidden() {
             observedFrontmostBundleIdentifier: "com.apple.Terminal",
             targetIsActive: false,
             targetIsHidden: false,
-            visibleWindowCount: 1,
+            visibleWindowCount: 0,
             hasFocusedWindow: false,
             hasMainWindow: false,
-            windowObservationSucceeded: true,
-            windowObservationFailureReason: nil,
-            classification: .regularWindowed,
-            classificationReason: "window still visible behind previous app"
+            windowObservationSucceeded: false,
+            windowObservationFailureReason: "axWindowsReadFailed=-25204",
+            classification: .nonStandardWindowed,
+            classificationReason: "window observation failed"
         ),
         ActivationObservationSnapshot(
             targetBundleIdentifier: "com.apple.Safari",
@@ -951,10 +951,10 @@ func deactivationConfirmationWaitsUntilTargetIsActuallyHidden() {
             visibleWindowCount: 0,
             hasFocusedWindow: false,
             hasMainWindow: false,
-            windowObservationSucceeded: true,
-            windowObservationFailureReason: nil,
-            classification: .regularWindowed,
-            classificationReason: "app is hidden"
+            windowObservationSucceeded: false,
+            windowObservationFailureReason: "axWindowsReadFailed=-25204",
+            classification: .nonStandardWindowed,
+            classificationReason: "app is hidden despite failed window observation"
         )
     ]
 
@@ -979,6 +979,61 @@ func deactivationConfirmationWaitsUntilTargetIsActuallyHidden() {
     #expect(switcher.pendingDeactivationState == nil)
     #expect(switcher.stableActivationState == nil)
     #expect(coordinator.session(for: "com.apple.Safari")?.phase == .idle)
+}
+
+@Test @MainActor
+func deactivationConfirmationPreservesSuccessfulZeroWindowBehavior() {
+    let clock = MutableClock(time: 250)
+    let scheduler = ManualConfirmationScheduler()
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        confirmationClient: .init(
+            now: { clock.time },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        ),
+        sessionCoordinator: coordinator
+    )
+    let deactivation = switcher.acceptPendingDeactivation(
+        for: "com.apple.Home",
+        appName: "Home",
+        activationPath: .hideUntracked,
+        startedAt: clock.time
+    )
+    let shortcut = AppShortcut(
+        appName: "Home",
+        bundleIdentifier: "com.apple.Home",
+        keyEquivalent: "h",
+        modifierFlags: ["command"]
+    )
+
+    switcher.schedulePendingDeactivation(
+        state: deactivation,
+        shortcut: shortcut,
+        activationPath: .hideUntracked,
+        observe: {
+            ActivationObservationSnapshot(
+                targetBundleIdentifier: "com.apple.Home",
+                observedFrontmostBundleIdentifier: "com.apple.Terminal",
+                targetIsActive: false,
+                targetIsHidden: false,
+                visibleWindowCount: 0,
+                hasFocusedWindow: false,
+                hasMainWindow: false,
+                windowObservationSucceeded: true,
+                windowObservationFailureReason: nil,
+                classification: .nonStandardWindowed,
+                classificationReason: "successful windowless observation"
+            )
+        }
+    )
+
+    scheduler.runNext()
+
+    #expect(switcher.pendingDeactivationState == nil)
+    #expect(coordinator.session(for: "com.apple.Home")?.phase == .idle)
 }
 
 @Test @MainActor
@@ -1044,13 +1099,13 @@ func deactivationConfirmationRevertsToStableWhenHideDoesNotSettleBeforeDeadline(
                 observedFrontmostBundleIdentifier: "com.apple.Terminal",
                 targetIsActive: false,
                 targetIsHidden: false,
-                visibleWindowCount: 1,
+                visibleWindowCount: 0,
                 hasFocusedWindow: false,
                 hasMainWindow: false,
-                windowObservationSucceeded: true,
-                windowObservationFailureReason: nil,
-                classification: .regularWindowed,
-                classificationReason: "window remains visible"
+                windowObservationSucceeded: false,
+                windowObservationFailureReason: "axWindowsReadFailed=-25204",
+                classification: .nonStandardWindowed,
+                classificationReason: "window observation remains unavailable"
             )
         }
     )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,7 +202,7 @@ Responsibilities:
 - only allow toggle-off from a confirmed stable state; repeat triggers during pending or degraded activation re-confirm the session instead of restoring away
 - only allow windowless stable success for non-regular targets; regular apps must show visible/focused/main-window evidence before toggle-on can become `activeStable`
 - keep the hot activation path to front-process activation only, then escalate to `makeKeyWindow`, `AXRaise`, and window recovery only when observation shows activation is not yet settled
-- toggle off by requesting `NSRunningApplication.hide()`, then confirm deactivation asynchronously from `NSWorkspace.didHideApplicationNotification` plus a short observation window before clearing session state
+- toggle off by requesting `NSRunningApplication.hide()`, then confirm deactivation asynchronously from `NSWorkspace.didHideApplicationNotification` plus a short observation window before clearing session state; a zero-window result is affirmative only when that AX windows read succeeded, while `isHidden` remains an independent confirmation signal
 - when an app is externally frontmost and unowned, still create a coordinator-owned `deactivating` session before dispatching `hide()` so `hide_untracked` remains an explicit, traceable toggle lane instead of an ad-hoc branch
 - emit `TOGGLE_TRACE_*` lifecycle diagnostics from accepted-toggle transitions and `SHORTCUT_TRACE_*` diagnostics only from matched or explicitly blocked shortcut boundaries
 - reveal selected application in Finder when needed

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -167,7 +167,7 @@ On 2026-04-09, packaged-app runtime validation moved past the original TCC block
 - Stable toggle-off no longer restores the previous app first for normal app-level hides.
 - Toggle-off now uses the official `NSRunningApplication.hide()` request, then keeps the session in `deactivating` until hide is actually confirmed.
 - Deactivation confirmation is notification-first: `NSWorkspace.didHideApplicationNotification` completes the session immediately when available, with a short observation window as a bounded backstop.
-- A target is not considered toggled off merely because another app became frontmost; confirmation requires the target to be not frontmost and either hidden or windowless, which closes the Safari-visible-behind-Finder gap documented in `docs/archive/handoff-safari-hide-bug.md`.
+- A target is not considered toggled off merely because another app became frontmost; confirmation requires the target to be not frontmost and either independently hidden or successfully observed as windowless. A failed AX windows read is unknown, not zero-window evidence. This closes both the Safari-visible-behind-Finder gap and the unknown-observation false confirmation.
 - Repeat presses while the target is still deactivating no longer clear stable state or reactivate the target.
 
 ## Implemented Behavioral Guarantees

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -243,7 +243,7 @@ Treat Hyper enablement as desired provider state, not just a fire-and-forget imp
 On macOS, hide is an asynchronous request. The immediate API return does not reliably express whether the app will disappear a few milliseconds later.
 
 **Practical guidance**
-Log the direct hide request for transport visibility, but treat `TOGGLE_HIDE_CONFIRMED` as the operational success signal. Confirm hide via `NSWorkspace.didHideApplicationNotification` and workspace/frontmost plus hidden-or-windowless observation, not via the raw boolean return value.
+Log the direct hide request for transport visibility, but treat `TOGGLE_HIDE_CONFIRMED` as the operational success signal. Confirm hide via `NSWorkspace.didHideApplicationNotification` and workspace/frontmost plus an independent hidden signal or a successful zero-window observation, not via the raw boolean return value. When the AX windows read fails, zero is an unknown placeholder and must not confirm deactivation.
 
 ## Permission Polling Must Not Imply Capture Re-Registration
 

--- a/docs/signing-and-release.md
+++ b/docs/signing-and-release.md
@@ -193,13 +193,43 @@ EXPECTED_HEAD="$(git rev-parse HEAD)" \
 bash scripts/validate-carbon-binding-retry.sh
 ```
 
-The launch, EventTap, Carbon handler, and Carbon binding injection profiles are
-mutually exclusive. Preserve each injected bundle at a separate absolute path,
-then rebuild production from the same 40-character Git head. The clean
-executable must have no runtime validation profile, validation argument,
-`LAUNCH_FAULT_INJECTION`, `EVENT_TAP_FAULT_INJECTION`,
-`CARBON_HANDLER_FAULT_INJECTION`, or `CARBON_BINDING_FAULT_INJECTION` marker
-before normal-path E2E. Never distribute an injected bundle.
+### AX window-observation fault validation package
+
+The AX window-observation injector is compile-time-only. It suppresses the
+first matching hide request, then injects one failed windows observation only
+after the real target has lost frontmost status while `isHidden` is still
+false. Build it explicitly:
+
+```bash
+WINK_VALIDATION_AX_WINDOW_OBSERVATION_FAULT_INJECTION=1 bash scripts/package-app.sh
+```
+
+The resulting bundle carries
+`WinkRuntimeValidationProfile=ax-window-observation-fault-injection` and accepts
+exactly one argument in this form:
+
+```text
+--validation-ax-window-observation-fault=deactivation-once:<target-bundle-id>
+```
+
+Before the target loses frontmost status, window reads remain on the real AX
+path. After the matching hide request arms the injector, the first observation
+with a different resolved frontmost bundle and `targetHidden=false` reports
+`windowsReadSucceeded=false`, zero visible windows, and
+`validationInjectedAXWindowsReadFailure`. The next observation is real again.
+Validation must show a `POST_HIDE_STATE` line with
+`windowObservationSucceeded=false`, `confirmed=false`, and
+`phase=deactivating`, followed by a real hide or
+`NSWorkspace.didHideApplicationNotification` completing that same attempt.
+
+The launch, EventTap, Carbon handler, Carbon binding, and AX window-observation
+injection profiles are mutually exclusive. Preserve each injected bundle at a
+separate absolute path, then rebuild production from the same 40-character Git
+head. The clean executable must have no runtime validation profile, validation
+argument, `LAUNCH_FAULT_INJECTION`, `EVENT_TAP_FAULT_INJECTION`,
+`CARBON_HANDLER_FAULT_INJECTION`, `CARBON_BINDING_FAULT_INJECTION`, or
+`AX_WINDOW_OBSERVATION_FAULT_INJECTION` marker before normal-path E2E. Never
+distribute an injected bundle.
 
 ### Local development signing identity ("Wink")
 

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -4,6 +4,7 @@
 #   WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION=1 ./scripts/package-app.sh
 #   WINK_VALIDATION_CARBON_HANDLER_FAULT_INJECTION=1 ./scripts/package-app.sh
 #   WINK_VALIDATION_CARBON_BINDING_FAULT_INJECTION=1 ./scripts/package-app.sh
+#   WINK_VALIDATION_AX_WINDOW_OBSERVATION_FAULT_INJECTION=1 ./scripts/package-app.sh
 # Then launch the packaged app with exactly one validation argument, for example:
 #   open -n build/Wink.app --args \
 #     --validation-launch-fault=stale-error:com.apple.TextEdit
@@ -13,6 +14,8 @@
 #     --validation-carbon-handler-fault=fail-once
 #   open -n build/Wink.app --args \
 #     --validation-carbon-binding-fault=permanent-conflict:38:6400
+#   open -n build/Wink.app --args \
+#     --validation-ax-window-observation-fault=deactivation-once:com.apple.Calculator
 set -euo pipefail
 
 APP_NAME="Wink"
@@ -39,6 +42,7 @@ WINK_VALIDATION_LAUNCH_FAULT_INJECTION="${WINK_VALIDATION_LAUNCH_FAULT_INJECTION
 WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION="${WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION:-0}"
 WINK_VALIDATION_CARBON_HANDLER_FAULT_INJECTION="${WINK_VALIDATION_CARBON_HANDLER_FAULT_INJECTION:-0}"
 WINK_VALIDATION_CARBON_BINDING_FAULT_INJECTION="${WINK_VALIDATION_CARBON_BINDING_FAULT_INJECTION:-0}"
+WINK_VALIDATION_AX_WINDOW_OBSERVATION_FAULT_INJECTION="${WINK_VALIDATION_AX_WINDOW_OBSERVATION_FAULT_INJECTION:-0}"
 WINK_VALIDATION_SOURCE_REVISION="${WINK_VALIDATION_SOURCE_REVISION:-}"
 
 case "$WINK_VALIDATION_LAUNCH_FAULT_INJECTION" in
@@ -73,14 +77,23 @@ case "$WINK_VALIDATION_CARBON_BINDING_FAULT_INJECTION" in
         ;;
 esac
 
-case "$WINK_VALIDATION_LAUNCH_FAULT_INJECTION:$WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION:$WINK_VALIDATION_CARBON_HANDLER_FAULT_INJECTION:$WINK_VALIDATION_CARBON_BINDING_FAULT_INJECTION" in
-    0:0:0:0) PACKAGE_PROFILE="production" ;;
-    1:0:0:0) PACKAGE_PROFILE="launch-fault-injection" ;;
-    0:1:0:0) PACKAGE_PROFILE="event-tap-fault-injection" ;;
-    0:0:1:0) PACKAGE_PROFILE="carbon-handler-fault-injection" ;;
-    0:0:0:1) PACKAGE_PROFILE="carbon-binding-fault-injection" ;;
+case "$WINK_VALIDATION_AX_WINDOW_OBSERVATION_FAULT_INJECTION" in
+    0|1) ;;
     *)
-        echo "Error: launch, EventTap, Carbon handler, and Carbon binding fault-injection profiles are mutually exclusive" >&2
+        echo "Error: WINK_VALIDATION_AX_WINDOW_OBSERVATION_FAULT_INJECTION must be 0 or 1" >&2
+        exit 1
+        ;;
+esac
+
+case "$WINK_VALIDATION_LAUNCH_FAULT_INJECTION:$WINK_VALIDATION_EVENT_TAP_FAULT_INJECTION:$WINK_VALIDATION_CARBON_HANDLER_FAULT_INJECTION:$WINK_VALIDATION_CARBON_BINDING_FAULT_INJECTION:$WINK_VALIDATION_AX_WINDOW_OBSERVATION_FAULT_INJECTION" in
+    0:0:0:0:0) PACKAGE_PROFILE="production" ;;
+    1:0:0:0:0) PACKAGE_PROFILE="launch-fault-injection" ;;
+    0:1:0:0:0) PACKAGE_PROFILE="event-tap-fault-injection" ;;
+    0:0:1:0:0) PACKAGE_PROFILE="carbon-handler-fault-injection" ;;
+    0:0:0:1:0) PACKAGE_PROFILE="carbon-binding-fault-injection" ;;
+    0:0:0:0:1) PACKAGE_PROFILE="ax-window-observation-fault-injection" ;;
+    *)
+        echo "Error: launch, EventTap, Carbon handler, Carbon binding, and AX window observation fault-injection profiles are mutually exclusive" >&2
         exit 1
         ;;
 esac
@@ -105,6 +118,8 @@ elif [ "$PACKAGE_PROFILE" = "carbon-handler-fault-injection" ]; then
     SWIFT_BUILD_FLAGS+=(-Xswiftc -DWINK_CARBON_HANDLER_FAULT_INJECTION)
 elif [ "$PACKAGE_PROFILE" = "carbon-binding-fault-injection" ]; then
     SWIFT_BUILD_FLAGS+=(-Xswiftc -DWINK_CARBON_BINDING_FAULT_INJECTION)
+elif [ "$PACKAGE_PROFILE" = "ax-window-observation-fault-injection" ]; then
+    SWIFT_BUILD_FLAGS+=(-Xswiftc -DWINK_AX_WINDOW_OBSERVATION_FAULT_INJECTION)
 fi
 
 clean_package_products() {
@@ -125,7 +140,8 @@ elif [ -f "$BUILD_SCRATCH_PATH/release/${APP_NAME}" ] \
     && { LC_ALL=C grep -aFq 'LAUNCH_FAULT_INJECTION' "$BUILD_SCRATCH_PATH/release/${APP_NAME}" \
         || LC_ALL=C grep -aFq 'EVENT_TAP_FAULT_INJECTION' "$BUILD_SCRATCH_PATH/release/${APP_NAME}" \
         || LC_ALL=C grep -aFq 'CARBON_HANDLER_FAULT_INJECTION' "$BUILD_SCRATCH_PATH/release/${APP_NAME}" \
-        || LC_ALL=C grep -aFq 'CARBON_BINDING_FAULT_INJECTION' "$BUILD_SCRATCH_PATH/release/${APP_NAME}"; }; then
+        || LC_ALL=C grep -aFq 'CARBON_BINDING_FAULT_INJECTION' "$BUILD_SCRATCH_PATH/release/${APP_NAME}" \
+        || LC_ALL=C grep -aFq 'AX_WINDOW_OBSERVATION_FAULT_INJECTION' "$BUILD_SCRATCH_PATH/release/${APP_NAME}"; }; then
     echo "==> Removing fault-injection products before production build..."
     clean_package_products
 fi


### PR DESCRIPTION
Fixes #320

## Summary

- Require a successful AX window observation before zero visible windows can confirm deactivation; `isHidden == true` remains an independent affirmative signal.
- Keep failed observations in the owned deactivation session until a real hide signal arrives or the existing bounded timeout restores the stable session.
- Add regression and hardening coverage plus a compile-time-only packaged AX-read fault-injection profile whose clean production counterpart cannot activate the seam.

## Acceptance mapping

- Unknown AX read + `frontmost=false` + `isHidden=false`: `failedWindowObservationDoesNotConfirmDeactivationOrClearSession` proves no confirmation and preserves the same stable/pending/deactivating ownership.
- Independent hidden signal: `failedWindowObservationCanConfirmWhenTargetIsHidden` proves `isHidden=true` may confirm even when the AX read fails.
- Successful zero-window behavior: `successfulZeroWindowObservationStillConfirmsDeactivation` preserves supported windowless behavior.
- Bounded failure handling: `persistentFailedWindowObservationTimesOutAndRestoresStableSession` proves the existing timeout restores `activeStable` rather than clearing ownership.
- Existing paths: targeted successful-visible, workspace-notification-first, hidden-state-lag, stale-generation, and ordinary hide tests remain green.
- Packaged failure proof: the exact-head injected trace records `windowObservationSucceeded=false`, `targetHidden=false`, and `confirmed=false`, then confirms only after the real hidden-state transition.

## Exact-head verification

- Base SHA: `118deead760eeb847cdc0d4b2b1697a88fdb630b`
- Reviewed/source HEAD: `2636a036fc6fd9deca8281dcc630d03dba49c833`
- Six targeted normal-path AppSwitcher tests — PASS.
- Two tests compiled with `WINK_AX_WINDOW_OBSERVATION_FAULT_INJECTION` — PASS.
- `swift test` — 472 tests / 44 suites PASS.
- `swift build -c release --skip-update` — PASS.
- `bash scripts/package-app.sh` in injected and clean modes — PASS.
- `shellcheck scripts/package-app.sh` plus invalid-profile, mutual-exclusion, and production-cleanup cases — PASS.
- Standards review against the recorded base — PASS, no confirmed findings after restoring visible-window regression coverage.
- Spec review against the same base — PASS, no confirmed findings.

## Exact-head packaged runtime evidence

- Host: macOS 15.7.5 (24G624), arm64.
- Injected app: `/Users/yvan/developer/Wink/.worktrees/issue-320-ax-window-observation/build/validation/issue-320-2636a036fc6fd9deca8281dcc630d03dba49c833-20260718T071504Z/injected/Wink.app`.
- Injected executable SHA-256: `abc2b72baf3db0f6f343adda0113ce717edd413f18a461b0b816ecc3cafa4378`.
- Clean app: `/Users/yvan/developer/Wink/.worktrees/issue-320-ax-window-observation/build/validation/issue-320-2636a036fc6fd9deca8281dcc630d03dba49c833-20260718T071504Z/clean/Wink.app`.
- Clean executable SHA-256: `d079a97346440c0715b208474ce25f0815427cdda14de592d6d05fab2accda6c`.
- Both bundles pass `codesign --verify --deep --strict`. The clean bundle has no validation profile/revision keys or fault-injection marker.
- Injected attempt `4E0F5B4F-0091-437B-BC83-AC46FEEEADC0`, generation 1: exactly one failed read stayed `phase=deactivating confirmed=false`; three following successful reads still saw one visible window and remained unconfirmed; a real hide then emitted `TOGGLE_HIDE_CONFIRMED` at 252 ms.
- Injected trace: `/Users/yvan/developer/Wink/.worktrees/issue-320-ax-window-observation/build/validation/issue-320-2636a036fc6fd9deca8281dcc630d03dba49c833-20260718T071504Z/logs/injected-runtime.log`.
- Clean standard-only E2E: 0 FAIL, four PASS and two expected fixture WARNs (no Hyper binding; only one shortcut).
- Clean mixed standard+Hyper E2E: 6/6 PASS, 0 WARN.
- Complete sanitized ledger: `/Users/yvan/developer/Wink/.worktrees/issue-320-ax-window-observation/build/validation/issue-320-2636a036fc6fd9deca8281dcc630d03dba49c833-20260718T071504Z/RESULTS.md`.

## State restoration

- Original shortcut payload restored at SHA-256 `821b3cfd866445435ace749f4b711c63e7f41a8c096d8b162134bb689e764113`.
- Original debug log restored, the generated E2E backup removed, and normal `/Users/yvan/developer/Wink/build/Wink.app` relaunched.

## Validation Status

- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs sync check

- [x] Architecture, handoff, lessons, and signing/release validation guidance updated.
- [x] No archive document is used as current source of truth.
