### PR TITLE
Refresh Settings usage data when Wink becomes active

### DIFF
--- a/Sources/Wink/Protocols/UsageTracking.swift
+++ b/Sources/Wink/Protocols/UsageTracking.swift
@@ -44,6 +44,32 @@ enum UsageWindowMath {
     }
 }
 
+/// Parameters for one Insights refresh. The single `referenceDate` anchor is
+/// shared by every dataset in the resulting snapshot.
+struct UsageDashboardRequest: Sendable, Equatable {
+    /// Days in the selected period window.
+    let days: Int
+    /// Days of daily history for per-app sparklines (`max(days, 7)`).
+    let sparklineDays: Int
+    let referenceDate: Date
+}
+
+/// Every dataset one Insights refresh needs, produced from one coherent read
+/// boundary. The fixed 7-day datasets (heatmap, unused detection) reuse the
+/// period datasets when the period itself is 7 days.
+struct UsageDashboardSnapshot: Sendable {
+    let timeZone: TimeZone
+    let totalCount: Int
+    let previousPeriodTotal: Int
+    let counts: [UUID: Int]
+    let previousCounts: [UUID: Int]
+    let dailyCounts: [String: [(date: String, count: Int)]]
+    let hourlyCounts: [HourlyUsageBucket]
+    let heatmapBuckets: [HourlyUsageBucket]
+    let unusedCounts: [UUID: Int]
+    let streakDays: Int
+}
+
 protocol UsageTracking: Sendable {
     func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int]
     func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]]
@@ -53,6 +79,10 @@ protocol UsageTracking: Sendable {
     func streakDays(relativeTo now: Date) async -> Int
     func usageTimeZone() async -> TimeZone
     func lastUsedPerShortcut() async -> [UUID: Date]
+    /// Returns nil when the surrounding task was cancelled; a cancelled
+    /// refresh stops issuing further queries instead of completing the
+    /// remaining phases.
+    func dashboardSnapshot(for request: UsageDashboardRequest) async -> UsageDashboardSnapshot?
 }
 
 extension UsageTracking {
@@ -82,5 +112,65 @@ extension UsageTracking {
 
     func lastUsedPerShortcut() async -> [UUID: Date] {
         [:]
+    }
+
+    /// Serial composition over the individual query methods with a
+    /// cancellation check before each phase and the 7-day datasets
+    /// deduplicated. Conformers backed by real storage should override this
+    /// with an implementation that also guarantees one coherent read
+    /// boundary (see `UsageTracker`).
+    func dashboardSnapshot(for request: UsageDashboardRequest) async -> UsageDashboardSnapshot? {
+        guard !Task.isCancelled else { return nil }
+        let timeZone = await usageTimeZone()
+        let previousReference = UsageWindowMath.previousWindowReference(
+            days: request.days,
+            relativeTo: request.referenceDate,
+            in: timeZone
+        )
+
+        guard !Task.isCancelled else { return nil }
+        let totalCount = await totalSwitches(days: request.days, relativeTo: request.referenceDate)
+        guard !Task.isCancelled else { return nil }
+        let previousPeriodTotal = await previousPeriodTotal(days: request.days, relativeTo: request.referenceDate)
+        guard !Task.isCancelled else { return nil }
+        let counts = await usageCounts(days: request.days, relativeTo: request.referenceDate)
+        guard !Task.isCancelled else { return nil }
+        let previousCounts = await usageCounts(days: request.days, relativeTo: previousReference)
+        guard !Task.isCancelled else { return nil }
+        let dailyCounts = await dailyCounts(days: request.sparklineDays, relativeTo: request.referenceDate)
+        guard !Task.isCancelled else { return nil }
+        let hourlyCounts = await hourlyCounts(days: request.days, relativeTo: request.referenceDate)
+
+        let heatmapBuckets: [HourlyUsageBucket]
+        if request.days == 7 {
+            heatmapBuckets = hourlyCounts
+        } else {
+            guard !Task.isCancelled else { return nil }
+            heatmapBuckets = await self.hourlyCounts(days: 7, relativeTo: request.referenceDate)
+        }
+
+        let unusedCounts: [UUID: Int]
+        if request.days == 7 {
+            unusedCounts = counts
+        } else {
+            guard !Task.isCancelled else { return nil }
+            unusedCounts = await usageCounts(days: 7, relativeTo: request.referenceDate)
+        }
+
+        guard !Task.isCancelled else { return nil }
+        let streakDays = await streakDays(relativeTo: request.referenceDate)
+
+        return UsageDashboardSnapshot(
+            timeZone: timeZone,
+            totalCount: totalCount,
+            previousPeriodTotal: previousPeriodTotal,
+            counts: counts,
+            previousCounts: previousCounts,
+            dailyCounts: dailyCounts,
+            hourlyCounts: hourlyCounts,
+            heatmapBuckets: heatmapBuckets,
+            unusedCounts: unusedCounts,
+            streakDays: streakDays
+        )
     }
 }

--- a/Sources/Wink/Protocols/UsageTracking.swift
+++ b/Sources/Wink/Protocols/UsageTracking.swift
@@ -13,6 +13,20 @@ enum UsageWindowMath {
         return calendar
     }
 
+    /// Canonical formatter for persisted usage date keys. `en_US_POSIX` pins
+    /// ASCII digits so keys stay byte-stable and lexicographically ordered
+    /// regardless of the user's locale or numbering system (issue #323);
+    /// Arabic/Persian locales otherwise emit localized digits that fall
+    /// outside ASCII TEXT range queries.
+    static func dateKeyFormatter(timeZone: TimeZone) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = timeZone
+        return formatter
+    }
+
     static func previousWindowReference(days: Int, relativeTo now: Date, in timeZone: TimeZone) -> Date {
         calendar(timeZone: timeZone).date(byAdding: .day, value: -max(days, 1), to: now) ?? now
     }

