### PR TITLE
Wire degraded recovery into the production toggle flow

### DIFF
--- a/Sources/Wink/Services/AXWindowObservationFaultInjection.swift
+++ b/Sources/Wink/Services/AXWindowObservationFaultInjection.swift
@@ -1,12 +1,13 @@
 #if WINK_AX_WINDOW_OBSERVATION_FAULT_INJECTION
 import AppKit
 
-/// Compile-time-only validation profile for deactivation confirmation when an
-/// AX windows read is unknown. Production builds contain neither this parser,
-/// driver, nor its diagnostic markers.
+/// Compile-time-only validation profile for activation/deactivation behavior
+/// when AX window evidence is withheld. Production builds contain neither this
+/// parser, driver, nor its diagnostic markers.
 struct AXWindowObservationFaultInjectionConfiguration: Equatable, Sendable {
     enum Mode: String, Sendable {
         case deactivationOnce = "deactivation-once"
+        case activationPersistent = "activation-persistent"
     }
 
     private static let argumentPrefix = "--validation-ax-window-observation-fault="
@@ -42,6 +43,7 @@ final class AXWindowObservationFaultInjectionDriver {
     private let diagnosticLog: (String) -> Void
     private var matchingHideWasSuppressed = false
     private var failedObservationWasInjected = false
+    private var withheldObservationCount = 0
 
     init(
         configuration: AXWindowObservationFaultInjectionConfiguration,
@@ -64,6 +66,12 @@ final class AXWindowObservationFaultInjectionDriver {
             return base(app)
         }
 
+        if configuration.mode == .activationPersistent {
+            let result = base(app)
+            log(event: "hide_forwarded", details: "apiReturn=\(result)")
+            return result
+        }
+
         guard !matchingHideWasSuppressed else {
             let result = base(app)
             log(event: "hide_forwarded", details: "apiReturn=\(result)")
@@ -79,8 +87,27 @@ final class AXWindowObservationFaultInjectionDriver {
         for app: NSRunningApplication,
         base: (NSRunningApplication) -> WindowObservation
     ) -> WindowObservation {
-        guard app.bundleIdentifier == configuration.targetBundleIdentifier,
-              matchingHideWasSuppressed,
+        guard app.bundleIdentifier == configuration.targetBundleIdentifier else {
+            return base(app)
+        }
+
+        if configuration.mode == .activationPersistent {
+            withheldObservationCount += 1
+            log(
+                event: "window_evidence_withheld",
+                details: "ordinal=\(withheldObservationCount) frontmost=\(currentFrontmostBundleIdentifier() ?? "nil") targetActive=\(app.isActive) targetHidden=\(app.isHidden) windowsReadSucceeded=false"
+            )
+            return WindowObservation(
+                windows: nil,
+                visibleWindowCount: 0,
+                hasFocusedWindow: false,
+                hasMainWindow: false,
+                windowsReadSucceeded: false,
+                failureReason: "validationInjectedActivationWindowEvidenceFailure"
+            )
+        }
+
+        guard matchingHideWasSuppressed,
               !failedObservationWasInjected,
               !app.isHidden,
               let frontmostBundleIdentifier = currentFrontmostBundleIdentifier(),

--- a/Sources/Wink/Services/AppSwitcher.swift
+++ b/Sources/Wink/Services/AppSwitcher.swift
@@ -163,6 +163,13 @@ final class AppSwitcher: AppSwitching {
         let schedule: @MainActor (TimeInterval, @escaping @MainActor () -> Void) -> Void
     }
 
+    struct RecoveryClient {
+        let perform: @MainActor (
+            WindowRecoveryStage,
+            @escaping @MainActor () -> Void
+        ) -> Void
+    }
+
     private let frontmostTracker: FrontmostApplicationTracker
     private let applicationObservation: ApplicationObservation
     private let activationClient: ActivationClient
@@ -170,6 +177,7 @@ final class AppSwitcher: AppSwitching {
     private let hideRequestClient: HideRequestClient
     private let appLookupClient: AppLookupClient
     private let confirmationClient: ConfirmationClient
+    private let recoveryClient: RecoveryClient?
     private let sessionCoordinator: ToggleSessionCoordinator
     private var frontmostTargetBehavior: FrontmostTargetBehavior = .toggle
 
@@ -208,6 +216,7 @@ final class AppSwitcher: AppSwitching {
         hideRequestClient: HideRequestClient = .live,
         appLookupClient: AppLookupClient = .live,
         confirmationClient: ConfirmationClient = .live,
+        recoveryClient: RecoveryClient? = nil,
         sessionCoordinator: ToggleSessionCoordinator? = nil
     ) {
         self.frontmostTracker = frontmostTracker
@@ -217,6 +226,7 @@ final class AppSwitcher: AppSwitching {
         self.hideRequestClient = hideRequestClient
         self.appLookupClient = appLookupClient
         self.confirmationClient = confirmationClient
+        self.recoveryClient = recoveryClient
         self.sessionCoordinator = sessionCoordinator ?? ToggleSessionCoordinator(now: confirmationClient.now)
         self.sessionCoordinator.startObservingWorkspaceNotifications()
         self.sessionCoordinator.setFrontmostTargetBehavior(frontmostTargetBehavior)
@@ -511,14 +521,20 @@ final class AppSwitcher: AppSwitching {
             }
 
             guard let nextRecoveryStage = self.nextRecoveryStage(for: snapshot, candidate: nextRecoveryStage) else {
+                guard self.sessionCoordinator.markDegraded(
+                    for: state.bundleIdentifier,
+                    reason: "activation_recovery_exhausted",
+                    generation: state.generation
+                ) != nil else {
+                    return
+                }
                 self.logToggleTrace(
-                    family: .reset,
+                    family: .confirmation,
                     bundleIdentifier: state.bundleIdentifier,
-                    event: "session_cleared",
+                    event: "degraded",
                     reason: "activation_recovery_exhausted",
                     activationPath: activationPath
                 )
-                self.clearActivationTracking(for: state.bundleIdentifier)
                 return
             }
 
@@ -679,6 +695,17 @@ final class AppSwitcher: AppSwitching {
         sessionCoordinator.resetSession(for: bundleIdentifier)
     }
 
+    private func degradedReconfirmationDetails(
+        result: String,
+        session: ToggleSessionCoordinator.Session?
+    ) -> String {
+        let retryCount = session?.retryCount ?? 0
+        let elapsedMilliseconds = session.map {
+            Int(($0.lastActivityAt - $0.activationStartedAt) * 1_000)
+        } ?? 0
+        return "result=\(result) retryCount=\(retryCount) retryCap=\(sessionCoordinator.configuration.degradedRetryCap) absoluteCeilingMs=\(Int(sessionCoordinator.configuration.absoluteActivationCeiling * 1_000)) elapsedMs=\(elapsedMilliseconds)"
+    }
+
     private func completePendingDeactivation(for bundleIdentifier: String) {
         sessionCoordinator.completeDeactivation(for: bundleIdentifier)
     }
@@ -810,16 +837,78 @@ final class AppSwitcher: AppSwitching {
             return false
         }
 
-        _ = sessionCoordinator.updateProcessIdentifier(
+        var reconfirmingDegradedSession: ToggleSessionCoordinator.Session?
+        let degradedReconfirmDecision = sessionCoordinator.reconfirmDegradedSession(
+            for: shortcut.bundleIdentifier
+        )
+        switch degradedReconfirmDecision.result {
+        case .accepted:
+            reconfirmingDegradedSession = degradedReconfirmDecision.session
+            logToggleTrace(
+                family: .decision,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "degraded_reconfirm",
+                reason: degradedReconfirmationDetails(
+                    result: "accepted",
+                    session: degradedReconfirmDecision.session
+                ),
+                activationPath: nil,
+                sessionSnapshot: degradedReconfirmDecision.session
+            )
+        case .retryCapped:
+            logToggleTrace(
+                family: .decision,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "degraded_reconfirm",
+                reason: degradedReconfirmationDetails(
+                    result: "retry_capped",
+                    session: degradedReconfirmDecision.session
+                ),
+                activationPath: nil,
+                sessionSnapshot: degradedReconfirmDecision.session
+            )
+            return true
+        case .absoluteCeilingReached:
+            logToggleTrace(
+                family: .decision,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "degraded_reconfirm",
+                reason: degradedReconfirmationDetails(
+                    result: "absolute_ceiling_reached",
+                    session: degradedReconfirmDecision.session
+                ),
+                activationPath: nil,
+                sessionSnapshot: degradedReconfirmDecision.session
+            )
+            return true
+        case .notDegraded:
+            reconfirmingDegradedSession = nil
+        }
+
+        let processUpdatedSession = sessionCoordinator.updateProcessIdentifier(
             for: shortcut.bundleIdentifier,
             pid: runningApp.processIdentifier
         )
+        if reconfirmingDegradedSession != nil {
+            reconfirmingDegradedSession = processUpdatedSession ?? reconfirmingDegradedSession
+        }
 
         let preActionWindowObservation = applicationObservation.windowObservation(for: runningApp)
         let preActionSnapshot = applicationObservation.snapshot(
             for: runningApp,
             windowObservation: preActionWindowObservation
         )
+
+        if let reconfirmingDegradedSession {
+            return performDegradedReconfirmation(
+                shortcut: shortcut,
+                runningApp: runningApp,
+                windowObservation: preActionWindowObservation,
+                snapshot: preActionSnapshot,
+                attemptStartedAt: attemptStartedAt,
+                session: reconfirmingDegradedSession
+            )
+        }
 
         if stableActivationState?.bundleIdentifier == shortcut.bundleIdentifier,
            pendingDeactivationState?.bundleIdentifier != shortcut.bundleIdentifier,
@@ -1006,6 +1095,13 @@ final class AppSwitcher: AppSwitching {
             runningApp.unhide()
         }
         unminimizeWindows(of: runningApp, observation: preActionWindowObservation)
+        logToggleTrace(
+            family: .decision,
+            bundleIdentifier: shortcut.bundleIdentifier,
+            event: "activation_side_effect",
+            reason: "front_process",
+            activationPath: activationPath
+        )
         let activated = activateViaWindowServer(runningApp, windows: preActionWindowObservation.windows)
         guard activated || continuingPendingActivation else {
             clearActivationTracking(for: shortcut.bundleIdentifier)
@@ -1032,8 +1128,103 @@ final class AppSwitcher: AppSwitching {
                 pid: runningApp.processIdentifier
             )
         }
-        schedulePendingConfirmation(
+        scheduleRuntimeActivationConfirmation(
             state: pendingState,
+            shortcut: shortcut,
+            runningApp: runningApp,
+            activationPath: activationPath
+        )
+        return true
+    }
+
+    private func performDegradedReconfirmation(
+        shortcut: AppShortcut,
+        runningApp: NSRunningApplication,
+        windowObservation: ApplicationObservation.WindowObservation,
+        snapshot: ActivationObservationSnapshot,
+        attemptStartedAt: CFAbsoluteTime,
+        session: ToggleSessionCoordinator.Session
+    ) -> Bool {
+        if canPromoteToStable(with: snapshot) {
+            logToggleTrace(
+                family: .decision,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "pending_promoted",
+                reason: "degraded_reconfirm_now_stable",
+                activationPath: session.activationPath,
+                sessionSnapshot: session
+            )
+            guard let stableSession = sessionCoordinator.markStable(
+                for: shortcut.bundleIdentifier,
+                generation: session.generation
+            ) else {
+                return true
+            }
+            logToggleTrace(
+                family: .confirmation,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "confirmed",
+                reason: "degraded_reconfirm_stable",
+                activationPath: stableSession.activationPath,
+                sessionSnapshot: stableSession
+            )
+            return true
+        }
+
+        let activationPath: ActivationPath = runningApp.isHidden ? .unhideActivate : .activate
+        logger.info("TOGGLE[\(shortcut.appName)]: DEGRADED RECONFIRM → activating, isHidden=\(runningApp.isHidden)")
+        DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: DEGRADED RECONFIRM → activating, isHidden=\(runningApp.isHidden)")
+        logToggleLifecycle(
+            for: shortcut,
+            lifecycle: .attempt,
+            activationPath: activationPath,
+            snapshot: snapshot,
+            elapsedMilliseconds: elapsedMilliseconds(since: attemptStartedAt),
+            sessionSnapshot: session
+        )
+        if runningApp.isHidden {
+            runningApp.unhide()
+        }
+        unminimizeWindows(of: runningApp, observation: windowObservation)
+        logToggleTrace(
+            family: .decision,
+            bundleIdentifier: shortcut.bundleIdentifier,
+            event: "activation_side_effect",
+            reason: "degraded_reconfirm_front_process",
+            activationPath: activationPath,
+            sessionSnapshot: session
+        )
+        _ = activateViaWindowServer(runningApp, windows: windowObservation.windows)
+
+        guard let continuedSession = sessionCoordinator.continueActivation(
+            for: shortcut.bundleIdentifier,
+            activationPath: activationPath,
+            pid: runningApp.processIdentifier
+        ) else {
+            return true
+        }
+        let pendingState = PendingActivationState(
+            bundleIdentifier: continuedSession.bundleIdentifier,
+            generation: continuedSession.generation,
+            startedAt: continuedSession.activationStartedAt
+        )
+        scheduleRuntimeActivationConfirmation(
+            state: pendingState,
+            shortcut: shortcut,
+            runningApp: runningApp,
+            activationPath: activationPath
+        )
+        return true
+    }
+
+    private func scheduleRuntimeActivationConfirmation(
+        state: PendingActivationState,
+        shortcut: AppShortcut,
+        runningApp: NSRunningApplication,
+        activationPath: ActivationPath
+    ) {
+        schedulePendingConfirmation(
+            state: state,
             shortcut: shortcut,
             activationPath: activationPath,
             observe: { [weak self] in
@@ -1059,24 +1250,28 @@ final class AppSwitcher: AppSwitching {
                 )
             },
             recoverIfNeeded: { [weak self] stage, completion in
-                self?.recoverActivation(
+                guard let self else { return }
+                if let recoveryClient = self.recoveryClient {
+                    recoveryClient.perform(stage, completion)
+                    return
+                }
+                self.recoverActivation(
                     runningApp,
                     shortcut: shortcut,
                     stage: stage,
                     fallbackActivate: {
-                        self?.requestFallbackActivation(
+                        self.requestFallbackActivation(
                             bundleURL: runningApp.bundleURL,
                             bundleIdentifier: runningApp.bundleIdentifier ?? "\(runningApp.processIdentifier)",
                             plainActivate: {
                                 runningApp.activate()
                             }
-                        ) ?? false
+                        )
                     },
                     completion: completion
                 )
             }
         )
-        return true
     }
 
     private func performFrontmostFocus(
@@ -1470,6 +1665,14 @@ final class AppSwitcher: AppSwitching {
                 return
             }
 
+            logToggleTrace(
+                family: .confirmation,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "recovery_side_effect",
+                reason: "stage=makeKeyWindow",
+                activationPath: nil
+            )
+
             switch activateProcess(
                 pid: app.processIdentifier,
                 windowID: windowID,
@@ -1485,6 +1688,13 @@ final class AppSwitcher: AppSwitching {
             completion()
         case .axRaise:
             let windows = fetchWindows(of: app)
+            logToggleTrace(
+                family: .confirmation,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "recovery_side_effect",
+                reason: "stage=axRaise",
+                activationPath: nil
+            )
             if hasVisibleWindows(of: app, windows: windows) {
                 raiseFirstWindow(from: windows)
                 logger.info("TOGGLE[\(shortcut.appName)]: activation recovery stage=axRaise")
@@ -1510,6 +1720,14 @@ final class AppSwitcher: AppSwitching {
                 return
             }
 
+            logToggleTrace(
+                family: .confirmation,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "recovery_side_effect",
+                reason: "stage=reopen",
+                activationPath: nil
+            )
+
             let config = NSWorkspace.OpenConfiguration()
             fallbackActivationClient.openApplication(appURL, config) { @Sendable _, error in
                 if let error {
@@ -1525,6 +1743,13 @@ final class AppSwitcher: AppSwitching {
                 }
             }
         case .commandN:
+            logToggleTrace(
+                family: .confirmation,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "recovery_side_effect",
+                reason: "stage=commandN",
+                activationPath: nil
+            )
             logger.info("TOGGLE[\(shortcut.appName)]: sending ⌘N as fallback")
             DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: sending ⌘N as fallback")
             openNewWindow(of: app)
@@ -1646,7 +1871,8 @@ final class AppSwitcher: AppSwitching {
         activationPath: ActivationPath,
         snapshot: ActivationObservationSnapshot? = nil,
         elapsedMilliseconds: Int,
-        effectiveStable: Bool? = nil
+        effectiveStable: Bool? = nil,
+        sessionSnapshot: ToggleSessionCoordinator.Session? = nil
     ) -> String {
         var fields = [
             "target=\(shortcut.bundleIdentifier)",
@@ -1659,7 +1885,10 @@ final class AppSwitcher: AppSwitching {
         } else {
             fields.append(ActivationObservationSnapshot.quotedField("frontmost", frontmostTracker.currentFrontmostBundleIdentifier()))
         }
-        fields.append(contentsOf: sessionLogFields(for: shortcut.bundleIdentifier))
+        fields.append(contentsOf: sessionLogFields(
+            for: shortcut.bundleIdentifier,
+            sessionSnapshot: sessionSnapshot
+        ))
 
         return "TOGGLE[\(shortcut.appName)]: \(lifecycle.rawValue) \(fields.joined(separator: " "))"
     }
@@ -1670,7 +1899,8 @@ final class AppSwitcher: AppSwitching {
         activationPath: ActivationPath,
         snapshot: ActivationObservationSnapshot? = nil,
         elapsedMilliseconds: Int,
-        effectiveStable: Bool? = nil
+        effectiveStable: Bool? = nil,
+        sessionSnapshot: ToggleSessionCoordinator.Session? = nil
     ) {
         let message = toggleLifecycleLogMessage(
             for: shortcut,
@@ -1678,7 +1908,8 @@ final class AppSwitcher: AppSwitching {
             activationPath: activationPath,
             snapshot: snapshot,
             elapsedMilliseconds: elapsedMilliseconds,
-            effectiveStable: effectiveStable
+            effectiveStable: effectiveStable,
+            sessionSnapshot: sessionSnapshot
         )
         logger.info("\(message)")
         DiagnosticLog.log(message)
@@ -1688,8 +1919,11 @@ final class AppSwitcher: AppSwitching {
         Int((confirmationClient.now() - startedAt) * 1000)
     }
 
-    private func sessionLogFields(for bundleIdentifier: String) -> [String] {
-        guard let session = sessionCoordinator.session(for: bundleIdentifier) else {
+    private func sessionLogFields(
+        for bundleIdentifier: String,
+        sessionSnapshot: ToggleSessionCoordinator.Session? = nil
+    ) -> [String] {
+        guard let session = sessionSnapshot ?? sessionCoordinator.session(for: bundleIdentifier) else {
             return ["attemptId=nil", "generation=nil", "pid=nil", "phase=nil"]
         }
         return [
@@ -1705,9 +1939,10 @@ final class AppSwitcher: AppSwitching {
         bundleIdentifier: String,
         event: String,
         reason: String?,
-        activationPath: ActivationPath?
+        activationPath: ActivationPath?,
+        sessionSnapshot: ToggleSessionCoordinator.Session? = nil
     ) {
-        let session = sessionCoordinator.session(for: bundleIdentifier)
+        let session = sessionSnapshot ?? sessionCoordinator.session(for: bundleIdentifier)
         let message = ToggleDiagnosticEvent(
             family: family,
             attemptID: session?.attemptID,

--- a/Sources/Wink/Services/ToggleSessionCoordinator.swift
+++ b/Sources/Wink/Services/ToggleSessionCoordinator.swift
@@ -48,6 +48,11 @@ final class ToggleSessionCoordinator {
         case notDegraded
     }
 
+    struct ReconfirmDecision: Equatable {
+        let result: ReconfirmResult
+        let session: Session?
+    }
+
     let configuration: Configuration
     private(set) var frontmostTargetBehavior: FrontmostTargetBehavior = .toggle
     private let now: @MainActor () -> CFAbsoluteTime
@@ -217,9 +222,16 @@ final class ToggleSessionCoordinator {
     }
 
     func reconfirmDegraded(for bundleIdentifier: String) -> ReconfirmResult {
+        reconfirmDegradedSession(for: bundleIdentifier).result
+    }
+
+    func reconfirmDegradedSession(for bundleIdentifier: String) -> ReconfirmDecision {
         guard var session = sessions[bundleIdentifier],
               session.phase == .degraded else {
-            return .notDegraded
+            return ReconfirmDecision(
+                result: .notDegraded,
+                session: sessions[bundleIdentifier]
+            )
         }
 
         let currentTime = now()
@@ -228,21 +240,28 @@ final class ToggleSessionCoordinator {
             session.phase = .idle
             session.lastActivityAt = currentTime
             sessions[bundleIdentifier] = session
-            return .absoluteCeilingReached
+            return ReconfirmDecision(result: .absoluteCeilingReached, session: session)
+        }
+
+        if currentTime - session.lastActivityAt > configuration.degradedIdleExpiry {
+            session.phase = .idle
+            session.lastActivityAt = currentTime
+            sessions[bundleIdentifier] = session
+            return ReconfirmDecision(result: .notDegraded, session: session)
         }
 
         if session.retryCount >= configuration.degradedRetryCap {
             session.phase = .idle
             session.lastActivityAt = currentTime
             sessions[bundleIdentifier] = session
-            return .retryCapped
+            return ReconfirmDecision(result: .retryCapped, session: session)
         }
 
         session.retryCount += 1
         session.phase = .activating
         session.lastActivityAt = currentTime
         sessions[bundleIdentifier] = session
-        return .accepted
+        return ReconfirmDecision(result: .accepted, session: session)
     }
 
     @discardableResult
@@ -335,8 +354,9 @@ final class ToggleSessionCoordinator {
     }
 
     func handleTermination(bundleIdentifier: String, pid: pid_t? = nil) {
-        guard let session = sessions[bundleIdentifier] else { return }
+        guard var session = sessions[bundleIdentifier] else { return }
         guard pid == nil || session.pid == nil || session.pid == pid else { return }
+        let idlesDegradedSession = session.phase == .degraded
         DiagnosticLog.log(
             ToggleDiagnosticEvent(
                 family: .reset,
@@ -345,12 +365,18 @@ final class ToggleSessionCoordinator {
                 pid: session.pid,
                 generation: session.generation,
                 phase: session.phase,
-                event: "session_cleared",
+                event: idlesDegradedSession ? "session_idled" : "session_cleared",
                 activationPath: session.activationPath,
                 reason: "termination"
             ).logMessage
         )
-        sessions.removeValue(forKey: bundleIdentifier)
+        if idlesDegradedSession {
+            session.phase = .idle
+            session.lastActivityAt = now()
+            sessions[bundleIdentifier] = session
+        } else {
+            sessions.removeValue(forKey: bundleIdentifier)
+        }
     }
 
     // MARK: - Live notification wiring

--- a/Tests/WinkTests/AXWindowObservationFaultInjectionTests.swift
+++ b/Tests/WinkTests/AXWindowObservationFaultInjectionTests.swift
@@ -28,6 +28,13 @@ struct AXWindowObservationFaultInjectionTests {
         ]))
         #expect(configuration.mode == .deactivationOnce)
         #expect(configuration.targetBundleIdentifier == "com.apple.Calculator")
+
+        let activationConfiguration = try #require(AXWindowObservationFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-ax-window-observation-fault=activation-persistent:com.apple.Calculator",
+        ]))
+        #expect(activationConfiguration.mode == .activationPersistent)
+        #expect(activationConfiguration.targetBundleIdentifier == "com.apple.Calculator")
     }
 
     @Test @MainActor
@@ -91,6 +98,83 @@ struct AXWindowObservationFaultInjectionTests {
         #expect(logs.contains {
             $0.contains("event=window_read_failed") && $0.contains("windowsReadSucceeded=false")
         })
+    }
+
+    @Test @MainActor
+    func activationPersistentModeWithholdsEveryMatchingObservationAndForwardsHide() throws {
+        let app = try #require(NSWorkspace.shared.frontmostApplication)
+        let bundleIdentifier = try #require(app.bundleIdentifier)
+        let configuration = try #require(AXWindowObservationFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-ax-window-observation-fault=activation-persistent:\(bundleIdentifier)",
+        ]))
+        var baseObservationCalls = 0
+        var baseHideCalls = 0
+        var logs: [String] = []
+        let driver = AXWindowObservationFaultInjectionDriver(
+            configuration: configuration,
+            currentFrontmostBundleIdentifier: { bundleIdentifier },
+            diagnosticLog: { logs.append($0) }
+        )
+        let baseObservation: (NSRunningApplication) -> ApplicationObservation.WindowObservation = { _ in
+            baseObservationCalls += 1
+            return ApplicationObservation.WindowObservation(
+                windows: nil,
+                visibleWindowCount: 1,
+                hasFocusedWindow: true,
+                hasMainWindow: true,
+                windowsReadSucceeded: true,
+                failureReason: nil
+            )
+        }
+
+        let first = driver.windowObservation(for: app, base: baseObservation)
+        let second = driver.windowObservation(for: app, base: baseObservation)
+        let hideResult = driver.hideApplication(app, base: { _ in
+            baseHideCalls += 1
+            return false
+        })
+
+        #expect(first.windowsReadSucceeded == false)
+        #expect(first.failureReason == "validationInjectedActivationWindowEvidenceFailure")
+        #expect(second.windowsReadSucceeded == false)
+        #expect(second.failureReason == "validationInjectedActivationWindowEvidenceFailure")
+        #expect(baseObservationCalls == 0)
+        #expect(hideResult == false)
+        #expect(baseHideCalls == 1)
+        #expect(logs.contains { $0.contains("event=window_evidence_withheld") && $0.contains("ordinal=1") })
+        #expect(logs.contains { $0.contains("event=window_evidence_withheld") && $0.contains("ordinal=2") })
+    }
+
+    @Test @MainActor
+    func activationPersistentModeLeavesNonMatchingApplicationsOnBaseObservation() throws {
+        let app = try #require(NSWorkspace.shared.frontmostApplication)
+        let bundleIdentifier = try #require(app.bundleIdentifier)
+        let configuration = try #require(AXWindowObservationFaultInjectionConfiguration(arguments: [
+            "Wink",
+            "--validation-ax-window-observation-fault=activation-persistent:com.example.different-target",
+        ]))
+        let driver = AXWindowObservationFaultInjectionDriver(
+            configuration: configuration,
+            currentFrontmostBundleIdentifier: { bundleIdentifier },
+            diagnosticLog: { _ in }
+        )
+        var baseObservationCalls = 0
+
+        let observation = driver.windowObservation(for: app, base: { _ in
+            baseObservationCalls += 1
+            return ApplicationObservation.WindowObservation(
+                windows: nil,
+                visibleWindowCount: 1,
+                hasFocusedWindow: true,
+                hasMainWindow: true,
+                windowsReadSucceeded: true,
+                failureReason: nil
+            )
+        })
+
+        #expect(observation.windowsReadSucceeded == true)
+        #expect(baseObservationCalls == 1)
     }
 }
 #endif

--- a/Tests/WinkTests/AppSwitcherTests.swift
+++ b/Tests/WinkTests/AppSwitcherTests.swift
@@ -729,6 +729,585 @@ func hiddenLagOnlyRetriesObservationOnceBeforeRecoveryEscalation() {
     #expect(switcher.stableActivationState?.bundleIdentifier == "dev.zed.Zed")
 }
 
+@Test @MainActor
+func activationRecoveryExhaustionEntersGenerationOwnedDegradedSession() {
+    let clock = MutableClock(time: 90)
+    let scheduler = ManualConfirmationScheduler()
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        confirmationClient: .init(
+            now: { clock.time },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        ),
+        sessionCoordinator: coordinator
+    )
+    let state = switcher.acceptPendingActivation(
+        for: "com.apple.Safari",
+        startedAt: clock.time
+    )
+    let originalSession = coordinator.session(for: state.bundleIdentifier)
+    let shortcut = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: state.bundleIdentifier,
+        keyEquivalent: "s",
+        modifierFlags: ["command"]
+    )
+    let failedObservation = ActivationObservationSnapshot(
+        targetBundleIdentifier: state.bundleIdentifier,
+        observedFrontmostBundleIdentifier: state.bundleIdentifier,
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 0,
+        hasFocusedWindow: false,
+        hasMainWindow: false,
+        windowObservationSucceeded: false,
+        windowObservationFailureReason: "axWindowsReadFailed=-25204",
+        classification: .nonStandardWindowed,
+        classificationReason: "window observation failed"
+    )
+    var recoveryStages: [AppSwitcher.WindowRecoveryStage] = []
+
+    switcher.schedulePendingConfirmation(
+        state: state,
+        shortcut: shortcut,
+        activationPath: .activate,
+        observe: { failedObservation },
+        recoverIfNeeded: { stage, completion in
+            recoveryStages.append(stage)
+            completion()
+        }
+    )
+
+    scheduler.runNext()
+    scheduler.runNext()
+    scheduler.runNext()
+    scheduler.runNext()
+
+    let degraded = coordinator.session(for: state.bundleIdentifier)
+    #expect(recoveryStages == [.axRaise, .reopen, .commandN])
+    #expect(degraded?.phase == .degraded)
+    #expect(degraded?.degradedReason == "activation_recovery_exhausted")
+    #expect(degraded?.attemptID == originalSession?.attemptID)
+    #expect(degraded?.generation == state.generation)
+    #expect(degraded?.retryCount == 0)
+}
+
+@Test @MainActor
+func degradedRepeatReconfirmsSameGenerationAndStopsAfterStableEvidence() throws {
+    let target = try #require(NSWorkspace.shared.frontmostApplication)
+    let bundleIdentifier = try #require(target.bundleIdentifier)
+    let clock = MutableClock(time: 100)
+    let scheduler = ManualConfirmationScheduler()
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let original = coordinator.beginActivation(
+        for: bundleIdentifier,
+        appName: target.localizedName,
+        pid: target.processIdentifier,
+        startedAt: clock.time
+    )
+    _ = coordinator.markDegraded(
+        for: bundleIdentifier,
+        reason: "activation_recovery_exhausted",
+        generation: original.generation
+    )
+    var activationCalls = 0
+    var hideCalls = 0
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        applicationObservation: ApplicationObservation(client: .init(
+            currentFrontmostBundleIdentifier: { bundleIdentifier },
+            windowObservation: { _ in
+                .init(
+                    windows: nil,
+                    visibleWindowCount: 1,
+                    hasFocusedWindow: true,
+                    hasMainWindow: true,
+                    windowsReadSucceeded: true,
+                    failureReason: nil
+                )
+            },
+            activationPolicy: { _ in .regular }
+        )),
+        activationClient: .init(activateFrontProcess: { _, _ in
+            activationCalls += 1
+            return .success(ProcessSerialNumber())
+        }),
+        hideRequestClient: .init(hideApplication: { _ in
+            hideCalls += 1
+            return true
+        }),
+        appLookupClient: .init(
+            runningApplications: { _ in [target] },
+            applicationURL: { _ in nil }
+        ),
+        confirmationClient: .init(
+            now: { clock.time },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        ),
+        sessionCoordinator: coordinator
+    )
+    let shortcut = AppShortcut(
+        appName: target.localizedName ?? "Frontmost",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "r",
+        modifierFlags: ["command", "option"]
+    )
+
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+
+    let stable = coordinator.session(for: bundleIdentifier)
+    #expect(stable?.phase == .activeStable)
+    #expect(stable?.attemptID == original.attemptID)
+    #expect(stable?.generation == original.generation)
+    #expect(stable?.retryCount == 1)
+    #expect(activationCalls == 0)
+    #expect(hideCalls == 0)
+    #expect(scheduler.pendingCount == 0)
+}
+
+@Test @MainActor
+func degradedRepeatObservationCannotExpireAcceptedSessionIntoNewGeneration() throws {
+    let target = try #require(NSWorkspace.shared.frontmostApplication)
+    let bundleIdentifier = try #require(target.bundleIdentifier)
+    let clock = MutableClock(time: 104.999)
+    let scheduler = ManualConfirmationScheduler()
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(
+            degradedIdleExpiry: 2,
+            absoluteActivationCeiling: 5,
+            degradedRetryCap: 2
+        ),
+        now: { clock.time }
+    )
+    let original = coordinator.beginActivation(
+        for: bundleIdentifier,
+        appName: target.localizedName,
+        pid: target.processIdentifier,
+        startedAt: 100
+    )
+    _ = coordinator.markDegraded(
+        for: bundleIdentifier,
+        reason: "activation_recovery_exhausted",
+        generation: original.generation
+    )
+    var activationCalls = 0
+    var hideCalls = 0
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        applicationObservation: ApplicationObservation(client: .init(
+            currentFrontmostBundleIdentifier: { bundleIdentifier },
+            windowObservation: { _ in
+                clock.time = 105.001
+                return .init(
+                    windows: nil,
+                    visibleWindowCount: 1,
+                    hasFocusedWindow: true,
+                    hasMainWindow: true,
+                    windowsReadSucceeded: true,
+                    failureReason: nil
+                )
+            },
+            activationPolicy: { _ in .regular }
+        )),
+        activationClient: .init(activateFrontProcess: { _, _ in
+            activationCalls += 1
+            return .success(ProcessSerialNumber())
+        }),
+        hideRequestClient: .init(hideApplication: { _ in
+            hideCalls += 1
+            return true
+        }),
+        appLookupClient: .init(
+            runningApplications: { _ in [target] },
+            applicationURL: { _ in nil }
+        ),
+        confirmationClient: .init(
+            now: { clock.time },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        ),
+        sessionCoordinator: coordinator
+    )
+    let shortcut = AppShortcut(
+        appName: target.localizedName ?? "Frontmost",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "b",
+        modifierFlags: ["command", "shift"]
+    )
+
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+
+    let stable = coordinator.session(for: bundleIdentifier)
+    #expect(stable?.phase == .activeStable)
+    #expect(stable?.attemptID == original.attemptID)
+    #expect(stable?.generation == original.generation)
+    #expect(stable?.retryCount == 1)
+    #expect(activationCalls == 0)
+    #expect(hideCalls == 0)
+    #expect(scheduler.pendingCount == 0)
+}
+
+@Test @MainActor
+func degradedRepeatsStopAtRetryCapWithoutFurtherSideEffects() throws {
+    let target = try #require(NSWorkspace.shared.frontmostApplication)
+    let bundleIdentifier = try #require(target.bundleIdentifier)
+    let clock = MutableClock(time: 200)
+    let scheduler = ManualConfirmationScheduler()
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(
+            degradedIdleExpiry: 2,
+            absoluteActivationCeiling: 20,
+            degradedRetryCap: 2
+        ),
+        now: { clock.time }
+    )
+    let original = coordinator.beginActivation(
+        for: bundleIdentifier,
+        appName: target.localizedName,
+        pid: target.processIdentifier,
+        startedAt: clock.time
+    )
+    _ = coordinator.markDegraded(
+        for: bundleIdentifier,
+        reason: "activation_recovery_exhausted",
+        generation: original.generation
+    )
+    var observationCalls = 0
+    var activationCalls = 0
+    var fallbackCalls = 0
+    var hideCalls = 0
+    var recoveryStages: [AppSwitcher.WindowRecoveryStage] = []
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        applicationObservation: ApplicationObservation(client: .init(
+            currentFrontmostBundleIdentifier: { bundleIdentifier },
+            windowObservation: { _ in
+                observationCalls += 1
+                return .init(
+                    windows: nil,
+                    visibleWindowCount: 0,
+                    hasFocusedWindow: false,
+                    hasMainWindow: false,
+                    windowsReadSucceeded: false,
+                    failureReason: "axWindowsReadFailed=-25204"
+                )
+            },
+            activationPolicy: { _ in .regular }
+        )),
+        activationClient: .init(activateFrontProcess: { _, _ in
+            activationCalls += 1
+            return .success(ProcessSerialNumber())
+        }),
+        fallbackActivationClient: .init(openApplication: { _, _, completion in
+            fallbackCalls += 1
+            completion(nil, nil)
+        }),
+        hideRequestClient: .init(hideApplication: { _ in
+            hideCalls += 1
+            return true
+        }),
+        appLookupClient: .init(
+            runningApplications: { _ in [target] },
+            applicationURL: { _ in nil }
+        ),
+        confirmationClient: .init(
+            now: { clock.time },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        ),
+        recoveryClient: .init(perform: { stage, completion in
+            recoveryStages.append(stage)
+            completion()
+        }),
+        sessionCoordinator: coordinator
+    )
+    let shortcut = AppShortcut(
+        appName: target.localizedName ?? "Frontmost",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "r",
+        modifierFlags: ["command", "option"]
+    )
+
+    for expectedRetryCount in 1...2 {
+        clock.time += 0.5
+        #expect(switcher.toggleApplication(for: shortcut) == true)
+        scheduler.runAll()
+
+        let degraded = coordinator.session(for: bundleIdentifier)
+        #expect(degraded?.phase == .degraded)
+        #expect(degraded?.attemptID == original.attemptID)
+        #expect(degraded?.generation == original.generation)
+        #expect(degraded?.retryCount == expectedRetryCount)
+    }
+
+    #expect(activationCalls == 2)
+    #expect(recoveryStages == [.axRaise, .reopen, .commandN, .axRaise, .reopen, .commandN])
+    let observationCallsBeforeCap = observationCalls
+    let activationCallsBeforeCap = activationCalls
+    let fallbackCallsBeforeCap = fallbackCalls
+    let hideCallsBeforeCap = hideCalls
+    let recoveryStagesBeforeCap = recoveryStages
+    let scheduledBeforeCap = scheduler.pendingCount
+
+    clock.time += 0.5
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+
+    let capped = coordinator.session(for: bundleIdentifier)
+    #expect(capped?.phase == .idle)
+    #expect(capped?.attemptID == original.attemptID)
+    #expect(capped?.generation == original.generation)
+    #expect(capped?.retryCount == 2)
+    #expect(observationCalls == observationCallsBeforeCap)
+    #expect(activationCalls == activationCallsBeforeCap)
+    #expect(fallbackCalls == fallbackCallsBeforeCap)
+    #expect(hideCalls == hideCallsBeforeCap)
+    #expect(recoveryStages == recoveryStagesBeforeCap)
+    #expect(scheduler.pendingCount == scheduledBeforeCap)
+
+    scheduler.runAll()
+    #expect(observationCalls == observationCallsBeforeCap)
+    #expect(activationCalls == activationCallsBeforeCap)
+    #expect(fallbackCalls == fallbackCallsBeforeCap)
+    #expect(hideCalls == hideCallsBeforeCap)
+    #expect(recoveryStages == recoveryStagesBeforeCap)
+}
+
+@Test @MainActor
+func degradedRepeatStopsAtAbsoluteCeilingWithoutAnySideEffect() throws {
+    let target = try #require(NSWorkspace.shared.frontmostApplication)
+    let bundleIdentifier = try #require(target.bundleIdentifier)
+    let clock = MutableClock(time: 300)
+    let scheduler = ManualConfirmationScheduler()
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(
+            degradedIdleExpiry: 2,
+            absoluteActivationCeiling: 1,
+            degradedRetryCap: 10
+        ),
+        now: { clock.time }
+    )
+    var lookupCalls = 0
+    var observationCalls = 0
+    var activationCalls = 0
+    var fallbackCalls = 0
+    var hideCalls = 0
+    var recoveryStages: [AppSwitcher.WindowRecoveryStage] = []
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        applicationObservation: ApplicationObservation(client: .init(
+            currentFrontmostBundleIdentifier: { bundleIdentifier },
+            windowObservation: { _ in
+                observationCalls += 1
+                return .init(
+                    windows: nil,
+                    visibleWindowCount: 0,
+                    hasFocusedWindow: false,
+                    hasMainWindow: false,
+                    windowsReadSucceeded: false,
+                    failureReason: "axWindowsReadFailed=-25204"
+                )
+            },
+            activationPolicy: { _ in .regular }
+        )),
+        activationClient: .init(activateFrontProcess: { _, _ in
+            activationCalls += 1
+            return .success(ProcessSerialNumber())
+        }),
+        fallbackActivationClient: .init(openApplication: { _, _, completion in
+            fallbackCalls += 1
+            completion(nil, nil)
+        }),
+        hideRequestClient: .init(hideApplication: { _ in
+            hideCalls += 1
+            return true
+        }),
+        appLookupClient: .init(
+            runningApplications: { _ in
+                lookupCalls += 1
+                return [target]
+            },
+            applicationURL: { _ in nil }
+        ),
+        confirmationClient: .init(
+            now: { clock.time },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        ),
+        recoveryClient: .init(perform: { stage, completion in
+            recoveryStages.append(stage)
+            completion()
+        }),
+        sessionCoordinator: coordinator
+    )
+    let shortcut = AppShortcut(
+        appName: target.localizedName ?? "Frontmost",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "c",
+        modifierFlags: ["command", "control"]
+    )
+
+    let state = switcher.acceptPendingActivation(
+        for: bundleIdentifier,
+        startedAt: clock.time,
+        pid: target.processIdentifier
+    )
+    let original = try #require(coordinator.session(for: bundleIdentifier))
+    let failedObservation = ActivationObservationSnapshot(
+        targetBundleIdentifier: bundleIdentifier,
+        observedFrontmostBundleIdentifier: bundleIdentifier,
+        targetIsActive: true,
+        targetIsHidden: false,
+        visibleWindowCount: 0,
+        hasFocusedWindow: false,
+        hasMainWindow: false,
+        windowObservationSucceeded: false,
+        windowObservationFailureReason: "axWindowsReadFailed=-25204",
+        classification: .nonStandardWindowed,
+        classificationReason: "window observation failed"
+    )
+    switcher.schedulePendingConfirmation(
+        state: state,
+        shortcut: shortcut,
+        activationPath: .activate,
+        observe: { failedObservation },
+        recoverIfNeeded: { stage, completion in
+            recoveryStages.append(stage)
+            completion()
+        }
+    )
+    scheduler.runAll()
+
+    let initiallyDegraded = coordinator.session(for: bundleIdentifier)
+    #expect(initiallyDegraded?.phase == .degraded)
+    #expect(initiallyDegraded?.attemptID == original.attemptID)
+    #expect(initiallyDegraded?.generation == original.generation)
+    #expect(initiallyDegraded?.activationStartedAt == original.activationStartedAt)
+    #expect(recoveryStages == [.axRaise, .reopen, .commandN])
+
+    clock.time += 0.5
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    scheduler.runAll()
+
+    let retried = coordinator.session(for: bundleIdentifier)
+    #expect(retried?.phase == .degraded)
+    #expect(retried?.attemptID == original.attemptID)
+    #expect(retried?.generation == original.generation)
+    #expect(retried?.activationStartedAt == original.activationStartedAt)
+    #expect(retried?.retryCount == 1)
+    #expect(activationCalls == 1)
+    #expect(recoveryStages == [.axRaise, .reopen, .commandN, .axRaise, .reopen, .commandN])
+
+    let lookupCallsBeforeCeiling = lookupCalls
+    let observationCallsBeforeCeiling = observationCalls
+    let activationCallsBeforeCeiling = activationCalls
+    let fallbackCallsBeforeCeiling = fallbackCalls
+    let hideCallsBeforeCeiling = hideCalls
+    let recoveryStagesBeforeCeiling = recoveryStages
+    let scheduledBeforeCeiling = scheduler.pendingCount
+
+    clock.time += 0.6
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+
+    let ended = coordinator.session(for: bundleIdentifier)
+    #expect(ended?.phase == .idle)
+    #expect(ended?.attemptID == original.attemptID)
+    #expect(ended?.generation == original.generation)
+    #expect(ended?.activationStartedAt == original.activationStartedAt)
+    #expect(ended?.retryCount == 1)
+    #expect(lookupCalls == lookupCallsBeforeCeiling + 1)
+    #expect(observationCalls == observationCallsBeforeCeiling)
+    #expect(activationCalls == activationCallsBeforeCeiling)
+    #expect(fallbackCalls == fallbackCallsBeforeCeiling)
+    #expect(hideCalls == hideCallsBeforeCeiling)
+    #expect(recoveryStages == recoveryStagesBeforeCeiling)
+    #expect(scheduler.pendingCount == scheduledBeforeCeiling)
+
+    scheduler.runAll()
+    #expect(observationCalls == observationCallsBeforeCeiling)
+    #expect(activationCalls == activationCallsBeforeCeiling)
+    #expect(fallbackCalls == fallbackCallsBeforeCeiling)
+    #expect(hideCalls == hideCallsBeforeCeiling)
+    #expect(recoveryStages == recoveryStagesBeforeCeiling)
+}
+
+@Test @MainActor
+func staleScheduledActivationConfirmationCannotMutateNewerDegradedSession() {
+    let scheduler = ManualConfirmationScheduler()
+    let coordinator = ToggleSessionCoordinator(now: { 400 })
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        confirmationClient: .init(
+            now: { 400 },
+            schedule: { delay, operation in
+                scheduler.schedule(after: delay, operation)
+            }
+        ),
+        sessionCoordinator: coordinator
+    )
+    let staleState = switcher.acceptPendingActivation(
+        for: "com.apple.Safari",
+        startedAt: 400
+    )
+    let shortcut = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: staleState.bundleIdentifier,
+        keyEquivalent: "s",
+        modifierFlags: ["command"]
+    )
+    var observationCalls = 0
+    var recoveryCalls = 0
+    switcher.schedulePendingConfirmation(
+        state: staleState,
+        shortcut: shortcut,
+        activationPath: .activate,
+        observe: {
+            observationCalls += 1
+            return ActivationObservationSnapshot(
+                targetBundleIdentifier: staleState.bundleIdentifier,
+                observedFrontmostBundleIdentifier: staleState.bundleIdentifier,
+                targetIsActive: true,
+                targetIsHidden: false,
+                visibleWindowCount: 0,
+                hasFocusedWindow: false,
+                hasMainWindow: false,
+                windowObservationSucceeded: false,
+                windowObservationFailureReason: "stale callback must not observe",
+                classification: .nonStandardWindowed,
+                classificationReason: "stale callback"
+            )
+        },
+        recoverIfNeeded: { _, completion in
+            recoveryCalls += 1
+            completion()
+        }
+    )
+
+    let currentState = switcher.acceptPendingActivation(
+        for: staleState.bundleIdentifier,
+        startedAt: 400
+    )
+    _ = coordinator.markDegraded(
+        for: currentState.bundleIdentifier,
+        reason: "newer_activation_recovery_exhausted",
+        generation: currentState.generation
+    )
+    let currentSession = coordinator.session(for: currentState.bundleIdentifier)
+
+    scheduler.runNext()
+
+    #expect(observationCalls == 0)
+    #expect(recoveryCalls == 0)
+    #expect(coordinator.session(for: currentState.bundleIdentifier) == currentSession)
+}
+
 // MARK: - Coordinator integration tests
 
 @Test @MainActor
