### PR TITLE
Make UsageTracker date keys locale-stable and migrate localized digits

### DIFF
--- a/Sources/Wink/Protocols/UsageTracking.swift
+++ b/Sources/Wink/Protocols/UsageTracking.swift
@@ -13,6 +13,20 @@ enum UsageWindowMath {
         return calendar
     }
 
+    /// Canonical formatter for persisted usage date keys. `en_US_POSIX` pins
+    /// ASCII digits so keys stay byte-stable and lexicographically ordered
+    /// regardless of the user's locale or numbering system (issue #323);
+    /// Arabic/Persian locales otherwise emit localized digits that fall
+    /// outside ASCII TEXT range queries.
+    static func dateKeyFormatter(timeZone: TimeZone) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = timeZone
+        return formatter
+    }
+
     static func previousWindowReference(days: Int, relativeTo now: Date, in timeZone: TimeZone) -> Date {
         calendar(timeZone: timeZone).date(byAdding: .day, value: -max(days, 1), to: now) ?? now
     }

--- a/Sources/Wink/Services/PersistenceService.swift
+++ b/Sources/Wink/Services/PersistenceService.swift
@@ -190,7 +190,10 @@ struct PersistenceService: Sendable {
 }
 
 enum UsageDatabaseBootstrap {
-    static let requiredSchemaVersion = 2
+    static let requiredSchemaVersion = 3
+    /// Hourly schema whose only delta to v3 is that date keys may carry
+    /// localized (non-ASCII) digits; migrated in place, never reset.
+    static let localeMigratableSchemaVersion = 2
 
     static func prepareDatabase(
         at path: String,
@@ -225,12 +228,18 @@ enum UsageDatabaseBootstrap {
         let userVersion = integerPragma("PRAGMA user_version", in: db) ?? 0
         let dailyColumns = tableColumns(named: "daily_usage", in: db)
         let hourlyColumns = tableColumns(named: "usage_hourly", in: db)
-        let shouldReset =
-            userVersion != requiredSchemaVersion ||
-            dailyColumns != ["shortcut_id", "date", "count"] ||
-            hourlyColumns != ["shortcut_id", "date", "hour", "count"]
+        let columnsMatchHourlySchema =
+            dailyColumns == ["shortcut_id", "date", "count"] &&
+            hourlyColumns == ["shortcut_id", "date", "hour", "count"]
 
-        guard shouldReset else {
+        if userVersion == requiredSchemaVersion && columnsMatchHourlySchema {
+            return
+        }
+
+        if userVersion == localeMigratableSchemaVersion && columnsMatchHourlySchema {
+            // On failure the transaction rolls back and user_version stays at
+            // v2, so the next launch retries instead of losing history.
+            migrateDateKeysToASCII(in: db, path: path, diagnosticClient: diagnosticClient)
             return
         }
 
@@ -251,6 +260,186 @@ enum UsageDatabaseBootstrap {
             logger.error("\(message, privacy: .public)")
             diagnosticClient.log(message)
         }
+    }
+
+    /// Reads the schema version recorded in the database header.
+    static func schemaVersion(in db: OpaquePointer?) -> Int? {
+        integerPragma("PRAGMA user_version", in: db)
+    }
+
+    /// Maps a persisted date key to canonical ASCII `yyyy-MM-dd`, translating
+    /// decimal digits from any numbering system (Arabic-Indic, Eastern
+    /// Arabic/Persian, ...). Returns nil when the key does not have the
+    /// expected shape, so unrecognizable rows are left untouched rather than
+    /// guessed at.
+    static func normalizedASCIIDateKey(_ key: String) -> String? {
+        var ascii = ""
+        for character in key {
+            if character == "-" {
+                ascii.append("-")
+                continue
+            }
+
+            guard
+                character.unicodeScalars.count == 1,
+                let scalar = character.unicodeScalars.first,
+                scalar.properties.numericType == .decimal,
+                let digit = character.wholeNumberValue,
+                (0...9).contains(digit)
+            else {
+                return nil
+            }
+
+            ascii.append(String(digit))
+        }
+
+        let shape = ascii.split(separator: "-", omittingEmptySubsequences: false)
+        guard shape.count == 3, shape[0].count == 4, shape[1].count == 2, shape[2].count == 2 else {
+            return nil
+        }
+
+        return ascii
+    }
+
+    private static func migrateDateKeysToASCII(
+        in db: OpaquePointer?,
+        path: String,
+        diagnosticClient: PersistenceService.DiagnosticClient
+    ) {
+        guard executeSQL("BEGIN IMMEDIATE", in: db) else {
+            logMigrationFailure(path: path, reason: "begin failed: \(errorMessage(in: db))", diagnosticClient: diagnosticClient)
+            return
+        }
+
+        var normalizedKeyCounts: [String: Int] = [:]
+        let tables: [(name: String, mergeSQL: String)] = [
+            (
+                name: "daily_usage",
+                mergeSQL: """
+                    INSERT INTO daily_usage (shortcut_id, date, count)
+                    SELECT shortcut_id, ?1, count FROM daily_usage WHERE date = ?2
+                    ON CONFLICT(shortcut_id, date) DO UPDATE SET count = count + excluded.count
+                    """
+            ),
+            (
+                name: "usage_hourly",
+                mergeSQL: """
+                    INSERT INTO usage_hourly (shortcut_id, date, hour, count)
+                    SELECT shortcut_id, ?1, hour, count FROM usage_hourly WHERE date = ?2
+                    ON CONFLICT(shortcut_id, date, hour) DO UPDATE SET count = count + excluded.count
+                    """
+            ),
+        ]
+
+        for table in tables {
+            let dateKeys = stringColumnValues("SELECT DISTINCT date FROM \(table.name)", in: db)
+            for key in dateKeys {
+                guard let normalized = normalizedASCIIDateKey(key), normalized != key else {
+                    continue
+                }
+
+                guard
+                    executeUpdate(table.mergeSQL, bindings: [normalized, key], in: db),
+                    executeUpdate("DELETE FROM \(table.name) WHERE date = ?1", bindings: [key], in: db)
+                else {
+                    _ = executeSQL("ROLLBACK", in: db)
+                    logMigrationFailure(
+                        path: path,
+                        reason: "normalizing \(table.name) key failed: \(errorMessage(in: db))",
+                        diagnosticClient: diagnosticClient
+                    )
+                    return
+                }
+
+                normalizedKeyCounts[table.name, default: 0] += 1
+            }
+        }
+
+        guard
+            executeSQL("PRAGMA user_version = \(requiredSchemaVersion)", in: db),
+            executeSQL("COMMIT", in: db)
+        else {
+            _ = executeSQL("ROLLBACK", in: db)
+            logMigrationFailure(path: path, reason: "commit failed: \(errorMessage(in: db))", diagnosticClient: diagnosticClient)
+            return
+        }
+
+        let message = """
+            Migrated usage date keys to locale-stable schema v\(requiredSchemaVersion): path=\(path) \
+            dailyKeysNormalized=\(normalizedKeyCounts["daily_usage", default: 0]) \
+            hourlyKeysNormalized=\(normalizedKeyCounts["usage_hourly", default: 0])
+            """
+        logger.info("\(message, privacy: .public)")
+        diagnosticClient.log(message)
+    }
+
+    private static func logMigrationFailure(
+        path: String,
+        reason: String,
+        diagnosticClient: PersistenceService.DiagnosticClient
+    ) {
+        let message = "Failed to migrate usage date keys to locale-stable schema: path=\(path) reason=\(reason)"
+        logger.error("\(message, privacy: .public)")
+        diagnosticClient.log(message)
+    }
+
+    private static func errorMessage(in db: OpaquePointer?) -> String {
+        guard let db else {
+            return "unknown"
+        }
+        return String(cString: sqlite3_errmsg(db))
+    }
+
+    private static func executeSQL(_ sql: String, in db: OpaquePointer?) -> Bool {
+        guard let db else {
+            return false
+        }
+        return sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK
+    }
+
+    private static func executeUpdate(_ sql: String, bindings: [String], in db: OpaquePointer?) -> Bool {
+        guard let db else {
+            return false
+        }
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            sqlite3_finalize(stmt)
+            return false
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        for (index, value) in bindings.enumerated() {
+            guard sqlite3_bind_text(stmt, Int32(index + 1), (value as NSString).utf8String, -1, transient) == SQLITE_OK else {
+                return false
+            }
+        }
+
+        return sqlite3_step(stmt) == SQLITE_DONE
+    }
+
+    private static func stringColumnValues(_ sql: String, in db: OpaquePointer?) -> [String] {
+        guard let db else {
+            return []
+        }
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            sqlite3_finalize(stmt)
+            return []
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var values: [String] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let text = sqlite3_column_text(stmt, 0) else {
+                continue
+            }
+            values.append(String(cString: text))
+        }
+
+        return values
     }
 
     private static func integerPragma(_ sql: String, in db: OpaquePointer?) -> Int? {

--- a/Sources/Wink/Services/PersistenceService.swift
+++ b/Sources/Wink/Services/PersistenceService.swift
@@ -332,7 +332,16 @@ enum UsageDatabaseBootstrap {
         ]
 
         for table in tables {
-            let dateKeys = stringColumnValues("SELECT DISTINCT date FROM \(table.name)", in: db)
+            // A failed key scan must abort the migration: treating it as an
+            // empty table would commit and stamp v3 with localized rows still
+            // unread, which this migration exists to prevent.
+            guard let dateKeys = stringColumnValues("SELECT DISTINCT date FROM \(table.name)", in: db) else {
+                let reason = "reading \(table.name) date keys failed: \(errorMessage(in: db))"
+                _ = executeSQL("ROLLBACK", in: db)
+                logMigrationFailure(path: path, reason: reason, diagnosticClient: diagnosticClient)
+                return
+            }
+
             for key in dateKeys {
                 guard let normalized = normalizedASCIIDateKey(key), normalized != key else {
                     continue
@@ -342,12 +351,11 @@ enum UsageDatabaseBootstrap {
                     executeUpdate(table.mergeSQL, bindings: [normalized, key], in: db),
                     executeUpdate("DELETE FROM \(table.name) WHERE date = ?1", bindings: [key], in: db)
                 else {
+                    // Capture the failure before ROLLBACK: a successful
+                    // rollback resets sqlite3_errmsg to "not an error".
+                    let reason = "normalizing \(table.name) key failed: \(errorMessage(in: db))"
                     _ = executeSQL("ROLLBACK", in: db)
-                    logMigrationFailure(
-                        path: path,
-                        reason: "normalizing \(table.name) key failed: \(errorMessage(in: db))",
-                        diagnosticClient: diagnosticClient
-                    )
+                    logMigrationFailure(path: path, reason: reason, diagnosticClient: diagnosticClient)
                     return
                 }
 
@@ -359,8 +367,9 @@ enum UsageDatabaseBootstrap {
             executeSQL("PRAGMA user_version = \(requiredSchemaVersion)", in: db),
             executeSQL("COMMIT", in: db)
         else {
+            let reason = "commit failed: \(errorMessage(in: db))"
             _ = executeSQL("ROLLBACK", in: db)
-            logMigrationFailure(path: path, reason: "commit failed: \(errorMessage(in: db))", diagnosticClient: diagnosticClient)
+            logMigrationFailure(path: path, reason: reason, diagnosticClient: diagnosticClient)
             return
         }
 
@@ -419,27 +428,33 @@ enum UsageDatabaseBootstrap {
         return sqlite3_step(stmt) == SQLITE_DONE
     }
 
-    private static func stringColumnValues(_ sql: String, in db: OpaquePointer?) -> [String] {
+    /// Returns nil on any prepare or step error so callers can distinguish
+    /// "no rows" from a scan that ended early (corruption, I/O error).
+    private static func stringColumnValues(_ sql: String, in db: OpaquePointer?) -> [String]? {
         guard let db else {
-            return []
+            return nil
         }
 
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             sqlite3_finalize(stmt)
-            return []
+            return nil
         }
         defer { sqlite3_finalize(stmt) }
 
         var values: [String] = []
-        while sqlite3_step(stmt) == SQLITE_ROW {
-            guard let text = sqlite3_column_text(stmt, 0) else {
-                continue
+        while true {
+            switch sqlite3_step(stmt) {
+            case SQLITE_ROW:
+                if let text = sqlite3_column_text(stmt, 0) {
+                    values.append(String(cString: text))
+                }
+            case SQLITE_DONE:
+                return values
+            default:
+                return nil
             }
-            values.append(String(cString: text))
         }
-
-        return values
     }
 
     private static func integerPragma(_ sql: String, in db: OpaquePointer?) -> Int? {

--- a/Sources/Wink/Services/UsageTracker.swift
+++ b/Sources/Wink/Services/UsageTracker.swift
@@ -477,7 +477,6 @@ actor UsageTracker: UsageTracking {
                 ON usage_hourly(date, hour);
             CREATE INDEX IF NOT EXISTS idx_daily_usage_date
                 ON daily_usage(date);
-            PRAGMA user_version = \(UsageDatabaseBootstrap.requiredSchemaVersion);
             """
 
         var errorMessage: UnsafeMutablePointer<CChar>?
@@ -487,6 +486,20 @@ actor UsageTracker: UsageTracking {
             DiagnosticLog.log("Failed to create usage tables: \(error)")
             sqlite3_free(errorMessage)
             return
+        }
+
+        // Only a fresh database (user_version 0) is stamped here. Existing
+        // files reach this point already stamped by the bootstrap, except a
+        // v2 file whose locale migration failed — that one must keep its old
+        // version so the next launch retries the migration instead of having
+        // an unconditional stamp mask it forever.
+        if UsageDatabaseBootstrap.schemaVersion(in: db) == 0 {
+            let stampSQL = "PRAGMA user_version = \(UsageDatabaseBootstrap.requiredSchemaVersion)"
+            if sqlite3_exec(db, stampSQL, nil, nil, nil) != SQLITE_OK {
+                let error = String(cString: sqlite3_errmsg(db))
+                logger.error("Failed to stamp usage schema version: \(error, privacy: .public)")
+                DiagnosticLog.log("Failed to stamp usage schema version: \(error)")
+            }
         }
     }
 
@@ -580,10 +593,6 @@ actor UsageTracker: UsageTracking {
     }
 
     private static func makeDateFormatter(for timeZone: TimeZone) -> (DateFormatter, String) {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = timeZone
-        return (formatter, timeZone.identifier)
+        (UsageWindowMath.dateKeyFormatter(timeZone: timeZone), timeZone.identifier)
     }
 }

--- a/Sources/Wink/UI/Insights/InsightsHourlyHeatmap.swift
+++ b/Sources/Wink/UI/Insights/InsightsHourlyHeatmap.swift
@@ -106,10 +106,7 @@ struct InsightsHourlyHeatmap: View {
     }
 
     private func dayLabel(for dateString: String) -> String {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = .current
+        let formatter = UsageWindowMath.dateKeyFormatter(timeZone: .current)
 
         guard let date = formatter.date(from: dateString) else {
             return dateString

--- a/Sources/Wink/UI/InsightsViewModel.swift
+++ b/Sources/Wink/UI/InsightsViewModel.swift
@@ -249,10 +249,7 @@ final class InsightsViewModel {
 
     private static func dateKeys(days: Int, relativeTo now: Date, timeZone: TimeZone) -> [String] {
         let window = UsageWindowMath.windowDates(days: days, relativeTo: now, in: timeZone)
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = timeZone
+        let formatter = UsageWindowMath.dateKeyFormatter(timeZone: timeZone)
 
         return window.days.map { date in
             formatter.string(from: date)

--- a/Tests/WinkTests/PersistenceServiceTests.swift
+++ b/Tests/WinkTests/PersistenceServiceTests.swift
@@ -584,7 +584,12 @@ struct UsageDateKeyLocaleMigrationTests {
         #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S1' AND date = '2025-01-01'", at: databaseURL) == 3)
         #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S1' AND date = '\(Self.arabicKey)'", at: databaseURL) == 2)
         #expect(try rowCount("SELECT COUNT(*) FROM usage_hourly", at: databaseURL) == 4)
-        #expect(diagnostics.messages.contains { $0.contains("Failed to migrate usage date keys") })
+        // The reason must carry the actual SQLite failure, captured before
+        // ROLLBACK resets sqlite3_errmsg to "not an error".
+        #expect(diagnostics.messages.contains {
+            $0.contains("Failed to migrate usage date keys")
+                && $0.contains("forced hourly normalization failure")
+        })
         #expect(FileManager.default.fileExists(atPath: databaseURL.path))
 
         // A fresh UsageTracker boot over the failed migration must not stamp

--- a/Tests/WinkTests/PersistenceServiceTests.swift
+++ b/Tests/WinkTests/PersistenceServiceTests.swift
@@ -455,6 +455,211 @@ struct UsageDatabaseBootstrapTests {
     }
 }
 
+@Suite("Usage date key locale migration")
+struct UsageDateKeyLocaleMigrationTests {
+    private static let arabicKey = "\u{0662}\u{0660}\u{0662}\u{0665}-\u{0660}\u{0661}-\u{0660}\u{0661}"
+    private static let persianSameDayKey = "\u{06F2}\u{06F0}\u{06F2}\u{06F5}-\u{06F0}\u{06F1}-\u{06F0}\u{06F1}"
+    private static let persianOtherDayKey = "\u{06F2}\u{06F0}\u{06F2}\u{06F5}-\u{06F0}\u{06F1}-\u{06F0}\u{06F2}"
+    private static let malformedKey = "\u{0662}\u{0660}\u{0662}\u{0665}-\u{0660}\u{0661}"
+
+    @Test
+    func dateKeyFormatterPinsPOSIXLocaleAndEmitsASCIIKeys() {
+        let formatter = UsageWindowMath.dateKeyFormatter(timeZone: TimeZone(secondsFromGMT: 0)!)
+
+        #expect(formatter.locale.identifier == "en_US_POSIX")
+        #expect(formatter.string(from: isoDateTime("2025-01-01T12:00:00Z")) == "2025-01-01")
+
+        // The bug this pin fixes: an unpinned formatter under an Arabic
+        // locale emits localized digits for the same Gregorian date.
+        let unpinned = DateFormatter()
+        unpinned.locale = Locale(identifier: "ar_SA")
+        unpinned.calendar = Calendar(identifier: .gregorian)
+        unpinned.dateFormat = "yyyy-MM-dd"
+        unpinned.timeZone = TimeZone(secondsFromGMT: 0)
+        #expect(unpinned.string(from: isoDateTime("2025-01-01T12:00:00Z")) == Self.arabicKey)
+    }
+
+    @Test
+    func normalizedASCIIDateKeyTranslatesLocalizedDigitsAndRejectsMalformedKeys() {
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey(Self.arabicKey) == "2025-01-01")
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey(Self.persianSameDayKey) == "2025-01-01")
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey("2025-01-01") == "2025-01-01")
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey(Self.malformedKey) == nil)
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey("2025-01-0a") == nil)
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey("") == nil)
+    }
+
+    @Test
+    func migrationNormalizesLocalizedKeysInPlaceAndMergesCollisions() throws {
+        let harness = TestPersistenceHarness()
+        defer { harness.cleanup() }
+        let diagnostics = DiagnosticRecorder()
+        let databaseURL = harness.directory.appendingPathComponent("usage.db")
+
+        try seedLocalizedV2UsageDatabase(at: databaseURL)
+
+        UsageDatabaseBootstrap.prepareDatabase(
+            at: databaseURL.path,
+            diagnosticClient: .init(log: { diagnostics.append($0) })
+        )
+
+        #expect(FileManager.default.fileExists(atPath: databaseURL.path))
+        #expect(try userVersion(at: databaseURL) == UsageDatabaseBootstrap.requiredSchemaVersion)
+
+        // S1 2025-01-01 merges ASCII(3) + Arabic-Indic(2) + Persian(7) = 12.
+        #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S1' AND date = '2025-01-01'", at: databaseURL) == 12)
+        // S2 Persian-only key normalizes without collision.
+        #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S2' AND date = '2025-01-02'", at: databaseURL) == 5)
+        // Malformed key is preserved untouched rather than guessed at.
+        #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S3' AND date = '\(Self.malformedKey)'", at: databaseURL) == 1)
+        // Every other daily key is ASCII now.
+        #expect(try rowCount("SELECT COUNT(*) FROM daily_usage WHERE date GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'", at: databaseURL) == 2)
+        #expect(try rowCount("SELECT COUNT(*) FROM daily_usage", at: databaseURL) == 3)
+        // Global daily total is exactly preserved after merging.
+        #expect(try rowCount("SELECT SUM(count) FROM daily_usage", at: databaseURL) == 18)
+
+        // Hourly: same-hour collision merges, distinct hour normalizes alongside.
+        #expect(try rowCount("SELECT count FROM usage_hourly WHERE shortcut_id = 'S1' AND date = '2025-01-01' AND hour = 9", at: databaseURL) == 5)
+        #expect(try rowCount("SELECT count FROM usage_hourly WHERE shortcut_id = 'S1' AND date = '2025-01-01' AND hour = 10", at: databaseURL) == 4)
+        #expect(try rowCount("SELECT count FROM usage_hourly WHERE shortcut_id = 'S2' AND date = '2025-01-02' AND hour = 0", at: databaseURL) == 5)
+        #expect(try rowCount("SELECT COUNT(*) FROM usage_hourly", at: databaseURL) == 3)
+        #expect(try rowCount("SELECT SUM(count) FROM usage_hourly", at: databaseURL) == 14)
+
+        #expect(diagnostics.messages.contains {
+            $0.contains("Migrated usage date keys to locale-stable schema v3")
+                && $0.contains("dailyKeysNormalized=3")
+                && $0.contains("hourlyKeysNormalized=3")
+        })
+        #expect(diagnostics.messages.allSatisfy { !$0.contains("Reset usage database") })
+    }
+
+    @Test
+    func migrationIsIdempotentAcrossRepeatedBootstraps() throws {
+        let harness = TestPersistenceHarness()
+        defer { harness.cleanup() }
+        let databaseURL = harness.directory.appendingPathComponent("usage.db")
+
+        try seedLocalizedV2UsageDatabase(at: databaseURL)
+
+        for _ in 0..<3 {
+            UsageDatabaseBootstrap.prepareDatabase(at: databaseURL.path, diagnosticClient: .init(log: { _ in }))
+        }
+
+        #expect(try userVersion(at: databaseURL) == UsageDatabaseBootstrap.requiredSchemaVersion)
+        #expect(try rowCount("SELECT SUM(count) FROM daily_usage", at: databaseURL) == 18)
+        #expect(try rowCount("SELECT COUNT(*) FROM daily_usage", at: databaseURL) == 3)
+        #expect(try rowCount("SELECT SUM(count) FROM usage_hourly", at: databaseURL) == 14)
+        #expect(try rowCount("SELECT COUNT(*) FROM usage_hourly", at: databaseURL) == 3)
+    }
+
+    @Test
+    func failedMigrationRollsBackBothTablesAndKeepsRetryableVersion() throws {
+        let harness = TestPersistenceHarness()
+        defer { harness.cleanup() }
+        let diagnostics = DiagnosticRecorder()
+        let databaseURL = harness.directory.appendingPathComponent("usage.db")
+
+        try seedLocalizedV2UsageDatabase(at: databaseURL)
+        try withSQLiteDatabase(at: databaseURL) { db in
+            try executeSQL(
+                """
+                CREATE TRIGGER fail_usage_hourly_normalization
+                BEFORE INSERT ON usage_hourly
+                BEGIN
+                    SELECT RAISE(FAIL, 'forced hourly normalization failure');
+                END;
+                """,
+                in: db
+            )
+        }
+
+        UsageDatabaseBootstrap.prepareDatabase(
+            at: databaseURL.path,
+            diagnosticClient: .init(log: { diagnostics.append($0) })
+        )
+
+        // daily_usage was processed first; the hourly failure must roll it back too.
+        #expect(try userVersion(at: databaseURL) == UsageDatabaseBootstrap.localeMigratableSchemaVersion)
+        #expect(try rowCount("SELECT COUNT(*) FROM daily_usage", at: databaseURL) == 5)
+        #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S1' AND date = '2025-01-01'", at: databaseURL) == 3)
+        #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S1' AND date = '\(Self.arabicKey)'", at: databaseURL) == 2)
+        #expect(try rowCount("SELECT COUNT(*) FROM usage_hourly", at: databaseURL) == 4)
+        #expect(diagnostics.messages.contains { $0.contains("Failed to migrate usage date keys") })
+        #expect(FileManager.default.fileExists(atPath: databaseURL.path))
+
+        // A fresh UsageTracker boot over the failed migration must not stamp
+        // the new version and strand the localized rows.
+        _ = UsageTracker(databasePath: databaseURL.path)
+        #expect(try userVersion(at: databaseURL) == UsageDatabaseBootstrap.localeMigratableSchemaVersion)
+
+        // Removing the fault lets the next bootstrap complete the migration.
+        try withSQLiteDatabase(at: databaseURL) { db in
+            try executeSQL("DROP TRIGGER fail_usage_hourly_normalization", in: db)
+        }
+        UsageDatabaseBootstrap.prepareDatabase(at: databaseURL.path, diagnosticClient: .init(log: { _ in }))
+        #expect(try userVersion(at: databaseURL) == UsageDatabaseBootstrap.requiredSchemaVersion)
+        #expect(try rowCount("SELECT SUM(count) FROM daily_usage", at: databaseURL) == 18)
+    }
+
+    @Test
+    func trackerBootMigratesLocalizedKeysAndServesMergedQueries() async throws {
+        let harness = TestPersistenceHarness()
+        defer { harness.cleanup() }
+        let databaseURL = harness.directory.appendingPathComponent("usage.db")
+        let shortcutID = UUID()
+
+        try seedLocalizedV2UsageDatabase(at: databaseURL, shortcutID: shortcutID.uuidString)
+
+        let tracker = UsageTracker(
+            databasePath: databaseURL.path,
+            timeZoneProvider: { TimeZone(secondsFromGMT: 0)! }
+        )
+
+        let counts = await tracker.usageCounts(days: 7, relativeTo: isoDateTime("2025-01-03T12:00:00Z"))
+        #expect(counts[shortcutID] == 12)
+
+        let lastUsed = await tracker.lastUsedPerShortcut()
+        #expect(lastUsed[shortcutID] == isoDateTime("2025-01-01T10:00:00Z"))
+    }
+
+    private func seedLocalizedV2UsageDatabase(at url: URL, shortcutID: String = "S1") throws {
+        try withSQLiteDatabase(at: url) { db in
+            try executeSQL(
+                """
+                CREATE TABLE daily_usage (
+                    shortcut_id TEXT NOT NULL,
+                    date        TEXT NOT NULL,
+                    count       INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (shortcut_id, date)
+                );
+                CREATE TABLE usage_hourly (
+                    shortcut_id TEXT NOT NULL,
+                    date        TEXT NOT NULL,
+                    hour        INTEGER NOT NULL CHECK(hour BETWEEN 0 AND 23),
+                    count       INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (shortcut_id, date, hour)
+                );
+                CREATE INDEX idx_usage_hourly_date_hour ON usage_hourly(date, hour);
+                CREATE INDEX idx_daily_usage_date ON daily_usage(date);
+                INSERT INTO daily_usage (shortcut_id, date, count) VALUES
+                    ('\(shortcutID)', '2025-01-01', 3),
+                    ('\(shortcutID)', '\(Self.arabicKey)', 2),
+                    ('\(shortcutID)', '\(Self.persianSameDayKey)', 7),
+                    ('S2', '\(Self.persianOtherDayKey)', 5),
+                    ('S3', '\(Self.malformedKey)', 1);
+                INSERT INTO usage_hourly (shortcut_id, date, hour, count) VALUES
+                    ('\(shortcutID)', '2025-01-01', 9, 3),
+                    ('\(shortcutID)', '\(Self.arabicKey)', 9, 2),
+                    ('\(shortcutID)', '\(Self.persianSameDayKey)', 10, 4),
+                    ('S2', '\(Self.persianOtherDayKey)', 0, 5);
+                PRAGMA user_version = 2;
+                """,
+                in: db
+            )
+        }
+    }
+}
+
 private func isoDateTime(_ value: String) -> Date {
     let formatter = ISO8601DateFormatter()
     formatter.timeZone = TimeZone(secondsFromGMT: 0)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,9 +213,10 @@ Responsibilities:
 - `UsageTracker`
 
 Responsibilities:
-- record shortcut activations with SQLite daily and hourly aggregation using fixed Gregorian `yyyy-MM-dd` buckets
+- record shortcut activations with SQLite daily and hourly aggregation using locale-pinned (`en_US_POSIX`) ASCII Gregorian `yyyy-MM-dd` buckets, shared through `UsageWindowMath.dateKeyFormatter` by every writer and parser of persisted date keys (issue #323)
 - provide current-window counts, previous-period totals, streaks, and hourly heatmap buckets for Insights and the menu bar Today view
-- reset a legacy usage database shape explicitly before startup opens the live database, instead of keeping a half-migrated schema around
+- migrate supported v2 databases in place to schema v3 during bootstrap: localized-digit date keys are normalized to ASCII inside one transaction, primary-key collisions merge by summing counts, unrecognizable keys are left untouched, and any failure (including a failed key scan) rolls back completely and stays at v2 so the next launch retries
+- still reset only pre-v2/unknown legacy database shapes explicitly before startup opens the live database, instead of keeping a half-migrated schema around; the fresh-database version stamp happens only at `user_version` 0 so a failed migration is never masked
 - run off the main actor via Swift actor isolation
 
 ### Permissions and packaging


### PR DESCRIPTION
Fixes #323

## Summary
- Pin the persisted usage date-key codec to `en_US_POSIX` via a single shared `UsageWindowMath.dateKeyFormatter(timeZone:)`, so Arabic/Persian locales can no longer write localized-digit keys that fall outside ASCII TEXT range queries. All readers of persisted keys (UsageTracker write/parse, Insights sparkline date keys, heatmap day-label parsing) now go through the same pinned factory.
- Bump the usage schema to v3 with an in-place bootstrap migration for supported v2 databases: localized-digit date keys in `daily_usage` and `usage_hourly` are normalized to ASCII `yyyy-MM-dd` inside one `BEGIN IMMEDIATE` transaction, primary-key collisions merge by summing counts, and keys that do not have a recognizable date shape are left untouched rather than guessed at. `user_version = 3` is stamped inside the same transaction.
- v2 databases no longer pass through the destructive reset path. A failed migration rolls back completely (both tables plus version) and stays at v2 so the next launch retries; `UsageTracker.createTables` now stamps the schema version only for fresh (version 0) databases so a failed migration cannot be masked by an unconditional stamp. Pre-v2/unknown shapes keep today's reset behavior.
- Root cause: the date-key `DateFormatter` fixed calendar/format/timezone but left `locale` implicit, so `ar_SA`/`fa_IR` emit Arabic-Indic/Extended Arabic-Indic digits for the same Gregorian date (reproduced in tests), stranding history outside every ASCII range query after a language switch.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

New coverage: POSIX-pin + ar_SA localized-digit reproduction; digit-normalization shape validation; full migration with 3-way collision merge and exact total preservation (daily 18, hourly 14); idempotency across repeated bootstraps; trigger-injected mid-migration failure rolling back both tables with retryable v2 version, plus recovery after removing the fault; tracker boot over a localized v2 database serving merged `usageCounts` and `lastUsedPerShortcut`. Full suite: 486 tests / 45 suites, 0 failures. `swift build -c release` passes.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.
- If the PR touches runtime-sensitive files, the PR metadata workflow will reject `Not runtime-sensitive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