--- a/Sources/Wink/Protocols/UsageTracking.swift
+++ b/Sources/Wink/Protocols/UsageTracking.swift
@@ -79,6 +79,7 @@ protocol UsageTracking: Sendable {
     func streakDays(relativeTo now: Date) async -> Int
     func usageTimeZone() async -> TimeZone
     func lastUsedPerShortcut() async -> [UUID: Date]
+    func deleteUsage(shortcutId: UUID) async
     /// Returns nil when the surrounding task was cancelled; a cancelled
     /// refresh stops issuing further queries instead of completing the
     /// remaining phases.
@@ -113,6 +114,11 @@ extension UsageTracking {
     func lastUsedPerShortcut() async -> [UUID: Date] {
         [:]
     }
+
+    // deleteUsage deliberately has NO extension default: an async default
+    // alongside UsageTracker's synchronous actor method would create a
+    // sync/async overload pair, and async contexts prefer the async
+    // candidate — silently routing concrete calls to a no-op.
 
     /// Serial composition over the individual query methods with a
     /// cancellation check before each phase and the 7-day datasets

--- a/Sources/Wink/Services/PersistenceService.swift
+++ b/Sources/Wink/Services/PersistenceService.swift
@@ -190,7 +190,10 @@ struct PersistenceService: Sendable {
 }
 
 enum UsageDatabaseBootstrap {
-    static let requiredSchemaVersion = 2
+    static let requiredSchemaVersion = 3
+    /// Hourly schema whose only delta to v3 is that date keys may carry
+    /// localized (non-ASCII) digits; migrated in place, never reset.
+    static let localeMigratableSchemaVersion = 2
 
     static func prepareDatabase(
         at path: String,
@@ -225,12 +228,18 @@ enum UsageDatabaseBootstrap {
         let userVersion = integerPragma("PRAGMA user_version", in: db) ?? 0
         let dailyColumns = tableColumns(named: "daily_usage", in: db)
         let hourlyColumns = tableColumns(named: "usage_hourly", in: db)
-        let shouldReset =
-            userVersion != requiredSchemaVersion ||
-            dailyColumns != ["shortcut_id", "date", "count"] ||
-            hourlyColumns != ["shortcut_id", "date", "hour", "count"]
+        let columnsMatchHourlySchema =
+            dailyColumns == ["shortcut_id", "date", "count"] &&
+            hourlyColumns == ["shortcut_id", "date", "hour", "count"]
 
-        guard shouldReset else {
+        if userVersion == requiredSchemaVersion && columnsMatchHourlySchema {
+            return
+        }
+
+        if userVersion == localeMigratableSchemaVersion && columnsMatchHourlySchema {
+            // On failure the transaction rolls back and user_version stays at
+            // v2, so the next launch retries instead of losing history.
+            migrateDateKeysToASCII(in: db, path: path, diagnosticClient: diagnosticClient)
             return
         }
 
@@ -251,6 +260,186 @@ enum UsageDatabaseBootstrap {
             logger.error("\(message, privacy: .public)")
             diagnosticClient.log(message)
         }
+    }
+
+    /// Reads the schema version recorded in the database header.
+    static func schemaVersion(in db: OpaquePointer?) -> Int? {
+        integerPragma("PRAGMA user_version", in: db)
+    }
+
+    /// Maps a persisted date key to canonical ASCII `yyyy-MM-dd`, translating
+    /// decimal digits from any numbering system (Arabic-Indic, Eastern
+    /// Arabic/Persian, ...). Returns nil when the key does not have the
+    /// expected shape, so unrecognizable rows are left untouched rather than
+    /// guessed at.
+    static func normalizedASCIIDateKey(_ key: String) -> String? {
+        var ascii = ""
+        for character in key {
+            if character == "-" {
+                ascii.append("-")
+                continue
+            }
+
+            guard
+                character.unicodeScalars.count == 1,
+                let scalar = character.unicodeScalars.first,
+                scalar.properties.numericType == .decimal,
+                let digit = character.wholeNumberValue,
+                (0...9).contains(digit)
+            else {
+                return nil
+            }
+
+            ascii.append(String(digit))
+        }
+
+        let shape = ascii.split(separator: "-", omittingEmptySubsequences: false)
+        guard shape.count == 3, shape[0].count == 4, shape[1].count == 2, shape[2].count == 2 else {
+            return nil
+        }
+
+        return ascii
+    }
+
+    private static func migrateDateKeysToASCII(
+        in db: OpaquePointer?,
+        path: String,
+        diagnosticClient: PersistenceService.DiagnosticClient
+    ) {
+        guard executeSQL("BEGIN IMMEDIATE", in: db) else {
+            logMigrationFailure(path: path, reason: "begin failed: \(errorMessage(in: db))", diagnosticClient: diagnosticClient)
+            return
+        }
+
+        var normalizedKeyCounts: [String: Int] = [:]
+        let tables: [(name: String, mergeSQL: String)] = [
+            (
+                name: "daily_usage",
+                mergeSQL: """
+                    INSERT INTO daily_usage (shortcut_id, date, count)
+                    SELECT shortcut_id, ?1, count FROM daily_usage WHERE date = ?2
+                    ON CONFLICT(shortcut_id, date) DO UPDATE SET count = count + excluded.count
+                    """
+            ),
+            (
+                name: "usage_hourly",
+                mergeSQL: """
+                    INSERT INTO usage_hourly (shortcut_id, date, hour, count)
+                    SELECT shortcut_id, ?1, hour, count FROM usage_hourly WHERE date = ?2
+                    ON CONFLICT(shortcut_id, date, hour) DO UPDATE SET count = count + excluded.count
+                    """
+            ),
+        ]
+
+        for table in tables {
+            let dateKeys = stringColumnValues("SELECT DISTINCT date FROM \(table.name)", in: db)
+            for key in dateKeys {
+                guard let normalized = normalizedASCIIDateKey(key), normalized != key else {
+                    continue
+                }
+
+                guard
+                    executeUpdate(table.mergeSQL, bindings: [normalized, key], in: db),
+                    executeUpdate("DELETE FROM \(table.name) WHERE date = ?1", bindings: [key], in: db)
+                else {
+                    _ = executeSQL("ROLLBACK", in: db)
+                    logMigrationFailure(
+                        path: path,
+                        reason: "normalizing \(table.name) key failed: \(errorMessage(in: db))",
+                        diagnosticClient: diagnosticClient
+                    )
+                    return
+                }
+
+                normalizedKeyCounts[table.name, default: 0] += 1
+            }
+        }
+
+        guard
+            executeSQL("PRAGMA user_version = \(requiredSchemaVersion)", in: db),
+            executeSQL("COMMIT", in: db)
+        else {
+            _ = executeSQL("ROLLBACK", in: db)
+            logMigrationFailure(path: path, reason: "commit failed: \(errorMessage(in: db))", diagnosticClient: diagnosticClient)
+            return
+        }
+
+        let message = """
+            Migrated usage date keys to locale-stable schema v\(requiredSchemaVersion): path=\(path) \
+            dailyKeysNormalized=\(normalizedKeyCounts["daily_usage", default: 0]) \
+            hourlyKeysNormalized=\(normalizedKeyCounts["usage_hourly", default: 0])
+            """
+        logger.info("\(message, privacy: .public)")
+        diagnosticClient.log(message)
+    }
+
+    private static func logMigrationFailure(
+        path: String,
+        reason: String,
+        diagnosticClient: PersistenceService.DiagnosticClient
+    ) {
+        let message = "Failed to migrate usage date keys to locale-stable schema: path=\(path) reason=\(reason)"
+        logger.error("\(message, privacy: .public)")
+        diagnosticClient.log(message)
+    }
+
+    private static func errorMessage(in db: OpaquePointer?) -> String {
+        guard let db else {
+            return "unknown"
+        }
+        return String(cString: sqlite3_errmsg(db))
+    }
+
+    private static func executeSQL(_ sql: String, in db: OpaquePointer?) -> Bool {
+        guard let db else {
+            return false
+        }
+        return sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK
+    }
+
+    private static func executeUpdate(_ sql: String, bindings: [String], in db: OpaquePointer?) -> Bool {
+        guard let db else {
+            return false
+        }
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            sqlite3_finalize(stmt)
+            return false
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        let transient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+        for (index, value) in bindings.enumerated() {
+            guard sqlite3_bind_text(stmt, Int32(index + 1), (value as NSString).utf8String, -1, transient) == SQLITE_OK else {
+                return false
+            }
+        }
+
+        return sqlite3_step(stmt) == SQLITE_DONE
+    }
+
+    private static func stringColumnValues(_ sql: String, in db: OpaquePointer?) -> [String] {
+        guard let db else {
+            return []
+        }
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            sqlite3_finalize(stmt)
+            return []
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var values: [String] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let text = sqlite3_column_text(stmt, 0) else {
+                continue
+            }
+            values.append(String(cString: text))
+        }
+
+        return values
     }
 
     private static func integerPragma(_ sql: String, in db: OpaquePointer?) -> Int? {

--- a/Sources/Wink/Services/PersistenceService.swift
+++ b/Sources/Wink/Services/PersistenceService.swift
@@ -332,7 +332,16 @@ enum UsageDatabaseBootstrap {
         ]
 
         for table in tables {
-            let dateKeys = stringColumnValues("SELECT DISTINCT date FROM \(table.name)", in: db)
+            // A failed key scan must abort the migration: treating it as an
+            // empty table would commit and stamp v3 with localized rows still
+            // unread, which this migration exists to prevent.
+            guard let dateKeys = stringColumnValues("SELECT DISTINCT date FROM \(table.name)", in: db) else {
+                let reason = "reading \(table.name) date keys failed: \(errorMessage(in: db))"
+                _ = executeSQL("ROLLBACK", in: db)
+                logMigrationFailure(path: path, reason: reason, diagnosticClient: diagnosticClient)
+                return
+            }
+
             for key in dateKeys {
                 guard let normalized = normalizedASCIIDateKey(key), normalized != key else {
                     continue
@@ -342,12 +351,11 @@ enum UsageDatabaseBootstrap {
                     executeUpdate(table.mergeSQL, bindings: [normalized, key], in: db),
                     executeUpdate("DELETE FROM \(table.name) WHERE date = ?1", bindings: [key], in: db)
                 else {
+                    // Capture the failure before ROLLBACK: a successful
+                    // rollback resets sqlite3_errmsg to "not an error".
+                    let reason = "normalizing \(table.name) key failed: \(errorMessage(in: db))"
                     _ = executeSQL("ROLLBACK", in: db)
-                    logMigrationFailure(
-                        path: path,
-                        reason: "normalizing \(table.name) key failed: \(errorMessage(in: db))",
-                        diagnosticClient: diagnosticClient
-                    )
+                    logMigrationFailure(path: path, reason: reason, diagnosticClient: diagnosticClient)
                     return
                 }
 
@@ -359,8 +367,9 @@ enum UsageDatabaseBootstrap {
             executeSQL("PRAGMA user_version = \(requiredSchemaVersion)", in: db),
             executeSQL("COMMIT", in: db)
         else {
+            let reason = "commit failed: \(errorMessage(in: db))"
             _ = executeSQL("ROLLBACK", in: db)
-            logMigrationFailure(path: path, reason: "commit failed: \(errorMessage(in: db))", diagnosticClient: diagnosticClient)
+            logMigrationFailure(path: path, reason: reason, diagnosticClient: diagnosticClient)
             return
         }
 
@@ -419,27 +428,33 @@ enum UsageDatabaseBootstrap {
         return sqlite3_step(stmt) == SQLITE_DONE
     }
 
-    private static func stringColumnValues(_ sql: String, in db: OpaquePointer?) -> [String] {
+    /// Returns nil on any prepare or step error so callers can distinguish
+    /// "no rows" from a scan that ended early (corruption, I/O error).
+    private static func stringColumnValues(_ sql: String, in db: OpaquePointer?) -> [String]? {
         guard let db else {
-            return []
+            return nil
         }
 
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
             sqlite3_finalize(stmt)
-            return []
+            return nil
         }
         defer { sqlite3_finalize(stmt) }
 
         var values: [String] = []
-        while sqlite3_step(stmt) == SQLITE_ROW {
-            guard let text = sqlite3_column_text(stmt, 0) else {
-                continue
+        while true {
+            switch sqlite3_step(stmt) {
+            case SQLITE_ROW:
+                if let text = sqlite3_column_text(stmt, 0) {
+                    values.append(String(cString: text))
+                }
+            case SQLITE_DONE:
+                return values
+            default:
+                return nil
             }
-            values.append(String(cString: text))
         }
-
-        return values
     }
 
     private static func integerPragma(_ sql: String, in db: OpaquePointer?) -> Int? {

--- a/Sources/Wink/Services/ShortcutEditorState.swift
+++ b/Sources/Wink/Services/ShortcutEditorState.swift
@@ -83,7 +83,8 @@ final class ShortcutEditorState {
 
     private let shortcutStore: ShortcutStore
     private let shortcutManager: ShortcutManager
-    private let usageTracker: UsageTracker?
+    private let usageTracker: (any UsageTracking)?
+    @ObservationIgnored private var usageRefreshGeneration: UInt64 = 0
     private let onShortcutConfigurationChange: @MainActor () -> Void
     private let shortcutValidator = ShortcutValidator()
     private let recipeCodec: WinkRecipeCodec
@@ -94,7 +95,7 @@ final class ShortcutEditorState {
     init(
         shortcutStore: ShortcutStore,
         shortcutManager: ShortcutManager,
-        usageTracker: UsageTracker? = nil,
+        usageTracker: (any UsageTracking)? = nil,
         recipeCodec: WinkRecipeCodec = WinkRecipeCodec(),
         recipeImportPlanner: WinkRecipeImportPlanner = WinkRecipeImportPlanner(),
         recipeTransferClient: RecipeTransferClient = .live,
@@ -323,12 +324,25 @@ final class ShortcutEditorState {
         pendingRecipeImport = nil
     }
 
+    /// Fire-and-forget wrapper for lifecycle triggers (tab selection, app
+    /// reactivation) that have no async context of their own.
+    func scheduleUsageRefresh() {
+        Task { await refreshUsageCounts() }
+    }
+
     func refreshUsageCounts() async {
         guard let usageTracker else { return }
+        usageRefreshGeneration &+= 1
+        let generation = usageRefreshGeneration
         async let counts = usageTracker.usageCounts(days: 7)
         async let lastUsedMap = usageTracker.lastUsedPerShortcut()
-        usageCounts = await counts
-        lastUsed = await lastUsedMap
+        let fetchedCounts = await counts
+        let fetchedLastUsed = await lastUsedMap
+        // A newer refresh owns the published maps; dropping the stale result
+        // keeps usageCounts/lastUsed from mixing two different fetches.
+        guard generation == usageRefreshGeneration else { return }
+        usageCounts = fetchedCounts
+        lastUsed = fetchedLastUsed
     }
 
     /// Saves through the manager (disk first, then in-memory store). On

--- a/Sources/Wink/Services/UsageTracker.swift
+++ b/Sources/Wink/Services/UsageTracker.swift
@@ -377,20 +377,34 @@ actor UsageTracker: UsageTracking {
         timeZoneProvider()
     }
 
-    func lastUsedPerShortcut() async -> [UUID: Date] {
-        let sql = """
-            SELECT shortcut_id, date, hour
-            FROM (
-                SELECT shortcut_id, date, hour,
-                       ROW_NUMBER() OVER (
-                           PARTITION BY shortcut_id
-                           ORDER BY date DESC, hour DESC
-                       ) AS rn
+    /// Loose index scan over the (shortcut_id, date, hour) primary-key index:
+    /// one reverse seek per shortcut instead of window-sorting the complete
+    /// retained history, so cost scales with the number of shortcuts, not
+    /// with total rows (issue #324). Kept as a named constant so tests can
+    /// assert the executed plan never falls back to a temporary B-tree.
+    static let lastUsedPerShortcutSQL = """
+        WITH RECURSIVE latest(shortcut_id, date, hour) AS (
+            SELECT * FROM (
+                SELECT shortcut_id, date, hour
                 FROM usage_hourly
+                ORDER BY shortcut_id DESC, date DESC, hour DESC
+                LIMIT 1
             )
-            WHERE rn = 1
-            """
-        guard let stmt = cachedStatement(&lastUsedPerShortcutStmt, sql: sql) else {
+          UNION ALL
+            SELECT u.shortcut_id, u.date, u.hour
+            FROM latest l
+            JOIN usage_hourly u ON u.rowid = (
+                SELECT u2.rowid FROM usage_hourly u2
+                WHERE u2.shortcut_id < l.shortcut_id
+                ORDER BY u2.shortcut_id DESC, u2.date DESC, u2.hour DESC
+                LIMIT 1
+            )
+        )
+        SELECT shortcut_id, date, hour FROM latest
+        """
+
+    func lastUsedPerShortcut() async -> [UUID: Date] {
+        guard let stmt = cachedStatement(&lastUsedPerShortcutStmt, sql: Self.lastUsedPerShortcutSQL) else {
             return [:]
         }
 

--- a/Sources/Wink/Services/UsageTracker.swift
+++ b/Sources/Wink/Services/UsageTracker.swift
@@ -14,6 +14,14 @@ actor UsageTracker: UsageTracking {
     private var dateFormatter: DateFormatter
     private var dateFormatterTimeZoneIdentifier: String
 
+    /// Executions per logical query, so tests can prove a dashboard snapshot
+    /// runs each dataset at most once and a cancelled snapshot stops issuing
+    /// further statements.
+    private var queryExecutionCounts: [String: Int] = [:]
+    /// Invoked before each dashboard phase's cancellation check; lets tests
+    /// cancel deterministically at a chosen phase boundary.
+    private var dashboardPhaseHook: (@Sendable (String) -> Void)?
+
     private nonisolated(unsafe) var recordDailyUsageStmt: OpaquePointer?
     private nonisolated(unsafe) var recordHourlyUsageStmt: OpaquePointer?
     private nonisolated(unsafe) var deleteDailyUsageStmt: OpaquePointer?
@@ -166,6 +174,11 @@ actor UsageTracker: UsageTracking {
     }
 
     func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] {
+        usageCounts(days: days, relativeTo: now, in: timeZoneProvider())
+    }
+
+    private func usageCounts(days: Int, relativeTo now: Date, in tz: TimeZone) -> [UUID: Int] {
+        recordQueryExecution("usageCounts")
         let sql = """
             SELECT shortcut_id, SUM(count)
             FROM daily_usage
@@ -176,7 +189,6 @@ actor UsageTracker: UsageTracking {
             return [:]
         }
 
-        let tz = timeZoneProvider()
         let range = windowDateRange(days: days, relativeTo: now, in: tz)
         sqlite3_bind_text(stmt, 1, (range.start as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
         sqlite3_bind_text(stmt, 2, (range.end as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
@@ -201,6 +213,11 @@ actor UsageTracker: UsageTracking {
     }
 
     func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] {
+        dailyCounts(days: days, relativeTo: now, in: timeZoneProvider())
+    }
+
+    private func dailyCounts(days: Int, relativeTo now: Date, in tz: TimeZone) -> [String: [(date: String, count: Int)]] {
+        recordQueryExecution("dailyCounts")
         let sql = """
             SELECT shortcut_id, date, count
             FROM daily_usage
@@ -211,7 +228,6 @@ actor UsageTracker: UsageTracking {
             return [:]
         }
 
-        let tz = timeZoneProvider()
         let range = windowDateRange(days: days, relativeTo: now, in: tz)
         sqlite3_bind_text(stmt, 1, (range.start as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
         sqlite3_bind_text(stmt, 2, (range.end as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
@@ -239,6 +255,11 @@ actor UsageTracker: UsageTracking {
     }
 
     func totalSwitches(days: Int, relativeTo now: Date) async -> Int {
+        totalSwitches(days: days, relativeTo: now, in: timeZoneProvider())
+    }
+
+    private func totalSwitches(days: Int, relativeTo now: Date, in tz: TimeZone) -> Int {
+        recordQueryExecution("totalSwitches")
         let sql = """
             SELECT COALESCE(SUM(count), 0)
             FROM usage_hourly
@@ -248,7 +269,6 @@ actor UsageTracker: UsageTracking {
             return 0
         }
 
-        let tz = timeZoneProvider()
         let range = windowDateRange(days: days, relativeTo: now, in: tz)
         sqlite3_bind_text(stmt, 1, (range.start as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
         sqlite3_bind_text(stmt, 2, (range.end as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
@@ -265,6 +285,11 @@ actor UsageTracker: UsageTracking {
     }
 
     func hourlyCounts(days: Int, relativeTo now: Date) async -> [HourlyUsageBucket] {
+        hourlyCounts(days: days, relativeTo: now, in: timeZoneProvider())
+    }
+
+    private func hourlyCounts(days: Int, relativeTo now: Date, in tz: TimeZone) -> [HourlyUsageBucket] {
+        recordQueryExecution("hourlyCounts")
         let sql = """
             SELECT date, hour, COALESCE(SUM(count), 0)
             FROM usage_hourly
@@ -276,7 +301,6 @@ actor UsageTracker: UsageTracking {
             return []
         }
 
-        let tz = timeZoneProvider()
         let range = windowDateRange(days: days, relativeTo: now, in: tz)
         sqlite3_bind_text(stmt, 1, (range.start as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
         sqlite3_bind_text(stmt, 2, (range.end as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
@@ -311,6 +335,11 @@ actor UsageTracker: UsageTracking {
     }
 
     func previousPeriodTotal(days: Int, relativeTo now: Date) async -> Int {
+        previousPeriodTotal(days: days, relativeTo: now, in: timeZoneProvider())
+    }
+
+    private func previousPeriodTotal(days: Int, relativeTo now: Date, in tz: TimeZone) -> Int {
+        recordQueryExecution("previousPeriodTotal")
         let sql = """
             SELECT COALESCE(SUM(count), 0)
             FROM usage_hourly
@@ -320,7 +349,6 @@ actor UsageTracker: UsageTracking {
             return 0
         }
 
-        let tz = timeZoneProvider()
         let previousRange = previousWindowDateRange(days: days, relativeTo: now, in: tz)
         sqlite3_bind_text(stmt, 1, (previousRange.start as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
         sqlite3_bind_text(stmt, 2, (previousRange.end as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
@@ -333,6 +361,11 @@ actor UsageTracker: UsageTracking {
     }
 
     func streakDays(relativeTo now: Date) async -> Int {
+        streakDays(relativeTo: now, in: timeZoneProvider())
+    }
+
+    private func streakDays(relativeTo now: Date, in tz: TimeZone) -> Int {
+        recordQueryExecution("streakDays")
         // Bounded to dates up to "today" so future-dated rows (clock skew,
         // corrupt insert) cannot break the walk on the first iteration, and
         // capped so the scan never materializes unbounded history. Served by
@@ -348,7 +381,6 @@ actor UsageTracker: UsageTracking {
             return 0
         }
 
-        let tz = timeZoneProvider()
         let calendar = UsageWindowMath.calendar(timeZone: tz)
         var expectedDate = calendar.startOfDay(for: now)
         var streak = 0
@@ -375,6 +407,103 @@ actor UsageTracker: UsageTracking {
 
     func usageTimeZone() async -> TimeZone {
         timeZoneProvider()
+    }
+
+    /// One coherent read boundary for a full Insights refresh: a single
+    /// actor-isolated pass with no suspension points, wrapped in a deferred
+    /// read transaction, over one time-zone snapshot and one reference date.
+    /// A concurrent `recordUsage` therefore lands entirely before or entirely
+    /// after the snapshot, never in between. Cancellation is checked before
+    /// every phase so an obsolete refresh stops scheduling further SQLite
+    /// work; the 7-day heatmap/unused datasets reuse the period datasets when
+    /// the period is 7 days.
+    func dashboardSnapshot(for request: UsageDashboardRequest) async -> UsageDashboardSnapshot? {
+        let tz = timeZoneProvider()
+        let previousReference = UsageWindowMath.previousWindowReference(
+            days: request.days,
+            relativeTo: request.referenceDate,
+            in: tz
+        )
+
+        var openedReadTransaction = false
+        if let db {
+            openedReadTransaction = execute(
+                sql: "BEGIN DEFERRED",
+                in: db,
+                failurePrefix: "Failed to begin dashboard snapshot read transaction"
+            )
+        }
+        defer {
+            if openedReadTransaction, let db {
+                _ = execute(
+                    sql: "COMMIT",
+                    in: db,
+                    failurePrefix: "Failed to end dashboard snapshot read transaction"
+                )
+            }
+        }
+
+        guard passesDashboardCheckpoint("totalSwitches") else { return nil }
+        let totalCount = totalSwitches(days: request.days, relativeTo: request.referenceDate, in: tz)
+        guard passesDashboardCheckpoint("previousPeriodTotal") else { return nil }
+        let previousPeriodTotal = previousPeriodTotal(days: request.days, relativeTo: request.referenceDate, in: tz)
+        guard passesDashboardCheckpoint("usageCounts") else { return nil }
+        let counts = usageCounts(days: request.days, relativeTo: request.referenceDate, in: tz)
+        guard passesDashboardCheckpoint("previousUsageCounts") else { return nil }
+        let previousCounts = usageCounts(days: request.days, relativeTo: previousReference, in: tz)
+        guard passesDashboardCheckpoint("dailyCounts") else { return nil }
+        let dailyCounts = dailyCounts(days: request.sparklineDays, relativeTo: request.referenceDate, in: tz)
+        guard passesDashboardCheckpoint("hourlyCounts") else { return nil }
+        let hourlyCounts = hourlyCounts(days: request.days, relativeTo: request.referenceDate, in: tz)
+
+        let heatmapBuckets: [HourlyUsageBucket]
+        if request.days == 7 {
+            heatmapBuckets = hourlyCounts
+        } else {
+            guard passesDashboardCheckpoint("heatmapBuckets") else { return nil }
+            heatmapBuckets = self.hourlyCounts(days: 7, relativeTo: request.referenceDate, in: tz)
+        }
+
+        let unusedCounts: [UUID: Int]
+        if request.days == 7 {
+            unusedCounts = counts
+        } else {
+            guard passesDashboardCheckpoint("unusedCounts") else { return nil }
+            unusedCounts = usageCounts(days: 7, relativeTo: request.referenceDate, in: tz)
+        }
+
+        guard passesDashboardCheckpoint("streakDays") else { return nil }
+        let streakDays = streakDays(relativeTo: request.referenceDate, in: tz)
+
+        return UsageDashboardSnapshot(
+            timeZone: tz,
+            totalCount: totalCount,
+            previousPeriodTotal: previousPeriodTotal,
+            counts: counts,
+            previousCounts: previousCounts,
+            dailyCounts: dailyCounts,
+            hourlyCounts: hourlyCounts,
+            heatmapBuckets: heatmapBuckets,
+            unusedCounts: unusedCounts,
+            streakDays: streakDays
+        )
+    }
+
+    func queryExecutionCountsForTesting() -> [String: Int] {
+        queryExecutionCounts
+    }
+
+    func setDashboardPhaseHookForTesting(_ hook: (@Sendable (String) -> Void)?) {
+        dashboardPhaseHook = hook
+    }
+
+    private func passesDashboardCheckpoint(_ phase: String) -> Bool {
+        dashboardPhaseHook?(phase)
+        return !Task.isCancelled
+    }
+
+    private func recordQueryExecution(_ name: String) {
+        queryExecutionCounts[name, default: 0] += 1
     }
 
     /// Loose index scan over the (shortcut_id, date, hour) primary-key index:

--- a/Sources/Wink/Services/UsageTracker.swift
+++ b/Sources/Wink/Services/UsageTracker.swift
@@ -477,7 +477,6 @@ actor UsageTracker: UsageTracking {
                 ON usage_hourly(date, hour);
             CREATE INDEX IF NOT EXISTS idx_daily_usage_date
                 ON daily_usage(date);
-            PRAGMA user_version = \(UsageDatabaseBootstrap.requiredSchemaVersion);
             """
 
         var errorMessage: UnsafeMutablePointer<CChar>?
@@ -487,6 +486,20 @@ actor UsageTracker: UsageTracking {
             DiagnosticLog.log("Failed to create usage tables: \(error)")
             sqlite3_free(errorMessage)
             return
+        }
+
+        // Only a fresh database (user_version 0) is stamped here. Existing
+        // files reach this point already stamped by the bootstrap, except a
+        // v2 file whose locale migration failed — that one must keep its old
+        // version so the next launch retries the migration instead of having
+        // an unconditional stamp mask it forever.
+        if UsageDatabaseBootstrap.schemaVersion(in: db) == 0 {
+            let stampSQL = "PRAGMA user_version = \(UsageDatabaseBootstrap.requiredSchemaVersion)"
+            if sqlite3_exec(db, stampSQL, nil, nil, nil) != SQLITE_OK {
+                let error = String(cString: sqlite3_errmsg(db))
+                logger.error("Failed to stamp usage schema version: \(error, privacy: .public)")
+                DiagnosticLog.log("Failed to stamp usage schema version: \(error)")
+            }
         }
     }
 
@@ -580,10 +593,6 @@ actor UsageTracker: UsageTracking {
     }
 
     private static func makeDateFormatter(for timeZone: TimeZone) -> (DateFormatter, String) {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = timeZone
-        return (formatter, timeZone.identifier)
+        (UsageWindowMath.dateKeyFormatter(timeZone: timeZone), timeZone.identifier)
     }
 }

--- a/Sources/Wink/UI/Insights/InsightsHourlyHeatmap.swift
+++ b/Sources/Wink/UI/Insights/InsightsHourlyHeatmap.swift
@@ -106,10 +106,7 @@ struct InsightsHourlyHeatmap: View {
     }
 
     private func dayLabel(for dateString: String) -> String {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = .current
+        let formatter = UsageWindowMath.dateKeyFormatter(timeZone: .current)
 
         guard let date = formatter.date(from: dateString) else {
             return dateString

--- a/Sources/Wink/UI/InsightsViewModel.swift
+++ b/Sources/Wink/UI/InsightsViewModel.swift
@@ -249,10 +249,7 @@ final class InsightsViewModel {
 
     private static func dateKeys(days: Int, relativeTo now: Date, timeZone: TimeZone) -> [String] {
         let window = UsageWindowMath.windowDates(days: days, relativeTo: now, in: timeZone)
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.timeZone = timeZone
+        let formatter = UsageWindowMath.dateKeyFormatter(timeZone: timeZone)
 
         return window.days.map { date in
             formatter.string(from: date)

--- a/Sources/Wink/UI/InsightsViewModel.swift
+++ b/Sources/Wink/UI/InsightsViewModel.swift
@@ -118,53 +118,42 @@ final class InsightsViewModel {
 
         let days = period.days
         let appSparklineDays = max(days, 7)
-        let reportingTimeZone = await usageTracker.usageTimeZone()
-        let previousReference = UsageWindowMath.previousWindowReference(
+        let request = UsageDashboardRequest(
             days: days,
-            relativeTo: now,
-            in: reportingTimeZone
+            sparklineDays: appSparklineDays,
+            referenceDate: now
         )
 
-        async let totalCountResult = usageTracker.totalSwitches(days: days, relativeTo: now)
-        async let previousPeriodTotalResult = usageTracker.previousPeriodTotal(days: days, relativeTo: now)
-        async let countsResult = usageTracker.usageCounts(days: days, relativeTo: now)
-        async let previousCountsResult = usageTracker.usageCounts(days: days, relativeTo: previousReference)
-        async let dailyCountsResult = usageTracker.dailyCounts(days: appSparklineDays, relativeTo: now)
-        async let hourlyCountsResult = usageTracker.hourlyCounts(days: days, relativeTo: now)
-        async let heatmapBucketsResult = usageTracker.hourlyCounts(days: 7, relativeTo: now)
-        async let unusedCountsResult = usageTracker.usageCounts(days: 7, relativeTo: now)
-        async let streakResult = usageTracker.streakDays(relativeTo: now)
+        // One coherent snapshot from one read boundary; nil means the refresh
+        // was cancelled mid-flight and a superseding refresh owns the UI.
+        guard let snapshot = await usageTracker.dashboardSnapshot(for: request) else {
+            return
+        }
 
-        let totalCount = await totalCountResult
-        let previousPeriodTotal = await previousPeriodTotalResult
-        let counts = await countsResult
-        let previousCounts = await previousCountsResult
-        let dailyCounts = await dailyCountsResult
-        let hourlyCounts = await hourlyCountsResult
-        let heatmapBuckets = await heatmapBucketsResult
-        let unusedCounts = await unusedCountsResult
-        let streakDays = await streakResult
+        let reportingTimeZone = snapshot.timeZone
+        let dailyCounts = snapshot.dailyCounts
+        let previousCounts = snapshot.previousCounts
         let shortcuts = shortcutStore.shortcuts
         let shortcutMap = Dictionary(uniqueKeysWithValues: shortcuts.map { ($0.id, $0) })
 
         guard !Task.isCancelled else { return }
         guard generation == refreshGeneration else { return }
 
-        self.totalCount = totalCount
-        self.previousPeriodTotal = previousPeriodTotal
-        self.currentStreakDays = streakDays
+        self.totalCount = snapshot.totalCount
+        self.previousPeriodTotal = snapshot.previousPeriodTotal
+        self.currentStreakDays = snapshot.streakDays
         self.activationSparklinePoints = Self.activationSparklinePoints(
             for: period,
-            hourlyCounts: hourlyCounts
+            hourlyCounts: snapshot.hourlyCounts
         )
-        self.heatmapBuckets = heatmapBuckets
+        self.heatmapBuckets = snapshot.heatmapBuckets
         self.unusedShortcutNames = shortcuts
             .filter(\.isEnabled)
-            .filter { (unusedCounts[$0.id] ?? 0) == 0 }
+            .filter { (snapshot.unusedCounts[$0.id] ?? 0) == 0 }
             .map(\.appName)
 
         var ranked: [RankedShortcut] = []
-        for (id, count) in counts {
+        for (id, count) in snapshot.counts {
             guard let shortcut = shortcutMap[id] else { continue }
             ranked.append(
                 RankedShortcut(

--- a/Sources/Wink/UI/SettingsView.swift
+++ b/Sources/Wink/UI/SettingsView.swift
@@ -18,8 +18,15 @@ final class SettingsUsageRefreshCoalescer {
 
     func shouldRefresh() -> Bool {
         let timestamp = now()
-        if let lastRefreshAt, timestamp.timeIntervalSince(lastRefreshAt) < Self.minimumInterval {
-            return false
+        if let lastRefreshAt {
+            let interval = timestamp.timeIntervalSince(lastRefreshAt)
+            // A negative interval means the wall clock stepped backwards;
+            // treating it as "inside the window" would suppress every
+            // refresh until the clock re-passes the old stamp, so it counts
+            // as outside the window instead.
+            if interval >= 0 && interval < Self.minimumInterval {
+                return false
+            }
         }
 
         lastRefreshAt = timestamp

--- a/Sources/Wink/UI/SettingsView.swift
+++ b/Sources/Wink/UI/SettingsView.swift
@@ -1,9 +1,53 @@
 import AppKit
 import SwiftUI
 
+/// Collapses bursts of reactivation notifications into at most one usage
+/// refresh per window. Held as view `@State` so the window survives across
+/// body evaluations; only dispatched refreshes consume the window, so a
+/// suppressed tab (General) never blocks a later real refresh.
+@MainActor
+final class SettingsUsageRefreshCoalescer {
+    static let minimumInterval: TimeInterval = 1.0
+
+    private let now: @Sendable () -> Date
+    private var lastRefreshAt: Date?
+
+    nonisolated init(now: @escaping @Sendable () -> Date = Date.init) {
+        self.now = now
+    }
+
+    func shouldRefresh() -> Bool {
+        let timestamp = now()
+        if let lastRefreshAt, timestamp.timeIntervalSince(lastRefreshAt) < Self.minimumInterval {
+            return false
+        }
+
+        lastRefreshAt = timestamp
+        return true
+    }
+}
+
 @MainActor
 struct SettingsViewLifecycleHandler {
     let preferences: AppPreferences
+    var usageRefreshCoalescer: SettingsUsageRefreshCoalescer
+    var selectedTab: () -> SettingsTab
+    var refreshInsightsUsage: () -> Void
+    var refreshShortcutsUsage: () -> Void
+
+    init(
+        preferences: AppPreferences,
+        usageRefreshCoalescer: SettingsUsageRefreshCoalescer = SettingsUsageRefreshCoalescer(),
+        selectedTab: @escaping () -> SettingsTab = { .shortcuts },
+        refreshInsightsUsage: @escaping () -> Void = {},
+        refreshShortcutsUsage: @escaping () -> Void = {}
+    ) {
+        self.preferences = preferences
+        self.usageRefreshCoalescer = usageRefreshCoalescer
+        self.selectedTab = selectedTab
+        self.refreshInsightsUsage = refreshInsightsUsage
+        self.refreshShortcutsUsage = refreshShortcutsUsage
+    }
 
     func handleAppear() {
         preferences.refreshPermissions()
@@ -13,6 +57,22 @@ struct SettingsViewLifecycleHandler {
     func handleAppDidBecomeActive() {
         preferences.refreshPermissions()
         preferences.refreshLaunchAtLoginStatus()
+        refreshUsageForSelectedTab()
+    }
+
+    /// Reactivation refreshes only the visible tab's usage model; the hidden
+    /// tab gets its own fresh query when it is selected (issue #326).
+    private func refreshUsageForSelectedTab() {
+        switch selectedTab() {
+        case .insights:
+            guard usageRefreshCoalescer.shouldRefresh() else { return }
+            refreshInsightsUsage()
+        case .shortcuts:
+            guard usageRefreshCoalescer.shouldRefresh() else { return }
+            refreshShortcutsUsage()
+        case .general:
+            break
+        }
     }
 }
 
@@ -27,9 +87,16 @@ struct SettingsView: View {
     @Bindable var settingsLauncher: SettingsLauncher
 
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    @State private var usageRefreshCoalescer = SettingsUsageRefreshCoalescer()
 
     private var lifecycleHandler: SettingsViewLifecycleHandler {
-        SettingsViewLifecycleHandler(preferences: preferences)
+        SettingsViewLifecycleHandler(
+            preferences: preferences,
+            usageRefreshCoalescer: usageRefreshCoalescer,
+            selectedTab: { settingsLauncher.selectedTab },
+            refreshInsightsUsage: { insightsViewModel.scheduleRefresh() },
+            refreshShortcutsUsage: { editor.scheduleUsageRefresh() }
+        )
     }
 
     var body: some View {
@@ -76,8 +143,13 @@ struct SettingsView: View {
             }
         }
         .onChange(of: settingsLauncher.selectedTab) { _, newTab in
-            if newTab == .insights {
+            switch newTab {
+            case .insights:
                 insightsViewModel.scheduleRefresh()
+            case .shortcuts:
+                editor.scheduleUsageRefresh()
+            case .general:
+                break
             }
         }
         .onAppear {

--- a/Tests/WinkTests/AppControllerTests.swift
+++ b/Tests/WinkTests/AppControllerTests.swift
@@ -290,6 +290,7 @@ private func ensureAppKitApplication() {
 }
 
 private actor EmptyUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] { [:] }
     func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] { [:] }
     func totalSwitches(days: Int, relativeTo now: Date) async -> Int { 0 }

--- a/Tests/WinkTests/InsightsViewModelTests.swift
+++ b/Tests/WinkTests/InsightsViewModelTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import Wink
 
 actor DelayedUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
 
     init(shortcutId: UUID) {
@@ -42,6 +43,7 @@ actor DelayedUsageTracker: UsageTracking {
 }
 
 actor BoundaryCrossingUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
 
     init(shortcutId: UUID) {
@@ -78,6 +80,7 @@ actor BoundaryCrossingUsageTracker: UsageTracking {
 }
 
 actor TimeZoneAlignedUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
     let timeZone: TimeZone
 

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -799,6 +799,7 @@ private extension NSPoint {
 }
 
 private actor StaticUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
 
     init(shortcutId: UUID) {
@@ -843,6 +844,7 @@ private actor StaticUsageTracker: UsageTracking {
 }
 
 private actor MultiShortcutUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     private let counts: [UUID: Int]
     private let dailyCountsByShortcut: [String: [(date: String, count: Int)]]
     private let hourlyBuckets: [HourlyUsageBucket]

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverSearchTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverSearchTests.swift
@@ -148,6 +148,7 @@ private final class SearchPopoverRuntimeState {
 }
 
 private actor SearchNoopUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] { [:] }
     func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] { [:] }
     func totalSwitches(days: Int, relativeTo now: Date) async -> Int { 0 }

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
@@ -334,6 +334,7 @@ private final class PopoverRuntimeState {
 }
 
 private actor StaticUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let total: Int
 
     init(total: Int) {

--- a/Tests/WinkTests/PersistenceServiceTests.swift
+++ b/Tests/WinkTests/PersistenceServiceTests.swift
@@ -584,7 +584,12 @@ struct UsageDateKeyLocaleMigrationTests {
         #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S1' AND date = '2025-01-01'", at: databaseURL) == 3)
         #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S1' AND date = '\(Self.arabicKey)'", at: databaseURL) == 2)
         #expect(try rowCount("SELECT COUNT(*) FROM usage_hourly", at: databaseURL) == 4)
-        #expect(diagnostics.messages.contains { $0.contains("Failed to migrate usage date keys") })
+        // The reason must carry the actual SQLite failure, captured before
+        // ROLLBACK resets sqlite3_errmsg to "not an error".
+        #expect(diagnostics.messages.contains {
+            $0.contains("Failed to migrate usage date keys")
+                && $0.contains("forced hourly normalization failure")
+        })
         #expect(FileManager.default.fileExists(atPath: databaseURL.path))
 
         // A fresh UsageTracker boot over the failed migration must not stamp

--- a/Tests/WinkTests/PersistenceServiceTests.swift
+++ b/Tests/WinkTests/PersistenceServiceTests.swift
@@ -455,6 +455,211 @@ struct UsageDatabaseBootstrapTests {
     }
 }
 
+@Suite("Usage date key locale migration")
+struct UsageDateKeyLocaleMigrationTests {
+    private static let arabicKey = "\u{0662}\u{0660}\u{0662}\u{0665}-\u{0660}\u{0661}-\u{0660}\u{0661}"
+    private static let persianSameDayKey = "\u{06F2}\u{06F0}\u{06F2}\u{06F5}-\u{06F0}\u{06F1}-\u{06F0}\u{06F1}"
+    private static let persianOtherDayKey = "\u{06F2}\u{06F0}\u{06F2}\u{06F5}-\u{06F0}\u{06F1}-\u{06F0}\u{06F2}"
+    private static let malformedKey = "\u{0662}\u{0660}\u{0662}\u{0665}-\u{0660}\u{0661}"
+
+    @Test
+    func dateKeyFormatterPinsPOSIXLocaleAndEmitsASCIIKeys() {
+        let formatter = UsageWindowMath.dateKeyFormatter(timeZone: TimeZone(secondsFromGMT: 0)!)
+
+        #expect(formatter.locale.identifier == "en_US_POSIX")
+        #expect(formatter.string(from: isoDateTime("2025-01-01T12:00:00Z")) == "2025-01-01")
+
+        // The bug this pin fixes: an unpinned formatter under an Arabic
+        // locale emits localized digits for the same Gregorian date.
+        let unpinned = DateFormatter()
+        unpinned.locale = Locale(identifier: "ar_SA")
+        unpinned.calendar = Calendar(identifier: .gregorian)
+        unpinned.dateFormat = "yyyy-MM-dd"
+        unpinned.timeZone = TimeZone(secondsFromGMT: 0)
+        #expect(unpinned.string(from: isoDateTime("2025-01-01T12:00:00Z")) == Self.arabicKey)
+    }
+
+    @Test
+    func normalizedASCIIDateKeyTranslatesLocalizedDigitsAndRejectsMalformedKeys() {
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey(Self.arabicKey) == "2025-01-01")
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey(Self.persianSameDayKey) == "2025-01-01")
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey("2025-01-01") == "2025-01-01")
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey(Self.malformedKey) == nil)
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey("2025-01-0a") == nil)
+        #expect(UsageDatabaseBootstrap.normalizedASCIIDateKey("") == nil)
+    }
+
+    @Test
+    func migrationNormalizesLocalizedKeysInPlaceAndMergesCollisions() throws {
+        let harness = TestPersistenceHarness()
+        defer { harness.cleanup() }
+        let diagnostics = DiagnosticRecorder()
+        let databaseURL = harness.directory.appendingPathComponent("usage.db")
+
+        try seedLocalizedV2UsageDatabase(at: databaseURL)
+
+        UsageDatabaseBootstrap.prepareDatabase(
+            at: databaseURL.path,
+            diagnosticClient: .init(log: { diagnostics.append($0) })
+        )
+
+        #expect(FileManager.default.fileExists(atPath: databaseURL.path))
+        #expect(try userVersion(at: databaseURL) == UsageDatabaseBootstrap.requiredSchemaVersion)
+
+        // S1 2025-01-01 merges ASCII(3) + Arabic-Indic(2) + Persian(7) = 12.
+        #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S1' AND date = '2025-01-01'", at: databaseURL) == 12)
+        // S2 Persian-only key normalizes without collision.
+        #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S2' AND date = '2025-01-02'", at: databaseURL) == 5)
+        // Malformed key is preserved untouched rather than guessed at.
+        #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S3' AND date = '\(Self.malformedKey)'", at: databaseURL) == 1)
+        // Every other daily key is ASCII now.
+        #expect(try rowCount("SELECT COUNT(*) FROM daily_usage WHERE date GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]'", at: databaseURL) == 2)
+        #expect(try rowCount("SELECT COUNT(*) FROM daily_usage", at: databaseURL) == 3)
+        // Global daily total is exactly preserved after merging.
+        #expect(try rowCount("SELECT SUM(count) FROM daily_usage", at: databaseURL) == 18)
+
+        // Hourly: same-hour collision merges, distinct hour normalizes alongside.
+        #expect(try rowCount("SELECT count FROM usage_hourly WHERE shortcut_id = 'S1' AND date = '2025-01-01' AND hour = 9", at: databaseURL) == 5)
+        #expect(try rowCount("SELECT count FROM usage_hourly WHERE shortcut_id = 'S1' AND date = '2025-01-01' AND hour = 10", at: databaseURL) == 4)
+        #expect(try rowCount("SELECT count FROM usage_hourly WHERE shortcut_id = 'S2' AND date = '2025-01-02' AND hour = 0", at: databaseURL) == 5)
+        #expect(try rowCount("SELECT COUNT(*) FROM usage_hourly", at: databaseURL) == 3)
+        #expect(try rowCount("SELECT SUM(count) FROM usage_hourly", at: databaseURL) == 14)
+
+        #expect(diagnostics.messages.contains {
+            $0.contains("Migrated usage date keys to locale-stable schema v3")
+                && $0.contains("dailyKeysNormalized=3")
+                && $0.contains("hourlyKeysNormalized=3")
+        })
+        #expect(diagnostics.messages.allSatisfy { !$0.contains("Reset usage database") })
+    }
+
+    @Test
+    func migrationIsIdempotentAcrossRepeatedBootstraps() throws {
+        let harness = TestPersistenceHarness()
+        defer { harness.cleanup() }
+        let databaseURL = harness.directory.appendingPathComponent("usage.db")
+
+        try seedLocalizedV2UsageDatabase(at: databaseURL)
+
+        for _ in 0..<3 {
+            UsageDatabaseBootstrap.prepareDatabase(at: databaseURL.path, diagnosticClient: .init(log: { _ in }))
+        }
+
+        #expect(try userVersion(at: databaseURL) == UsageDatabaseBootstrap.requiredSchemaVersion)
+        #expect(try rowCount("SELECT SUM(count) FROM daily_usage", at: databaseURL) == 18)
+        #expect(try rowCount("SELECT COUNT(*) FROM daily_usage", at: databaseURL) == 3)
+        #expect(try rowCount("SELECT SUM(count) FROM usage_hourly", at: databaseURL) == 14)
+        #expect(try rowCount("SELECT COUNT(*) FROM usage_hourly", at: databaseURL) == 3)
+    }
+
+    @Test
+    func failedMigrationRollsBackBothTablesAndKeepsRetryableVersion() throws {
+        let harness = TestPersistenceHarness()
+        defer { harness.cleanup() }
+        let diagnostics = DiagnosticRecorder()
+        let databaseURL = harness.directory.appendingPathComponent("usage.db")
+
+        try seedLocalizedV2UsageDatabase(at: databaseURL)
+        try withSQLiteDatabase(at: databaseURL) { db in
+            try executeSQL(
+                """
+                CREATE TRIGGER fail_usage_hourly_normalization
+                BEFORE INSERT ON usage_hourly
+                BEGIN
+                    SELECT RAISE(FAIL, 'forced hourly normalization failure');
+                END;
+                """,
+                in: db
+            )
+        }
+
+        UsageDatabaseBootstrap.prepareDatabase(
+            at: databaseURL.path,
+            diagnosticClient: .init(log: { diagnostics.append($0) })
+        )
+
+        // daily_usage was processed first; the hourly failure must roll it back too.
+        #expect(try userVersion(at: databaseURL) == UsageDatabaseBootstrap.localeMigratableSchemaVersion)
+        #expect(try rowCount("SELECT COUNT(*) FROM daily_usage", at: databaseURL) == 5)
+        #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S1' AND date = '2025-01-01'", at: databaseURL) == 3)
+        #expect(try rowCount("SELECT count FROM daily_usage WHERE shortcut_id = 'S1' AND date = '\(Self.arabicKey)'", at: databaseURL) == 2)
+        #expect(try rowCount("SELECT COUNT(*) FROM usage_hourly", at: databaseURL) == 4)
+        #expect(diagnostics.messages.contains { $0.contains("Failed to migrate usage date keys") })
+        #expect(FileManager.default.fileExists(atPath: databaseURL.path))
+
+        // A fresh UsageTracker boot over the failed migration must not stamp
+        // the new version and strand the localized rows.
+        _ = UsageTracker(databasePath: databaseURL.path)
+        #expect(try userVersion(at: databaseURL) == UsageDatabaseBootstrap.localeMigratableSchemaVersion)
+
+        // Removing the fault lets the next bootstrap complete the migration.
+        try withSQLiteDatabase(at: databaseURL) { db in
+            try executeSQL("DROP TRIGGER fail_usage_hourly_normalization", in: db)
+        }
+        UsageDatabaseBootstrap.prepareDatabase(at: databaseURL.path, diagnosticClient: .init(log: { _ in }))
+        #expect(try userVersion(at: databaseURL) == UsageDatabaseBootstrap.requiredSchemaVersion)
+        #expect(try rowCount("SELECT SUM(count) FROM daily_usage", at: databaseURL) == 18)
+    }
+
+    @Test
+    func trackerBootMigratesLocalizedKeysAndServesMergedQueries() async throws {
+        let harness = TestPersistenceHarness()
+        defer { harness.cleanup() }
+        let databaseURL = harness.directory.appendingPathComponent("usage.db")
+        let shortcutID = UUID()
+
+        try seedLocalizedV2UsageDatabase(at: databaseURL, shortcutID: shortcutID.uuidString)
+
+        let tracker = UsageTracker(
+            databasePath: databaseURL.path,
+            timeZoneProvider: { TimeZone(secondsFromGMT: 0)! }
+        )
+
+        let counts = await tracker.usageCounts(days: 7, relativeTo: isoDateTime("2025-01-03T12:00:00Z"))
+        #expect(counts[shortcutID] == 12)
+
+        let lastUsed = await tracker.lastUsedPerShortcut()
+        #expect(lastUsed[shortcutID] == isoDateTime("2025-01-01T10:00:00Z"))
+    }
+
+    private func seedLocalizedV2UsageDatabase(at url: URL, shortcutID: String = "S1") throws {
+        try withSQLiteDatabase(at: url) { db in
+            try executeSQL(
+                """
+                CREATE TABLE daily_usage (
+                    shortcut_id TEXT NOT NULL,
+                    date        TEXT NOT NULL,
+                    count       INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (shortcut_id, date)
+                );
+                CREATE TABLE usage_hourly (
+                    shortcut_id TEXT NOT NULL,
+                    date        TEXT NOT NULL,
+                    hour        INTEGER NOT NULL CHECK(hour BETWEEN 0 AND 23),
+                    count       INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (shortcut_id, date, hour)
+                );
+                CREATE INDEX idx_usage_hourly_date_hour ON usage_hourly(date, hour);
+                CREATE INDEX idx_daily_usage_date ON daily_usage(date);
+                INSERT INTO daily_usage (shortcut_id, date, count) VALUES
+                    ('\(shortcutID)', '2025-01-01', 3),
+                    ('\(shortcutID)', '\(Self.arabicKey)', 2),
+                    ('\(shortcutID)', '\(Self.persianSameDayKey)', 7),
+                    ('S2', '\(Self.persianOtherDayKey)', 5),
+                    ('S3', '\(Self.malformedKey)', 1);
+                INSERT INTO usage_hourly (shortcut_id, date, hour, count) VALUES
+                    ('\(shortcutID)', '2025-01-01', 9, 3),
+                    ('\(shortcutID)', '\(Self.arabicKey)', 9, 2),
+                    ('\(shortcutID)', '\(Self.persianSameDayKey)', 10, 4),
+                    ('S2', '\(Self.persianOtherDayKey)', 0, 5);
+                PRAGMA user_version = 2;
+                """,
+                in: db
+            )
+        }
+    }
+}
+
 private func isoDateTime(_ value: String) -> Date {
     let formatter = ISO8601DateFormatter()
     formatter.timeZone = TimeZone(secondsFromGMT: 0)

--- a/Tests/WinkTests/SettingsViewTests.swift
+++ b/Tests/WinkTests/SettingsViewTests.swift
@@ -65,6 +65,160 @@ func handleAppDidBecomeActiveRefreshesShortcutCaptureAndLaunchAtLoginStatus() {
     #expect(preferences.launchAtLoginStatus == .enabled)
 }
 
+@Test @MainActor
+func didBecomeActiveWithInsightsSelectedRefreshesInsightsUsageOnly() {
+    let counters = UsageRefreshCounters()
+    let handler = makeLifecycleHandler(selectedTab: .insights, counters: counters)
+
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 1)
+    #expect(counters.shortcuts == 0)
+}
+
+@Test @MainActor
+func didBecomeActiveWithShortcutsSelectedRefreshesShortcutsUsageOnly() {
+    let counters = UsageRefreshCounters()
+    let handler = makeLifecycleHandler(selectedTab: .shortcuts, counters: counters)
+
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 0)
+    #expect(counters.shortcuts == 1)
+}
+
+@Test @MainActor
+func didBecomeActiveWithGeneralSelectedRefreshesNoUsage() {
+    let counters = UsageRefreshCounters()
+    let handler = makeLifecycleHandler(selectedTab: .general, counters: counters)
+
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 0)
+    #expect(counters.shortcuts == 0)
+}
+
+@Test @MainActor
+func reactivationBurstCoalescesToOneUsageRefreshPerWindow() {
+    let counters = UsageRefreshCounters()
+    let clock = MutableDateBox(date: Date(timeIntervalSinceReferenceDate: 0))
+    let handler = makeLifecycleHandler(
+        selectedTab: .insights,
+        counters: counters,
+        coalescer: SettingsUsageRefreshCoalescer(now: { clock.date })
+    )
+
+    handler.handleAppDidBecomeActive()
+    clock.date = Date(timeIntervalSinceReferenceDate: 0.2)
+    handler.handleAppDidBecomeActive()
+    clock.date = Date(timeIntervalSinceReferenceDate: 0.9)
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 1)
+
+    clock.date = Date(timeIntervalSinceReferenceDate: 1.5)
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 2)
+}
+
+@Test @MainActor
+func generalTabActivationDoesNotConsumeTheCoalescingWindow() {
+    let counters = UsageRefreshCounters()
+    let clock = MutableDateBox(date: Date(timeIntervalSinceReferenceDate: 0))
+    let selectedTab = MutableTabBox(tab: .general)
+    let coalescer = SettingsUsageRefreshCoalescer(now: { clock.date })
+    let handler = SettingsViewLifecycleHandler(
+        preferences: makePreferences(
+            permissionState: MutablePermissionState(ax: false, input: false),
+            launchAtLoginState: MutableLaunchAtLoginState(status: .notRegistered)
+        ),
+        usageRefreshCoalescer: coalescer,
+        selectedTab: { selectedTab.tab },
+        refreshInsightsUsage: { counters.insights += 1 },
+        refreshShortcutsUsage: { counters.shortcuts += 1 }
+    )
+
+    handler.handleAppDidBecomeActive()
+    #expect(counters.insights == 0)
+
+    // A suppressed General activation must not start the window; a refresh
+    // 0.2s later on Insights still runs.
+    selectedTab.tab = .insights
+    clock.date = Date(timeIntervalSinceReferenceDate: 0.2)
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 1)
+}
+
+@Test @MainActor
+func didBecomeActiveStillRefreshesPermissionsAndLaunchAtLoginAlongsideUsage() {
+    let permissionState = MutablePermissionState(ax: false, input: false)
+    let launchAtLoginState = MutableLaunchAtLoginState(status: .requiresApproval)
+    let counters = UsageRefreshCounters()
+    let preferences = makePreferences(
+        permissionState: permissionState,
+        launchAtLoginState: launchAtLoginState
+    )
+    let handler = SettingsViewLifecycleHandler(
+        preferences: preferences,
+        selectedTab: { .insights },
+        refreshInsightsUsage: { counters.insights += 1 },
+        refreshShortcutsUsage: { counters.shortcuts += 1 }
+    )
+
+    permissionState.ax = true
+    permissionState.input = true
+    launchAtLoginState.statusValue = .enabled
+
+    handler.handleAppDidBecomeActive()
+
+    #expect(preferences.launchAtLoginStatus == .enabled)
+    #expect(preferences.shortcutCaptureStatus.accessibilityGranted)
+    #expect(counters.insights == 1)
+}
+
+@MainActor
+private func makeLifecycleHandler(
+    selectedTab: SettingsTab,
+    counters: UsageRefreshCounters,
+    coalescer: SettingsUsageRefreshCoalescer = SettingsUsageRefreshCoalescer()
+) -> SettingsViewLifecycleHandler {
+    SettingsViewLifecycleHandler(
+        preferences: makePreferences(
+            permissionState: MutablePermissionState(ax: false, input: false),
+            launchAtLoginState: MutableLaunchAtLoginState(status: .notRegistered)
+        ),
+        usageRefreshCoalescer: coalescer,
+        selectedTab: { selectedTab },
+        refreshInsightsUsage: { counters.insights += 1 },
+        refreshShortcutsUsage: { counters.shortcuts += 1 }
+    )
+}
+
+@MainActor
+private final class UsageRefreshCounters {
+    var insights = 0
+    var shortcuts = 0
+}
+
+private final class MutableDateBox: @unchecked Sendable {
+    var date: Date
+
+    init(date: Date) {
+        self.date = date
+    }
+}
+
+@MainActor
+private final class MutableTabBox {
+    var tab: SettingsTab
+
+    init(tab: SettingsTab) {
+        self.tab = tab
+    }
+}
+
 @MainActor
 private func makePreferences(
     permissionState: MutablePermissionState,

--- a/Tests/WinkTests/SettingsViewTests.swift
+++ b/Tests/WinkTests/SettingsViewTests.swift
@@ -123,6 +123,35 @@ func reactivationBurstCoalescesToOneUsageRefreshPerWindow() {
 }
 
 @Test @MainActor
+func backwardClockJumpDoesNotSuppressReactivationRefreshes() {
+    let counters = UsageRefreshCounters()
+    let clock = MutableDateBox(date: Date(timeIntervalSinceReferenceDate: 600))
+    let handler = makeLifecycleHandler(
+        selectedTab: .insights,
+        counters: counters,
+        coalescer: SettingsUsageRefreshCoalescer(now: { clock.date })
+    )
+
+    handler.handleAppDidBecomeActive()
+    #expect(counters.insights == 1)
+
+    // The wall clock steps back 10 minutes; the stale stamp must not
+    // suppress refreshes until the clock re-passes it.
+    clock.date = Date(timeIntervalSinceReferenceDate: 0)
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 2)
+
+    // The window restarts from the new (earlier) stamp.
+    clock.date = Date(timeIntervalSinceReferenceDate: 0.5)
+    handler.handleAppDidBecomeActive()
+    #expect(counters.insights == 2)
+    clock.date = Date(timeIntervalSinceReferenceDate: 1.5)
+    handler.handleAppDidBecomeActive()
+    #expect(counters.insights == 3)
+}
+
+@Test @MainActor
 func generalTabActivationDoesNotConsumeTheCoalescingWindow() {
     let counters = UsageRefreshCounters()
     let clock = MutableDateBox(date: Date(timeIntervalSinceReferenceDate: 0))

--- a/Tests/WinkTests/ShortcutEditorStateTests.swift
+++ b/Tests/WinkTests/ShortcutEditorStateTests.swift
@@ -862,3 +862,124 @@ private func makeEditorContext(
 
     return (editor, manager, shortcutStore, harness, callbackCount)
 }
+
+@Test @MainActor
+func staleUsageRefreshCannotOverwriteNewerPublishedUsageData() async {
+    let shortcutStore = ShortcutStore()
+    let manager = ShortcutManager(
+        shortcutStore: shortcutStore,
+        persistenceService: TestPersistenceHarness().makePersistenceService(),
+        appSwitcher: FakeAppSwitcher(),
+        captureCoordinator: ShortcutCaptureCoordinator(
+            standardProvider: FakeCaptureProvider(),
+            hyperProvider: FakeHyperCaptureProvider()
+        ),
+        permissionService: FakePermissionService(ax: true, input: false),
+        diagnosticClient: .init(log: { _ in })
+    )
+    let tracker = GatedUsageTracker()
+    let editor = ShortcutEditorState(
+        shortcutStore: shortcutStore,
+        shortcutManager: manager,
+        usageTracker: tracker
+    )
+    let shortcutID = UUID()
+
+    // Drain the init-scheduled refresh so the scenario owns the gate.
+    await waitForPendingUsageCounts(on: tracker, count: 1)
+    await tracker.releaseFirstUsageCounts(returning: [:])
+    await waitForPendingUsageCounts(on: tracker, count: 0)
+
+    let staleLastUsed = [shortcutID: Date(timeIntervalSinceReferenceDate: 100)]
+    let freshLastUsed = [shortcutID: Date(timeIntervalSinceReferenceDate: 900)]
+
+    await tracker.setLastUsedValue(staleLastUsed)
+    let staleRefresh = Task { await editor.refreshUsageCounts() }
+    await waitForPendingUsageCounts(on: tracker, count: 1)
+
+    await tracker.setLastUsedValue(freshLastUsed)
+    let freshRefresh = Task { await editor.refreshUsageCounts() }
+    await waitForPendingUsageCounts(on: tracker, count: 2)
+
+    // The newer refresh completes first and publishes.
+    await tracker.releaseLastUsageCounts(returning: [shortcutID: 9])
+    await freshRefresh.value
+
+    #expect(editor.usageCounts == [shortcutID: 9])
+    #expect(editor.lastUsed == freshLastUsed)
+
+    // The superseded refresh finishes afterwards; its stale result must be
+    // discarded instead of tearing the published usage maps.
+    await tracker.releaseFirstUsageCounts(returning: [shortcutID: 1])
+    await staleRefresh.value
+
+    #expect(editor.usageCounts == [shortcutID: 9])
+    #expect(editor.lastUsed == freshLastUsed)
+}
+
+@MainActor
+private func waitForPendingUsageCounts(on tracker: GatedUsageTracker, count: Int) async {
+    for _ in 0..<5000 {
+        if await tracker.pendingUsageCountsCount() == count {
+            return
+        }
+        await Task.yield()
+    }
+    Issue.record("timed out waiting for \(count) pending usageCounts calls")
+}
+
+private actor GatedUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
+    private var pendingUsageCounts: [CheckedContinuation<[UUID: Int], Never>] = []
+    private var lastUsedValue: [UUID: Date] = [:]
+
+    func setLastUsedValue(_ value: [UUID: Date]) {
+        lastUsedValue = value
+    }
+
+    func pendingUsageCountsCount() -> Int {
+        pendingUsageCounts.count
+    }
+
+    func releaseFirstUsageCounts(returning value: [UUID: Int]) {
+        guard !pendingUsageCounts.isEmpty else { return }
+        pendingUsageCounts.removeFirst().resume(returning: value)
+    }
+
+    func releaseLastUsageCounts(returning value: [UUID: Int]) {
+        guard !pendingUsageCounts.isEmpty else { return }
+        pendingUsageCounts.removeLast().resume(returning: value)
+    }
+
+    func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] {
+        await withCheckedContinuation { pendingUsageCounts.append($0) }
+    }
+
+    func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] {
+        [:]
+    }
+
+    func totalSwitches(days: Int, relativeTo now: Date) async -> Int {
+        0
+    }
+
+    func hourlyCounts(days: Int, relativeTo now: Date) async -> [HourlyUsageBucket] {
+        []
+    }
+
+    func previousPeriodTotal(days: Int, relativeTo now: Date) async -> Int {
+        0
+    }
+
+    func streakDays(relativeTo now: Date) async -> Int {
+        0
+    }
+
+    func usageTimeZone() async -> TimeZone {
+        .current
+    }
+
+    func lastUsedPerShortcut() async -> [UUID: Date] {
+        lastUsedValue
+    }
+}

--- a/Tests/WinkTests/UsageDashboardSnapshotTests.swift
+++ b/Tests/WinkTests/UsageDashboardSnapshotTests.swift
@@ -1,0 +1,273 @@
+import Foundation
+import Testing
+
+@testable import Wink
+
+@Suite("Usage dashboard snapshot")
+struct UsageDashboardSnapshotTests {
+    @Test
+    func weekSnapshotExecutesEachLogicalDatasetAtMostOnce() async throws {
+        let tracker = try await makeSeededTracker()
+        let request = UsageDashboardRequest(
+            days: 7,
+            sparklineDays: 7,
+            referenceDate: isoDateTime("2026-04-22T12:00:00Z")
+        )
+
+        let snapshot = try #require(await tracker.dashboardSnapshot(for: request))
+
+        let executions = await tracker.queryExecutionCountsForTesting()
+        // Current + previous period; the unused-shortcut dataset reuses the
+        // current-period counts instead of a third query.
+        #expect(executions["usageCounts"] == 2)
+        // The 7-day heatmap reuses the period dataset instead of a second query.
+        #expect(executions["hourlyCounts"] == 1)
+        #expect(executions["totalSwitches"] == 1)
+        #expect(executions["previousPeriodTotal"] == 1)
+        #expect(executions["dailyCounts"] == 1)
+        #expect(executions["streakDays"] == 1)
+
+        #expect(snapshot.heatmapBuckets == snapshot.hourlyCounts)
+        #expect(snapshot.unusedCounts == snapshot.counts)
+    }
+
+    @Test
+    func monthSnapshotComputesSeparateSevenDayDatasets() async throws {
+        let tracker = try await makeSeededTracker()
+        let request = UsageDashboardRequest(
+            days: 30,
+            sparklineDays: 30,
+            referenceDate: isoDateTime("2026-04-22T12:00:00Z")
+        )
+
+        _ = try #require(await tracker.dashboardSnapshot(for: request))
+
+        let executions = await tracker.queryExecutionCountsForTesting()
+        #expect(executions["usageCounts"] == 3)
+        #expect(executions["hourlyCounts"] == 2)
+    }
+
+    @Test
+    func snapshotValuesMatchIndividualQueries() async throws {
+        let tracker = try await makeSeededTracker()
+        let anchor = isoDateTime("2026-04-22T12:00:00Z")
+        let request = UsageDashboardRequest(days: 7, sparklineDays: 7, referenceDate: anchor)
+
+        let snapshot = try #require(await tracker.dashboardSnapshot(for: request))
+
+        let timeZone = await tracker.usageTimeZone()
+        let previousReference = UsageWindowMath.previousWindowReference(
+            days: 7,
+            relativeTo: anchor,
+            in: timeZone
+        )
+        #expect(snapshot.totalCount == (await tracker.totalSwitches(days: 7, relativeTo: anchor)))
+        #expect(snapshot.previousPeriodTotal == (await tracker.previousPeriodTotal(days: 7, relativeTo: anchor)))
+        #expect(snapshot.counts == (await tracker.usageCounts(days: 7, relativeTo: anchor)))
+        #expect(snapshot.previousCounts == (await tracker.usageCounts(days: 7, relativeTo: previousReference)))
+        #expect(snapshot.hourlyCounts == (await tracker.hourlyCounts(days: 7, relativeTo: anchor)))
+        #expect(snapshot.streakDays == (await tracker.streakDays(relativeTo: anchor)))
+        #expect(snapshot.timeZone.identifier == timeZone.identifier)
+    }
+
+    @Test
+    func alreadyCancelledTaskStartsNoQueries() async throws {
+        let tracker = try await makeSeededTracker()
+        let request = UsageDashboardRequest(
+            days: 7,
+            sparklineDays: 7,
+            referenceDate: isoDateTime("2026-04-22T12:00:00Z")
+        )
+
+        let result = await Task { () -> UsageDashboardSnapshot? in
+            withUnsafeCurrentTask { $0?.cancel() }
+            return await tracker.dashboardSnapshot(for: request)
+        }.value
+
+        #expect(result == nil)
+        let executions = await tracker.queryExecutionCountsForTesting()
+        #expect(executions.isEmpty)
+    }
+
+    @Test
+    func midPhaseCancellationStopsSchedulingFurtherQueries() async throws {
+        let tracker = try await makeSeededTracker()
+        await tracker.setDashboardPhaseHookForTesting { phase in
+            if phase == "dailyCounts" {
+                withUnsafeCurrentTask { $0?.cancel() }
+            }
+        }
+        let request = UsageDashboardRequest(
+            days: 7,
+            sparklineDays: 7,
+            referenceDate: isoDateTime("2026-04-22T12:00:00Z")
+        )
+
+        let result = await Task {
+            await tracker.dashboardSnapshot(for: request)
+        }.value
+
+        #expect(result == nil)
+        let executions = await tracker.queryExecutionCountsForTesting()
+        #expect(executions["totalSwitches"] == 1)
+        #expect(executions["previousPeriodTotal"] == 1)
+        #expect(executions["usageCounts"] == 2)
+        #expect(executions["dailyCounts"] == nil)
+        #expect(executions["hourlyCounts"] == nil)
+        #expect(executions["streakDays"] == nil)
+    }
+
+    @Test
+    func snapshotStaysCoherentAcrossConcurrentWrites() async throws {
+        let tracker = UsageTracker(
+            databasePath: ":memory:",
+            timeZoneProvider: { TimeZone(secondsFromGMT: 0)! }
+        )
+        let shortcut = UUID()
+        let anchor = isoDateTime("2026-04-22T12:00:00Z")
+        let request = UsageDashboardRequest(days: 7, sparklineDays: 7, referenceDate: anchor)
+
+        for iteration in 0..<20 {
+            async let write: Void = tracker.recordUsage(
+                shortcutId: shortcut,
+                on: isoDateTime("2026-04-22T09:15:00Z")
+            )
+            async let snapshotResult = tracker.dashboardSnapshot(for: request)
+
+            let snapshot = await snapshotResult
+            await write
+
+            // Every write lands in both tables inside one transaction, and
+            // all seeded usage sits inside the 7-day window, so a coherent
+            // snapshot must agree between the hourly-derived total and the
+            // daily-derived per-shortcut counts. A torn snapshot would let a
+            // write slip between the two reads and break the equality.
+            if let snapshot {
+                #expect(
+                    snapshot.totalCount == snapshot.counts.values.reduce(0, +),
+                    "iteration \(iteration): totalCount=\(snapshot.totalCount) counts=\(snapshot.counts)"
+                )
+            }
+        }
+    }
+
+    @Test @MainActor
+    func viewModelWeekRefreshIssuesNoDuplicateQueries() async {
+        let shortcutId = UUID()
+        let store = ShortcutStore()
+        store.replaceAll(with: [
+            AppShortcut(
+                id: shortcutId,
+                appName: "Terminal",
+                bundleIdentifier: "com.apple.Terminal",
+                keyEquivalent: "t",
+                modifierFlags: ["command"]
+            )
+        ])
+        let recorder = RecordingUsageTracker(shortcutId: shortcutId)
+        let viewModel = InsightsViewModel(usageTracker: recorder, shortcutStore: store)
+
+        await viewModel.refresh(for: .week)
+
+        let calls = await recorder.callCounts()
+        #expect(calls["usageCounts"] == 2)
+        #expect(calls["hourlyCounts"] == 1)
+        #expect(calls["totalSwitches"] == 1)
+        #expect(calls["previousPeriodTotal"] == 1)
+        #expect(calls["dailyCounts"] == 1)
+        #expect(calls["streakDays"] == 1)
+    }
+
+    @Test @MainActor
+    func viewModelMonthRefreshStillQueriesFixedSevenDayDatasets() async {
+        let shortcutId = UUID()
+        let store = ShortcutStore()
+        store.replaceAll(with: [
+            AppShortcut(
+                id: shortcutId,
+                appName: "Terminal",
+                bundleIdentifier: "com.apple.Terminal",
+                keyEquivalent: "t",
+                modifierFlags: ["command"]
+            )
+        ])
+        let recorder = RecordingUsageTracker(shortcutId: shortcutId)
+        let viewModel = InsightsViewModel(usageTracker: recorder, shortcutStore: store)
+
+        await viewModel.refresh(for: .month)
+
+        let calls = await recorder.callCounts()
+        #expect(calls["usageCounts"] == 3)
+        #expect(calls["hourlyCounts"] == 2)
+    }
+
+    private func makeSeededTracker() async throws -> UsageTracker {
+        let tracker = UsageTracker(
+            databasePath: ":memory:",
+            timeZoneProvider: { TimeZone(secondsFromGMT: 0)! }
+        )
+        let first = UUID()
+        let second = UUID()
+        await tracker.recordUsage(shortcutId: first, on: isoDateTime("2026-04-22T09:15:00Z"))
+        await tracker.recordUsage(shortcutId: first, on: isoDateTime("2026-04-20T22:40:00Z"))
+        await tracker.recordUsage(shortcutId: second, on: isoDateTime("2026-04-13T08:05:00Z"))
+        return tracker
+    }
+}
+
+private actor RecordingUsageTracker: UsageTracking {
+    let shortcutId: UUID
+    private var counts: [String: Int] = [:]
+
+    init(shortcutId: UUID) {
+        self.shortcutId = shortcutId
+    }
+
+    func callCounts() -> [String: Int] {
+        counts
+    }
+
+    private func record(_ name: String) {
+        counts[name, default: 0] += 1
+    }
+
+    func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] {
+        record("usageCounts")
+        return [shortcutId: days]
+    }
+
+    func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] {
+        record("dailyCounts")
+        return [:]
+    }
+
+    func totalSwitches(days: Int, relativeTo now: Date) async -> Int {
+        record("totalSwitches")
+        return days
+    }
+
+    func hourlyCounts(days: Int, relativeTo now: Date) async -> [HourlyUsageBucket] {
+        record("hourlyCounts")
+        return []
+    }
+
+    func previousPeriodTotal(days: Int, relativeTo now: Date) async -> Int {
+        record("previousPeriodTotal")
+        return 0
+    }
+
+    func streakDays(relativeTo now: Date) async -> Int {
+        record("streakDays")
+        return 0
+    }
+
+    func usageTimeZone() async -> TimeZone {
+        .current
+    }
+}
+
+private func isoDateTime(_ value: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    return formatter.date(from: value)!
+}

--- a/Tests/WinkTests/UsageDashboardSnapshotTests.swift
+++ b/Tests/WinkTests/UsageDashboardSnapshotTests.swift
@@ -216,6 +216,7 @@ struct UsageDashboardSnapshotTests {
 }
 
 private actor RecordingUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
     private var counts: [String: Int] = [:]
 

--- a/Tests/WinkTests/UsageTrackerLastUsedTests.swift
+++ b/Tests/WinkTests/UsageTrackerLastUsedTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import SQLite3
+import Testing
+
+@testable import Wink
+
+@Suite("UsageTracker last-used lookup")
+struct UsageTrackerLastUsedTests {
+    @Test
+    func lastUsedReturnsLatestBucketPerShortcut() async throws {
+        let tracker = UsageTracker(
+            databasePath: ":memory:",
+            timeZoneProvider: { TimeZone(secondsFromGMT: 0)! }
+        )
+        let first = UUID()
+        let second = UUID()
+
+        await tracker.recordUsage(shortcutId: first, on: isoDateTime("2026-03-01T08:30:00Z"))
+        await tracker.recordUsage(shortcutId: first, on: isoDateTime("2026-03-04T22:10:00Z"))
+        await tracker.recordUsage(shortcutId: first, on: isoDateTime("2026-03-04T05:00:00Z"))
+        await tracker.recordUsage(shortcutId: second, on: isoDateTime("2026-02-11T13:45:00Z"))
+
+        let lastUsed = await tracker.lastUsedPerShortcut()
+
+        #expect(lastUsed.count == 2)
+        #expect(lastUsed[first] == isoDateTime("2026-03-04T22:00:00Z"))
+        #expect(lastUsed[second] == isoDateTime("2026-02-11T13:00:00Z"))
+    }
+
+    @Test
+    func lastUsedBreaksSameDayTiesByLatestHour() async throws {
+        let tracker = UsageTracker(
+            databasePath: ":memory:",
+            timeZoneProvider: { TimeZone(secondsFromGMT: 0)! }
+        )
+        let shortcut = UUID()
+
+        await tracker.recordUsage(shortcutId: shortcut, on: isoDateTime("2026-03-04T05:00:00Z"))
+        await tracker.recordUsage(shortcutId: shortcut, on: isoDateTime("2026-03-04T23:59:00Z"))
+        await tracker.recordUsage(shortcutId: shortcut, on: isoDateTime("2026-03-04T12:00:00Z"))
+
+        let lastUsed = await tracker.lastUsedPerShortcut()
+
+        #expect(lastUsed[shortcut] == isoDateTime("2026-03-04T23:00:00Z"))
+    }
+
+    @Test
+    func lastUsedIsEmptyForEmptyDatabaseAndOmitsNeverUsedShortcuts() async throws {
+        let tracker = UsageTracker(
+            databasePath: ":memory:",
+            timeZoneProvider: { TimeZone(secondsFromGMT: 0)! }
+        )
+
+        #expect(await tracker.lastUsedPerShortcut().isEmpty)
+
+        let used = UUID()
+        let neverUsed = UUID()
+        await tracker.recordUsage(shortcutId: used, on: isoDateTime("2026-01-15T09:00:00Z"))
+
+        let lastUsed = await tracker.lastUsedPerShortcut()
+        #expect(lastUsed.count == 1)
+        #expect(lastUsed[used] != nil)
+        #expect(lastUsed[neverUsed] == nil)
+    }
+
+    @Test
+    func looseIndexScanMatchesWindowFunctionBaselineOnRandomizedHistory() throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("last-used-equivalence-\(UUID().uuidString).db")
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        try seedRandomizedUsageHourly(at: databaseURL, rowTarget: 2000)
+
+        let baselineSQL = """
+            SELECT shortcut_id, date, hour FROM (
+                SELECT shortcut_id, date, hour,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY shortcut_id
+                           ORDER BY date DESC, hour DESC
+                       ) AS rn
+                FROM usage_hourly
+            )
+            WHERE rn = 1
+            """
+
+        let baseline = try queryRows(baselineSQL, at: databaseURL)
+        let optimized = try queryRows(UsageTracker.lastUsedPerShortcutSQL, at: databaseURL)
+
+        #expect(!baseline.isEmpty)
+        #expect(Set(optimized) == Set(baseline))
+    }
+
+    @Test
+    func lastUsedQueryPlanAvoidsTemporaryBTree() throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("last-used-plan-\(UUID().uuidString).db")
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        try seedRandomizedUsageHourly(at: databaseURL, rowTarget: 200)
+
+        let planSteps = try queryPlanSteps(UsageTracker.lastUsedPerShortcutSQL, at: databaseURL)
+
+        #expect(!planSteps.isEmpty)
+        #expect(planSteps.allSatisfy { !$0.contains("TEMP B-TREE") })
+        #expect(planSteps.contains { $0.contains("COVERING INDEX sqlite_autoindex_usage_hourly_1") })
+    }
+
+    private func seedRandomizedUsageHourly(at url: URL, rowTarget: Int) throws {
+        var db: OpaquePointer?
+        guard sqlite3_open(url.path, &db) == SQLITE_OK else {
+            sqlite3_close(db)
+            throw LastUsedTestError.openFailed
+        }
+        defer { sqlite3_close(db) }
+
+        guard sqlite3_exec(
+            db,
+            """
+            CREATE TABLE usage_hourly (
+                shortcut_id TEXT NOT NULL,
+                date        TEXT NOT NULL,
+                hour        INTEGER NOT NULL CHECK(hour BETWEEN 0 AND 23),
+                count       INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (shortcut_id, date, hour)
+            );
+            CREATE INDEX idx_usage_hourly_date_hour ON usage_hourly(date, hour);
+            BEGIN;
+            """,
+            nil, nil, nil
+        ) == SQLITE_OK else {
+            throw LastUsedTestError.execFailed
+        }
+
+        let shortcutIDs = (0..<7).map { index in
+            "0000000\(index)-1111-4222-8333-444444444444"
+        } + ["not-a-uuid-key"]
+        var generator = DeterministicGenerator(seed: 0x324)
+
+        var inserted = 0
+        while inserted < rowTarget {
+            let shortcut = shortcutIDs[Int(generator.next() % UInt64(shortcutIDs.count))]
+            let year = 2021 + Int(generator.next() % 6)
+            let month = 1 + Int(generator.next() % 12)
+            let day = 1 + Int(generator.next() % 28)
+            let hour = Int(generator.next() % 24)
+            let date = String(format: "%04d-%02d-%02d", year, month, day)
+            let sql = """
+                INSERT INTO usage_hourly (shortcut_id, date, hour, count)
+                VALUES ('\(shortcut)', '\(date)', \(hour), 1)
+                ON CONFLICT(shortcut_id, date, hour) DO UPDATE SET count = count + 1
+                """
+            guard sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK else {
+                throw LastUsedTestError.execFailed
+            }
+            inserted += 1
+        }
+
+        guard sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK else {
+            throw LastUsedTestError.execFailed
+        }
+    }
+
+    private func queryRows(_ sql: String, at url: URL) throws -> [String] {
+        var db: OpaquePointer?
+        guard sqlite3_open(url.path, &db) == SQLITE_OK else {
+            sqlite3_close(db)
+            throw LastUsedTestError.openFailed
+        }
+        defer { sqlite3_close(db) }
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            sqlite3_finalize(stmt)
+            throw LastUsedTestError.prepareFailed
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var rows: [String] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard
+                let idText = sqlite3_column_text(stmt, 0),
+                let dateText = sqlite3_column_text(stmt, 1)
+            else {
+                continue
+            }
+            rows.append(
+                "\(String(cString: idText))|\(String(cString: dateText))|\(sqlite3_column_int(stmt, 2))"
+            )
+        }
+        return rows
+    }
+
+    private func queryPlanSteps(_ sql: String, at url: URL) throws -> [String] {
+        var db: OpaquePointer?
+        guard sqlite3_open(url.path, &db) == SQLITE_OK else {
+            sqlite3_close(db)
+            throw LastUsedTestError.openFailed
+        }
+        defer { sqlite3_close(db) }
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "EXPLAIN QUERY PLAN \(sql)", -1, &stmt, nil) == SQLITE_OK else {
+            sqlite3_finalize(stmt)
+            throw LastUsedTestError.prepareFailed
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        var steps: [String] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            if let detail = sqlite3_column_text(stmt, 3) {
+                steps.append(String(cString: detail))
+            }
+        }
+        return steps
+    }
+}
+
+/// SplitMix64 — deterministic across runs so the equivalence fixture is
+/// reproducible without seeding global randomness.
+private struct DeterministicGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+private enum LastUsedTestError: Error {
+    case openFailed
+    case prepareFailed
+    case execFailed
+}
+
+private func isoDateTime(_ value: String) -> Date {
+    let formatter = ISO8601DateFormatter()
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    return formatter.date(from: value)!
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,9 +213,10 @@ Responsibilities:
 - `UsageTracker`
 
 Responsibilities:
-- record shortcut activations with SQLite daily and hourly aggregation using fixed Gregorian `yyyy-MM-dd` buckets
+- record shortcut activations with SQLite daily and hourly aggregation using locale-pinned (`en_US_POSIX`) ASCII Gregorian `yyyy-MM-dd` buckets, shared through `UsageWindowMath.dateKeyFormatter` by every writer and parser of persisted date keys (issue #323)
 - provide current-window counts, previous-period totals, streaks, and hourly heatmap buckets for Insights and the menu bar Today view
-- reset a legacy usage database shape explicitly before startup opens the live database, instead of keeping a half-migrated schema around
+- migrate supported v2 databases in place to schema v3 during bootstrap: localized-digit date keys are normalized to ASCII inside one transaction, primary-key collisions merge by summing counts, unrecognizable keys are left untouched, and any failure (including a failed key scan) rolls back completely and stays at v2 so the next launch retries
+- still reset only pre-v2/unknown legacy database shapes explicitly before startup opens the live database, instead of keeping a half-migrated schema around; the fresh-database version stamp happens only at `user_version` 0 so a failed migration is never masked
 - run off the main actor via Swift actor isolation
 
 ### Permissions and packaging


### PR DESCRIPTION
Fixes #326

## Summary
- Reactivating Wink while Settings stays open now refreshes the usage model for the currently selected tab only: Insights re-runs its snapshot refresh through the existing generation-owned `scheduleRefresh()` path; the Shortcuts tab re-fetches usage counts and last-used metadata. The General tab triggers no usage work, and the #136 permission/launch-at-login refresh on reactivation is unchanged.
- Selecting the other tab later triggers that tab's own fresh query: the tab-change handler now also refreshes editor usage when switching to Shortcuts (Insights already refreshed on selection).
- Reactivation bursts are coalesced by a view-state `SettingsUsageRefreshCoalescer` (1s window). Only a dispatched refresh consumes the window, so a suppressed General-tab activation cannot block a real refresh moments later.
- `ShortcutEditorState` moves to `any UsageTracking` (with `deleteUsage` promoted to a protocol requirement) and guards `refreshUsageCounts()` with a generation so a superseded refresh can never tear or overwrite newer published usage maps. `deleteUsage` deliberately has no async extension default: async contexts prefer async overloads, so a default next to the tracker's synchronous actor method would silently route concrete calls to a no-op (caught by test; fakes implement the one-line stub explicitly).

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

New coverage: per-tab reactivation refresh (Insights-selected refreshes Insights only, Shortcuts-selected refreshes Shortcuts only, General refreshes none), burst coalescing to one refresh per window with a later notification starting a new one, General activations not consuming the coalescing window, permissions + launch-at-login still refreshed alongside usage, and a gated-tracker editor test proving a stale overlapping refresh is discarded after a newer one publishes. Full suite: 506 tests / 47 suites, 0 failures.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.
- If the PR touches runtime-sensitive files, the PR metadata workflow will reject `Not runtime-sensitive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