@@ -1860,5 +2439,16 @@ private final class ManualConfirmationScheduler {
         }
         let operation = operations.removeFirst()
         operation()
+    }
+
+    func runAll(limit: Int = 100) {
+        var executed = 0
+        while !operations.isEmpty, executed < limit {
+            executed += 1
+            runNext()
+        }
+        if !operations.isEmpty {
+            Issue.record("Scheduled confirmation operations exceeded the bounded drain limit")
+        }
     }
 }

--- a/Tests/WinkTests/ToggleSessionCoordinatorTests.swift
+++ b/Tests/WinkTests/ToggleSessionCoordinatorTests.swift
@@ -125,6 +125,29 @@ func degradedReconfirmResetsIdleExpiryTimer() {
 }
 
 @Test @MainActor
+func degradedReconfirmAfterIdleExpiryReturnsNotDegradedAndIdlesSession() {
+    let clock = CoordinatorTestClock(time: 100)
+    let coordinator = ToggleSessionCoordinator(
+        configuration: .init(
+            degradedIdleExpiry: 2,
+            absoluteActivationCeiling: 10,
+            degradedRetryCap: 2
+        ),
+        now: { clock.time }
+    )
+
+    coordinator.beginActivation(for: "com.apple.Home")
+    coordinator.markDegraded(for: "com.apple.Home", reason: "no windows")
+    clock.time = 102.1
+
+    let result = coordinator.reconfirmDegraded(for: "com.apple.Home")
+
+    #expect(result == .notDegraded)
+    #expect(coordinator.session(for: "com.apple.Home")?.phase == .idle)
+    #expect(coordinator.session(for: "com.apple.Home")?.retryCount == 0)
+}
+
+@Test @MainActor
 func degradedReconfirmDoesNotResetAbsoluteActivationCeiling() {
     let clock = CoordinatorTestClock(time: 100)
     let coordinator = ToggleSessionCoordinator(
@@ -294,15 +317,37 @@ func evictionDoesNotEvictCurrentlyMutatingSession() {
 }
 
 @Test @MainActor
-func terminatedTargetClearsDegradedSession() {
+func terminatedTargetTransitionsDegradedSessionToIdle() {
     let coordinator = ToggleSessionCoordinator(now: { 100 })
 
     coordinator.beginActivation(for: "com.apple.Home")
     coordinator.markDegraded(for: "com.apple.Home", reason: "no windows")
+    coordinator.beginActivation(for: "com.apple.Clock")
+    coordinator.markDegraded(for: "com.apple.Clock", reason: "clock has no windows")
+    let unrelatedSession = coordinator.session(for: "com.apple.Clock")
 
     coordinator.handleTermination(bundleIdentifier: "com.apple.Home")
 
-    #expect(coordinator.session(for: "com.apple.Home") == nil)
+    #expect(coordinator.session(for: "com.apple.Home")?.phase == .idle)
+    #expect(coordinator.session(for: "com.apple.Home")?.degradedReason == "no windows")
+    #expect(coordinator.session(for: "com.apple.Clock") == unrelatedSession)
+}
+
+@Test @MainActor
+func explicitResetIdlesOnlyAffectedDegradedSession() {
+    let coordinator = ToggleSessionCoordinator(now: { 100 })
+
+    coordinator.beginActivation(for: "com.apple.Home")
+    coordinator.markDegraded(for: "com.apple.Home", reason: "no windows")
+    coordinator.beginActivation(for: "com.apple.Clock")
+    coordinator.markDegraded(for: "com.apple.Clock", reason: "clock has no windows")
+    let unrelatedSession = coordinator.session(for: "com.apple.Clock")
+
+    coordinator.resetSession(for: "com.apple.Home")
+
+    #expect(coordinator.session(for: "com.apple.Home")?.phase == .idle)
+    #expect(coordinator.session(for: "com.apple.Home")?.degradedReason == "no windows")
+    #expect(coordinator.session(for: "com.apple.Clock") == unrelatedSession)
 }
 
 @Test @MainActor

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ flowchart LR
 
   subgraph T["Toggle 运行时"]
     W["W(AppSwitcher)\n激活 / 隐藏编排"]
-    T1["T(ToggleSessionCoordinator)\ncanonical owner\nlaunching → activating → activeStable → deactivating → degraded / idle"]
+    T1["T(ToggleSessionCoordinator)\ncanonical owner\nlaunching → activating → activeStable → deactivating → idle\nactivating → degraded → activating / idle"]
     O["O(ApplicationObservation)\nfrontmost + window 证据"]
     F["F(FrontmostApplicationTracker)\nfrontmost snapshot / session seed"]
     L["L(AppBundleLocator)\n目标 app 定位"]
@@ -198,8 +198,10 @@ Responsibilities:
 - treat `ToggleSessionCoordinator` as the canonical lifecycle owner; `AppSwitcher` only exposes derived pending/stable views instead of keeping a second mutable toggle owner
 - keep `attemptID`, `pid`, phase, timing, and activation path on the coordinator session so relaunches and pid rollover stay traceable
 - attach the `NSRunningApplication` returned by `NSWorkspace.openApplication` back onto the existing `launching` session so launch and activate share the same confirmation pipeline
-- invalidate or clear sessions from `NSWorkspace.didActivateApplicationNotification` and `NSWorkspace.didTerminateApplicationNotification` instead of polling
-- only allow toggle-off from a confirmed stable state; repeat triggers during pending or degraded activation re-confirm the session instead of restoring away
+- invalidate or clear sessions from `NSWorkspace.didActivateApplicationNotification` and `NSWorkspace.didTerminateApplicationNotification` instead of polling; termination transitions an affected degraded session to `idle` while preserving its attempt diagnostics
+- only allow toggle-off from a confirmed stable state; recovery exhaustion transitions `activating → degraded` under the same `attemptID` and generation, and a repeat trigger atomically checks the absolute ceiling, degraded-idle expiry, and retry cap before it can re-confirm that same session
+- an accepted degraded repeat transitions `degraded → activating`, then either reaches `activeStable` from fresh stable evidence or returns to `degraded` after the bounded recovery ladder; retry-cap and absolute-ceiling results transition to `idle` and end the trigger before activation, hide, or recovery side effects
+- reject activation confirmation callbacks whose generation no longer matches the owned session, so a stale attempt cannot mutate a newer `activating` or `degraded` generation
 - only allow windowless stable success for non-regular targets; regular apps must show visible/focused/main-window evidence before toggle-on can become `activeStable`
 - keep the hot activation path to front-process activation only, then escalate to `makeKeyWindow`, `AXRaise`, and window recovery only when observation shows activation is not yet settled
 - toggle off by requesting `NSRunningApplication.hide()`, then confirm deactivation asynchronously from `NSWorkspace.didHideApplicationNotification` plus a short observation window before clearing session state; a zero-window result is affirmative only when that AX windows read succeeded, while `isHidden` remains an independent confirmation signal
@@ -327,6 +329,9 @@ Global shortcut event
   -> ToggleSessionCoordinator creates/updates the pid-aware attempt session
   -> ApplicationObservation captures frontmost/window evidence
   -> activate / confirm / recover stage-by-stage
+  -> recovery exhaustion keeps the same attempt/generation and enters degraded
+  -> a degraded repeat returns to activating, reaches activeStable from evidence,
+     or terminates at retry cap / absolute ceiling with zero further side effects
   -> `TOGGLE_TRACE_*` lines record branch reason, reset reason, and confirmation outcome for that attempt
   -> direct hide request only from activeStable, then async hide confirmation
 ```
@@ -359,12 +364,13 @@ CGEvent callback receives tapDisabledByTimeout / tapDisabledByUserInput
 - **Pid-aware attempt sessions**: launch / relaunch / termination recovery use attempt-scoped sessions that track `attemptID`, `pid`, `activationPath`, and current phase so process-lifetime boundaries cannot silently desynchronize ownership
 - **No-window success policy**: regular apps require usable window evidence before `activeStable`; only `activationPolicy != .regular` targets may succeed while windowless
 - **Attempt-scoped diagnostics**: `TOGGLE_TRACE_*` and `SHORTCUT_TRACE_*` explain branch choice and failure boundaries without adding detailed logs to unrelated key events
-- **Notification-driven invalidation**: `NSWorkspace` activation and termination notifications clear or expire stable/deactivating sessions without polling
+- **Notification-driven invalidation**: `NSWorkspace` activation and termination notifications clear or expire stable/deactivating sessions without polling; an affected degraded session is idled with its attempt diagnostics preserved
 - **Hardened EventTap lifecycle**: explicit ownership, callback-safe timeout snapshots, threshold-based escalation, and same-thread run-loop recreation
 - **Split capture transports**: standard shortcuts use Carbon hotkeys; Hyper-only shortcuts use the active interception tap. Standard Fn+F-row bindings add a minimal active Fn/F-row observer solely to reject Carbon's bare-F-row alias, and that observer returns events unchanged. Passive `.listenOnly` mode is not used because it cannot provide the required interception-order state barrier
 - **SkyLight primary activation path**: private API is used for reliable foreground switching from LSUIElement context
 - **Modern AppKit fallback**: when SkyLight activation fails, Wink re-requests activation via `NSWorkspace.OpenConfiguration` (`activates = true`) and only falls back to a plain AppKit activation request if no bundle URL is available
 - **Minimal-by-default activation**: front-process activation is the only hot-path activation step; `makeKeyWindow`, `AXRaise`, and reopen/new-window recovery are bounded escalation steps driven by observation
+- **Bounded degraded recovery**: recovery exhaustion preserves one generation-owned attempt; atomic reconfirm decisions enforce the two-repeat cap, five-second absolute ceiling, and two-second degraded idle expiry before any new runtime side effect
 - **Stable-state toggle semantics**: activate immediately, confirm asynchronously, allow toggle-off only from `activeStable`, and avoid restore-away rollback on confirmation failure
 - **Official hide request path**: toggle-off uses `NSRunningApplication.hide()` plus asynchronous confirmation instead of event-synthesized hide commands
 - **Service-level test seams**: system-facing services use small injected clients or existing collaborators so runtime decision logic can be covered without live TCC or app-launch side effects

--- a/docs/handoff-notes.md
+++ b/docs/handoff-notes.md
@@ -172,8 +172,8 @@ On 2026-04-09, packaged-app runtime validation moved past the original TCC block
 
 ## Implemented Behavioral Guarantees
 - Half-active frontmost mismatches are not promoted to stable: `ActivationObservationSnapshot.isStableActivation` requires target/frontmost agreement, `targetIsActive == true`, `targetIsHidden == false`, and supporting window evidence before `AppSwitcher` can promote a pending activation
-- A second press during pending activation does not toggle off: `pendingActivationState` blocks `shouldToggleOff`, and a repeat accepted trigger refreshes confirmation generation instead of restoring away
-- Confirmation failure does not trigger flicker-inducing restore-away rollback: failed confirmation either advances through the staged recovery path or drops the session back to idle/degraded without restoring the previous app automatically
+- A second press during pending activation does not toggle off: `pendingActivationState` blocks `shouldToggleOff`; after recovery exhaustion, a repeat atomically re-confirms the same attempt and generation instead of restoring away or allocating a fresh recovery budget
+- Confirmation failure does not trigger flicker-inducing restore-away rollback: exhausted recovery enters generation-owned `degraded`; accepted repeats return to `activating`, while retry-cap or absolute-ceiling termination enters `idle` before any further activation, hide, or recovery side effect
 - Stable toggle-off now enters an explicit `deactivating` phase, requests `hide()` on the target app, and clears runtime session state only after hide confirmation succeeds
 - Event tap recovery now either recreates the tap successfully on the existing background RunLoop thread or leaves an explicit degraded readiness state after repeated recreation failures
 - Standard shortcuts and Hyper shortcuts now report readiness independently, so missing Input Monitoring only degrades Hyper capture instead of the whole app
@@ -182,6 +182,7 @@ On 2026-04-09, packaged-app runtime validation moved past the original TCC block
 - `NSWorkspace.openApplication` completion is now used as a process-identity seam: the returned `NSRunningApplication` feeds pid attachment and the same confirmation pipeline used by activate/unhide, instead of leaving launch as fire-and-forget
 - Regular apps cannot silently succeed toggle-on without usable window evidence; only targets with `activationPolicy != .regular` may remain stable without visible/focused/main-window proof
 - `hide_untracked` now creates an explicit coordinator-owned `deactivating` session before dispatching `hide()`, so external activation still gets a real `HIDE_REQUEST` / confirmation pair instead of only logging the branch
+- Activation recovery exhaustion is now wired into the production coordinator flow: degraded repeats retain one `attemptID`/generation, consume at most the configured retry budget, and cannot execute another AX raise, reopen, Command-N, hide, or activation action after the retry cap or absolute ceiling terminates the session
 
 ## Toggle Reliability Recovery (2026-04-09)
 - `ToggleSessionCoordinator` now owns pid-aware attempt sessions with explicit `launching`, `activating`, `activeStable`, `deactivating`, `degraded`, and `idle` phases.
@@ -194,12 +195,15 @@ On 2026-04-09, packaged-app runtime validation moved past the original TCC block
 - Toggle-off settled: `TOGGLE_TRACE_CONFIRMATION attemptId=... event=confirmed reason="hide_confirmed"`
 - Owned launch path started correctly: `TOGGLE_TRACE_SESSION attemptId=... event=session_started activationPath=launch reason="not_running_launch_request"`
 - Owned launch attached to the real process: `TOGGLE_TRACE_SESSION attemptId=... event=launch_attached activationPath=launch reason="launch_completion_process_lookup"`
+- Activation recovery exhausted under the owned attempt: `TOGGLE_TRACE_CONFIRMATION attemptId=... event=degraded reason="activation_recovery_exhausted"`
+- Degraded repeat decision: `TOGGLE_TRACE_DECISION attemptId=... event=degraded_reconfirm reason="result=accepted|retry_capped|absolute_ceiling_reached ..."`
 - Hyper-routed IINA in the current local config: `SHORTCUT_TRACE_DECISION event=matched bundle=com.colliderli.iina route=hyper`
 
 ### Trace signatures to treat as failure or follow-up
 - Regular app frontmost but still unusable: `TOGGLE_TRACE_CONFIRMATION attemptId=... event=awaiting_window_evidence reason="frontmost_without_window_evidence"`
 - Hide request degraded instead of settling: `TOGGLE_TRACE_CONFIRMATION attemptId=... event=degraded reason="partial_hide_degraded"`
-- Session reset: `TOGGLE_TRACE_RESET attemptId=... event=session_cleared reason="termination" | "pid_rollover" | "launch_failed" | "activation_recovery_exhausted"`
+- Degraded target termination: `TOGGLE_TRACE_RESET attemptId=... event=session_idled reason="termination"`
+- Session reset outside degraded recovery: `TOGGLE_TRACE_RESET attemptId=... event=session_cleared reason="termination" | "pid_rollover" | "launch_failed"`
 - Stale tracking corrected: `TOGGLE_TRACE_RESET attemptId=... event=session_invalidated reason="stale_state_invalidated"`
 - Capture path blocked before toggle dispatch: `SHORTCUT_TRACE_BLOCKED reason="missing_registration_or_system_conflict" | "input_monitoring_missing" | "event_tap_inactive"`
 

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -407,7 +407,7 @@ Repeated shortcut presses can flap between "activate" and "toggle off" if Wink d
 The first trigger may only have started activation, while the second trigger arrives before the app has reached a stable frontmost state with a usable window.
 
 **Practical guidance**
-Do not let "activation requested" mean "activation complete". Require a short post-activation confirmation pass and only allow toggle-off from a stable active state. During pending or degraded activation, a repeat trigger should re-confirm or re-attempt activation instead of making hide/reactivate decisions from a transient snapshot.
+Do not let "activation requested" mean "activation complete". Require a short post-activation confirmation pass and only allow toggle-off from a stable active state. Recovery exhaustion must retain one generation-owned degraded attempt. A repeat trigger atomically checks the absolute ceiling, degraded-idle expiry, and retry cap before re-attempting; cap or ceiling termination must enter idle before any further activation, hide, AX raise, reopen, or Command-N side effect.
 
 ## Retiring Previous-App Memory When It Stops Driving Behavior
 
@@ -429,7 +429,7 @@ Launch -> quit -> relaunch flows can leave Wink believing a target is both "stab
 When bundle-keyed session tracking is duplicated across multiple owners, termination or pid rollover can clear one owner while the other still holds stale stable/pending state. That is how relaunch paths degrade into `phase=no_session`, `hide_untracked`, or other ownership confusion right after an otherwise valid launch.
 
 **Practical guidance**
-Make `ToggleSessionCoordinator` the only lifecycle owner. Keep pid, attempt id, phase, activation path, and timing on that single session object, and reset or replace the session on termination and pid rollover. `AppSwitcher` may expose derived read-only views, but it must not become a second mutable lifecycle owner.
+Make `ToggleSessionCoordinator` the only lifecycle owner. Keep pid, attempt id, phase, activation path, and timing on that single session object. Termination or explicit reset idles an affected degraded session, while pid rollover replaces an incompatible process-owned session. `AppSwitcher` may expose derived read-only views, but it must not become a second mutable lifecycle owner.
 
 Do not throw away the `NSRunningApplication` returned by `NSWorkspace.openApplication`. The launch completion is the cleanest process-identity seam Wink gets for a just-launched target. Attach that pid back onto the existing `launching` session immediately and run the same confirmation pipeline used by activate/unhide, or the next press can still fall through to `hide_untracked` despite an otherwise successful launch.
 
@@ -464,7 +464,7 @@ Stable toggle state can become stale as soon as the user changes apps outside Wi
 Polling or one-shot snapshots miss external activation and termination changes, especially while a toggle session is still marked `activeStable` or `deactivating`.
 
 **Practical guidance**
-Use `NSWorkspace.didActivateApplicationNotification` to drop stable/deactivating sessions when another app becomes frontmost, and `NSWorkspace.didTerminateApplicationNotification` to clear sessions for terminated targets. This keeps runtime state aligned with user-visible app focus without adding polling noise.
+Use `NSWorkspace.didActivateApplicationNotification` to drop stable/deactivating sessions when another app becomes frontmost, and `NSWorkspace.didTerminateApplicationNotification` to clear ordinary sessions or transition an affected degraded session to idle. This keeps runtime state aligned with user-visible app focus without adding polling noise.
 
 ## System Apps Need Honest Downgrade Rules
 
@@ -475,7 +475,7 @@ Apps such as Home can produce visible windows without behaving like normal key-w
 Some system utilities use nonstandard scene, hide/unhide, or window activation behavior that does not match assumptions baked into regular AppKit apps.
 
 **Practical guidance**
-Do not force all apps through one generic "front app with visible window means success" rule. Keep a degraded-success path for system or window-weird apps, log why the app is degraded, and avoid counting degraded activation as safe toggle-off state.
+Do not force all apps through one generic "front app with visible window means success" rule. Allow explicitly classified non-regular apps to stabilize without ordinary window evidence. For unresolved regular-app evidence failures, enter a bounded degraded recovery state, log the reason, and never count degraded activation as safe toggle-off state.
 
 ## Untracked Frontmost Apps Need a Direct Hide Path
 

--- a/docs/signing-and-release.md
+++ b/docs/signing-and-release.md
@@ -195,10 +195,13 @@ bash scripts/validate-carbon-binding-retry.sh
 
 ### AX window-observation fault validation package
 
-The AX window-observation injector is compile-time-only. It suppresses the
-first matching hide request, then injects one failed windows observation only
-after the real target has lost frontmost status while `isHidden` is still
-false. Build it explicitly:
+The AX window-observation injector is compile-time-only. Its
+`deactivation-once` mode suppresses the first matching hide request, then
+injects one failed windows observation only after the real target has lost
+frontmost status while `isHidden` is still false. Its `activation-persistent`
+mode leaves hide requests untouched and withholds every matching activation
+window observation so the complete recovery ladder and degraded-repeat limits
+can be exercised. Build either mode explicitly:
 
 ```bash
 WINK_VALIDATION_AX_WINDOW_OBSERVATION_FAULT_INJECTION=1 bash scripts/package-app.sh
@@ -206,10 +209,11 @@ WINK_VALIDATION_AX_WINDOW_OBSERVATION_FAULT_INJECTION=1 bash scripts/package-app
 
 The resulting bundle carries
 `WinkRuntimeValidationProfile=ax-window-observation-fault-injection` and accepts
-exactly one argument in this form:
+exactly one argument in one of these forms:
 
 ```text
 --validation-ax-window-observation-fault=deactivation-once:<target-bundle-id>
+--validation-ax-window-observation-fault=activation-persistent:<target-bundle-id>
 ```
 
 Before the target loses frontmost status, window reads remain on the real AX
@@ -221,6 +225,36 @@ Validation must show a `POST_HIDE_STATE` line with
 `windowObservationSucceeded=false`, `confirmed=false`, and
 `phase=deactivating`, followed by a real hide or
 `NSWorkspace.didHideApplicationNotification` completing that same attempt.
+
+For `activation-persistent`, each matching read records
+`event=window_evidence_withheld`, an ordinal, real frontmost/active/hidden
+state, and `windowsReadSucceeded=false`, then returns zero visible/focused/main
+evidence with reason `validationInjectedActivationWindowEvidenceFailure`.
+Matching hide requests remain real, and non-matching apps use the unmodified AX
+observation path. With no validation argument the driver is not created; the
+default clean package does not compile the seam at all.
+
+Validate the retry cap and absolute ceiling in separate launches because the
+default retry cap can terminate the attempt before the ceiling. Use a standard
+Calculator fixture such as Control+Option+Command+J (Ctrl+Alt+Win+J on a
+Windows-layout keyboard; no Fn or Caps Lock). For the cap run, trigger once
+through recovery exhaustion, then repeat after at least 600 ms while keeping
+each gap below the 2-second degraded-idle expiry: retry 1, retry 2, then a
+fourth trigger must report `retry_capped`. The terminal repeat must add zero
+observation, activation, hide, AX raise, reopen, Command-N, or scheduled-
+confirmation side effects. For the ceiling run, start a new session and trigger
+near t=0, 1.6, 3.3, and 5.2 seconds. Each degraded gap remains below the idle
+expiry while the final trigger crosses the 5-second ceiling before the retry
+cap; that slice must report `absolute_ceiling_reached` and likewise add zero
+side effects. Both traces must retain one `attemptId` and generation through
+`degraded → activating → degraded`, then finish in `idle` with
+`result=retry_capped` or `result=absolute_ceiling_reached`.
+
+After preserving the injected bundle and sanitized trace, rebuild the default
+package from the same exact head. Relaunch without a validation argument and
+prove that the same target reaches `activeStable` and toggles off normally.
+Then run standard-only and mixed standard+Hyper E2E plus a physical held-key
+repeat check against that clean bundle.
 
 The launch, EventTap, Carbon handler, Carbon binding, and AX window-observation
 injection profiles are mutually exclusive. Preserve each injected bundle at a

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -16,6 +16,8 @@
 #     --validation-carbon-binding-fault=permanent-conflict:38:6400
 #   open -n build/Wink.app --args \
 #     --validation-ax-window-observation-fault=deactivation-once:com.apple.Calculator
+#   open -n build/Wink.app --args \
+#     --validation-ax-window-observation-fault=activation-persistent:com.apple.Calculator
 set -euo pipefail
 
 APP_NAME="Wink"


### PR DESCRIPTION
Fixes #319

## Summary

- Keep exhausted activation recovery in a generation-owned degraded session instead of clearing ownership to idle.
- Route degraded repeat triggers through one atomic coordinator decision that preserves the attempt/generation and enforces idle expiry, retry cap, and absolute ceiling before any new observation or side effect.
- Return immediately on cap/ceiling termination, protect newer generations from stale termination/reset, and retain healthy stable/toggle-off behavior.
- Add AppSwitcher integration coverage, compile-time-only persistent window-evidence fault injection, and matching architecture/runtime validation documentation.

## Acceptance mapping

- Recovery exhaustion: integration tests and packaged traces show `phase=degraded reason="activation_recovery_exhausted"` under the owning attempt/generation.
- Production reconfirm: physical repeat traces enter `event=degraded_reconfirm`; accepted repeats keep the same attempt ID and generation.
- Bounded recovery: separate physical launches prove retry cap and 5000 ms absolute ceiling, each with two accepted retries and zero observation, AX raise, reopen, Command-N, hide, activation, or recovery side effects after the terminal decision.
- Stable promotion: integration coverage proves `degraded → activating → activeStable`; the packaged healthy run reaches `activeStable` and toggles off normally.
- Lifecycle ownership: targeted tests cover termination, explicit reset, stale generations, and a newer degraded/activating session.
- Regression behavior: full tests, clean standard/mixed E2E, and clean physical held-key evidence cover active-stable toggle-off, `ACTIVE_UNTRACKED`, windowless apps, cooldown, and repeat handling.
- Production seam exclusion: injected and clean packages were built from the same SHA; clean metadata/marker scans and compile-time tests prove production configuration cannot activate the seam.
- Documentation: architecture, handoff, lessons, signing/release, and packaging guidance match the final transition graph and validation profile.

## Exact-head verification

- Base SHA: `3a964b4cf7f682a55b80989410e1bca629669c6e`
- Final reviewed/source SHA: `29660ba33ce434463e8e1aaf0c172c488e48df6c`
- Targeted degraded integration suite: 11 tests PASS.
- Compile-time fault-injection suite: 4 tests PASS.
- `swift test`: 480 tests / 44 suites PASS.
- `swift build -c release`: PASS.
- Injected and clean `bash scripts/package-app.sh`: PASS.
- Standards review against the recorded base: PASS, no confirmed findings.
- Spec review against the same base: PASS, no confirmed findings.

## Exact-head packaged runtime evidence

- Host: macOS 15.7.5 (24G624), arm64.
- Injected app: `/Users/yvan/developer/Wink/.worktrees/issue-319-degraded-recovery/build/validation/issue-319-29660ba33ce434463e8e1aaf0c172c488e48df6c-20260718T081528Z/bundles/Wink-injected.app`.
- Injected executable SHA-256: `f1c6b17f7ef6c5c568483fcb6039cd47539037905a728f88e956380214201f4d`.
- Clean app: `/Users/yvan/developer/Wink/.worktrees/issue-319-degraded-recovery/build/validation/issue-319-29660ba33ce434463e8e1aaf0c172c488e48df6c-20260718T081528Z/bundles/Wink-clean.app`.
- Clean executable SHA-256: `8c55e1c561e4c8e0a378b8d968da7fe8a9a1f71db84f81a46736e519fc308eaf`.
- Both bundles pass strict deep codesign verification; the clean bundle has no validation profile/revision or injection marker.
- Physical retry-cap run: 4 `MATCHED`, one attempt/generation, accepted retry counts 1 and 2, then `retry_capped` at 1885 ms; 0 post-terminal side effects.
- Physical absolute-ceiling run: 4 `MATCHED`, one attempt/generation, accepted retry counts 1 and 2, then `absolute_ceiling_reached` at 5653 ms for the configured 5000 ms ceiling; 0 post-terminal side effects.
- Same injected bundle without a validation argument: healthy Calculator activation reached `activeStable`, then normal toggle-off confirmed; no injection/degraded/recovery line.
- Clean standard-only E2E: 0 FAIL; one expected WARN because that fixture intentionally has no Hyper binding.
- Clean mixed standard + Hyper canonical rerun: 6/6 PASS, 0 WARN. The preserved first run had a legacy unstructured `MATCHED` slice race while its structured route/attempt/frontmost/hide evidence and the other five modules passed; the unchanged-package rerun was clean.
- Clean physical held-key run: one `MATCHED`, one generation, one stable confirmation, and 0 hide/degraded/recovery events while Ctrl+Option+Command+J was held for about 3 seconds.
- Complete sanitized ledger: `/Users/yvan/developer/Wink/.worktrees/issue-319-degraded-recovery/build/validation/issue-319-29660ba33ce434463e8e1aaf0c172c488e48df6c-20260718T081528Z/RESULTS.md`.

## State restoration

- Original shortcut payload restored and verified after relaunch at SHA-256 `821b3cfd866445435ace749f4b711c63e7f41a8c096d8b162134bb689e764113`.
- Original defaults imported and original debug log restored before normal logging resumed.
- Validation packages stopped; normal `/Users/yvan/developer/Wink/build/Wink.app` relaunched with its original arguments.

## Validation Status

- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs sync check

- [x] Architecture, handoff, lessons, signing/release, and packaging guidance updated.
- [x] No archive document is used as current source of truth.
