### PR TITLE
Surface launch-at-login registration failures in General settings

### DIFF
--- a/Sources/Wink/Services/AppPreferences.swift
+++ b/Sources/Wink/Services/AppPreferences.swift
@@ -39,6 +39,7 @@ final class AppPreferences {
     private(set) var shortcutCaptureStatus: ShortcutCaptureStatus
     private(set) var launchAtLoginStatus: LaunchAtLoginStatus = .disabled
     private(set) var launchAtLoginAvailability: LaunchAtLoginAvailability = .available
+    private(set) var launchAtLoginMutationFailure: LaunchAtLoginMutationFailure?
     private(set) var hyperKeyEnabled: Bool = false
     private(set) var shortcutsPaused: Bool = false
     /// Apple's own DTS guidance: `SMAppService.Status.notFound` is the normal
@@ -91,21 +92,44 @@ final class AppPreferences {
     var launchAtLoginPresentation: LaunchAtLoginPresentation {
         switch launchAtLoginStatus {
         case .enabled:
-            LaunchAtLoginPresentation(
-                toggleIsOn: true,
-                toggleIsEnabled: true,
-                message: nil,
-                messageStyle: .none,
-                showsOpenSettingsButton: false
-            )
+            // The toggle reflects the real post-attempt state; only the
+            // banner carries the mutation failure. .requiresApproval and
+            // .notFound keep their more specific presentations below.
+            if let failure = launchAtLoginMutationFailure {
+                LaunchAtLoginPresentation(
+                    toggleIsOn: true,
+                    toggleIsEnabled: true,
+                    message: Self.mutationFailureMessage(failure),
+                    messageStyle: .error,
+                    showsOpenSettingsButton: true
+                )
+            } else {
+                LaunchAtLoginPresentation(
+                    toggleIsOn: true,
+                    toggleIsEnabled: true,
+                    message: nil,
+                    messageStyle: .none,
+                    showsOpenSettingsButton: false
+                )
+            }
         case .disabled:
-            LaunchAtLoginPresentation(
-                toggleIsOn: false,
-                toggleIsEnabled: true,
-                message: nil,
-                messageStyle: .none,
-                showsOpenSettingsButton: false
-            )
+            if let failure = launchAtLoginMutationFailure {
+                LaunchAtLoginPresentation(
+                    toggleIsOn: false,
+                    toggleIsEnabled: true,
+                    message: Self.mutationFailureMessage(failure),
+                    messageStyle: .error,
+                    showsOpenSettingsButton: true
+                )
+            } else {
+                LaunchAtLoginPresentation(
+                    toggleIsOn: false,
+                    toggleIsEnabled: true,
+                    message: nil,
+                    messageStyle: .none,
+                    showsOpenSettingsButton: false
+                )
+            }
         case .requiresApproval:
             LaunchAtLoginPresentation(
                 toggleIsOn: true,
@@ -214,7 +238,9 @@ final class AppPreferences {
         if enabled {
             hasAttemptedLaunchAtLoginRegistration = true
         }
-        launchAtLoginService.setEnabled(enabled)
+        // A successful later attempt clears any stale failure because the
+        // result is nil on success.
+        launchAtLoginMutationFailure = launchAtLoginService.setEnabled(enabled)
         refreshLaunchAtLoginStatus()
     }
 
@@ -233,6 +259,20 @@ final class AppPreferences {
         let launchAtLoginSnapshot = launchAtLoginService.snapshot
         launchAtLoginStatus = launchAtLoginSnapshot.status
         launchAtLoginAvailability = launchAtLoginSnapshot.availability
+
+        // Clear a stale failure once the observed status shows the failed
+        // mutation's intent was achieved externally (e.g. in System Settings).
+        // A failed register leaves the status .disabled and a failed
+        // unregister leaves it .enabled, so a fresh failure stays visible.
+        guard let failure = launchAtLoginMutationFailure else { return }
+        let isRegistered = launchAtLoginStatus == .enabled || launchAtLoginStatus == .requiresApproval
+        let intentAchieved = switch failure.mutation {
+        case .register: isRegistered
+        case .unregister: !isRegistered
+        }
+        if intentAchieved {
+            launchAtLoginMutationFailure = nil
+        }
     }
 
     func openLoginItemsSettings() {
@@ -330,6 +370,15 @@ final class AppPreferences {
         hyperKeyEnabled = hyperKeyService.isEnabled
         shortcutManager.setHyperKeyEnabled(hyperKeyEnabled)
         refreshPermissions()
+    }
+
+    private static func mutationFailureMessage(_ failure: LaunchAtLoginMutationFailure) -> String {
+        switch failure.mutation {
+        case .register:
+            "Wink couldn't enable Launch at Login: \(failure.reason). Try again, or manage it in System Settings › Login Items."
+        case .unregister:
+            "Wink couldn't disable Launch at Login: \(failure.reason). Try again, or manage it in System Settings › Login Items."
+        }
     }
 
     private static func currentVersionString(bundle: Bundle = .main) -> String {

--- a/Sources/Wink/Services/LaunchAtLoginService.swift
+++ b/Sources/Wink/Services/LaunchAtLoginService.swift
@@ -26,6 +26,16 @@ struct LaunchAtLoginSnapshot: Equatable {
     let availability: LaunchAtLoginAvailability
 }
 
+enum LaunchAtLoginMutation: String, Equatable, Sendable {
+    case register
+    case unregister
+}
+
+struct LaunchAtLoginMutationFailure: Equatable, Sendable {
+    let mutation: LaunchAtLoginMutation
+    let reason: String
+}
+
 struct LaunchAtLoginService {
     struct Client: Sendable {
         let status: @Sendable () -> SMAppService.Status
@@ -92,7 +102,7 @@ struct LaunchAtLoginService {
         status.isEnabled
     }
 
-    func setEnabled(_ enabled: Bool) {
+    func setEnabled(_ enabled: Bool) -> LaunchAtLoginMutationFailure? {
         do {
             if enabled {
                 try client.register()
@@ -101,9 +111,14 @@ struct LaunchAtLoginService {
                 try client.unregister()
                 logger.info("Unregistered as login item")
             }
+            return nil
         } catch {
             logger.error("Failed to \(enabled ? "register" : "unregister") login item: \(error)")
             DiagnosticLog.log("Failed to \(enabled ? "register" : "unregister") login item: \(error)")
+            return LaunchAtLoginMutationFailure(
+                mutation: enabled ? .register : .unregister,
+                reason: error.localizedDescription
+            )
         }
     }
 

--- a/Tests/WinkTests/AppPreferencesTests.swift
+++ b/Tests/WinkTests/AppPreferencesTests.swift
@@ -48,6 +48,164 @@ func setLaunchAtLoginDoesNotUpdateStateWhenRegistrationFails() {
 
     #expect(preferences.launchAtLoginStatus == .disabled)
     #expect(preferences.launchAtLoginEnabled == false)
+    #expect(preferences.launchAtLoginMutationFailure == LaunchAtLoginMutationFailure(
+        mutation: .register,
+        reason: TestError.registerFailed.localizedDescription
+    ))
+    let presentation = preferences.launchAtLoginPresentation
+    #expect(presentation.toggleIsOn == false)
+    #expect(presentation.toggleIsEnabled == true)
+    #expect(presentation.messageStyle == .error)
+    #expect(presentation.message == "Wink couldn't enable Launch at Login: register denied by policy. Try again, or manage it in System Settings › Login Items.")
+    #expect(presentation.showsOpenSettingsButton == true)
+}
+
+@Test @MainActor
+func setLaunchAtLoginSurfacesUnregisterFailureWhenUnregistrationFails() {
+    let state = MutableLaunchAtLoginState(status: .enabled)
+    state.unregisterError = TestError.unregisterFailed
+    let preferences = makePreferences(state: state)
+
+    preferences.setLaunchAtLogin(false)
+
+    #expect(preferences.launchAtLoginStatus == .enabled)
+    #expect(preferences.launchAtLoginEnabled == true)
+    #expect(preferences.launchAtLoginMutationFailure == LaunchAtLoginMutationFailure(
+        mutation: .unregister,
+        reason: TestError.unregisterFailed.localizedDescription
+    ))
+    let presentation = preferences.launchAtLoginPresentation
+    #expect(presentation.toggleIsOn == true)
+    #expect(presentation.toggleIsEnabled == true)
+    #expect(presentation.messageStyle == .error)
+    #expect(presentation.message == "Wink couldn't disable Launch at Login: unregister denied by policy. Try again, or manage it in System Settings › Login Items.")
+    #expect(presentation.showsOpenSettingsButton == true)
+}
+
+@Test @MainActor
+func setLaunchAtLoginClearsRegisterFailureAfterSuccessfulRetry() {
+    let state = MutableLaunchAtLoginState(status: .notRegistered)
+    state.registerError = TestError.registerFailed
+    let preferences = makePreferences(state: state)
+
+    preferences.setLaunchAtLogin(true)
+    #expect(preferences.launchAtLoginMutationFailure != nil)
+
+    state.registerError = nil
+    preferences.setLaunchAtLogin(true)
+
+    #expect(preferences.launchAtLoginMutationFailure == nil)
+    #expect(preferences.launchAtLoginStatus == .enabled)
+    let presentation = preferences.launchAtLoginPresentation
+    #expect(presentation.toggleIsOn == true)
+    #expect(presentation.toggleIsEnabled == true)
+    #expect(presentation.message == nil)
+    #expect(presentation.messageStyle == .none)
+    #expect(presentation.showsOpenSettingsButton == false)
+}
+
+@Test @MainActor
+func setLaunchAtLoginClearsUnregisterFailureAfterSuccessfulRetry() {
+    let state = MutableLaunchAtLoginState(status: .enabled)
+    state.unregisterError = TestError.unregisterFailed
+    let preferences = makePreferences(state: state)
+
+    preferences.setLaunchAtLogin(false)
+    #expect(preferences.launchAtLoginMutationFailure != nil)
+
+    state.unregisterError = nil
+    preferences.setLaunchAtLogin(false)
+
+    #expect(preferences.launchAtLoginMutationFailure == nil)
+    #expect(preferences.launchAtLoginStatus == .disabled)
+    let presentation = preferences.launchAtLoginPresentation
+    #expect(presentation.toggleIsOn == false)
+    #expect(presentation.toggleIsEnabled == true)
+    #expect(presentation.message == nil)
+    #expect(presentation.messageStyle == .none)
+    #expect(presentation.showsOpenSettingsButton == false)
+}
+
+@Test @MainActor
+func refreshLaunchAtLoginStatusClearsStaleRegisterFailureWhenEnabledExternally() {
+    let state = MutableLaunchAtLoginState(status: .notRegistered)
+    state.registerError = TestError.registerFailed
+    let preferences = makePreferences(state: state)
+
+    preferences.setLaunchAtLogin(true)
+    #expect(preferences.launchAtLoginMutationFailure != nil)
+
+    // User fixes it in System Settings › Login Items.
+    state.status = .enabled
+    preferences.refreshLaunchAtLoginStatus()
+
+    #expect(preferences.launchAtLoginMutationFailure == nil)
+    #expect(preferences.launchAtLoginStatus == .enabled)
+    let presentation = preferences.launchAtLoginPresentation
+    #expect(presentation.toggleIsOn == true)
+    #expect(presentation.message == nil)
+    #expect(presentation.messageStyle == .none)
+    #expect(presentation.showsOpenSettingsButton == false)
+}
+
+@Test @MainActor
+func launchAtLoginMutationFailureDoesNotOverrideRequiresApprovalPresentation() {
+    // A failed unregister that leaves the service awaiting approval keeps
+    // the failure recorded, but the .requiresApproval branch retains its
+    // more specific informational copy.
+    let state = MutableLaunchAtLoginState(status: .requiresApproval)
+    state.unregisterError = TestError.unregisterFailed
+    let preferences = makePreferences(state: state)
+
+    preferences.setLaunchAtLogin(false)
+
+    #expect(preferences.launchAtLoginStatus == .requiresApproval)
+    #expect(preferences.launchAtLoginMutationFailure == LaunchAtLoginMutationFailure(
+        mutation: .unregister,
+        reason: TestError.unregisterFailed.localizedDescription
+    ))
+    let presentation = preferences.launchAtLoginPresentation
+    #expect(presentation.toggleIsOn == true)
+    #expect(presentation.toggleIsEnabled == true)
+    #expect(presentation.messageStyle == .informational)
+    #expect(presentation.message == "Wink is registered to launch at login, but macOS still needs your approval in Login Items.")
+    #expect(presentation.showsOpenSettingsButton == true)
+}
+
+@Test @MainActor
+func launchAtLoginMutationFailureDoesNotOverrideNotFoundPresentations() {
+    // In Applications: the post-attempt configuration-error copy wins.
+    let missingConfigurationState = MutableLaunchAtLoginState(status: .notFound)
+    missingConfigurationState.registerError = TestError.registerFailed
+    let inApplications = makePreferences(state: missingConfigurationState)
+
+    inApplications.setLaunchAtLogin(true)
+
+    #expect(inApplications.launchAtLoginMutationFailure != nil)
+    let configurationPresentation = inApplications.launchAtLoginPresentation
+    #expect(configurationPresentation.toggleIsOn == false)
+    #expect(configurationPresentation.toggleIsEnabled == false)
+    #expect(configurationPresentation.messageStyle == .error)
+    #expect(configurationPresentation.message == "Wink couldn't find its login item configuration. This usually points to an installation or packaging problem.")
+    #expect(configurationPresentation.showsOpenSettingsButton == false)
+
+    // Outside Applications: the install guidance copy wins.
+    let outsideState = MutableLaunchAtLoginState(status: .notFound)
+    outsideState.registerError = TestError.registerFailed
+    let outsideApplications = makePreferences(
+        state: outsideState,
+        bundleURL: URL(fileURLWithPath: "/tmp/Wink.app")
+    )
+
+    outsideApplications.setLaunchAtLogin(true)
+
+    #expect(outsideApplications.launchAtLoginMutationFailure != nil)
+    let guidancePresentation = outsideApplications.launchAtLoginPresentation
+    #expect(guidancePresentation.toggleIsOn == false)
+    #expect(guidancePresentation.toggleIsEnabled == false)
+    #expect(guidancePresentation.messageStyle == .informational)
+    #expect(guidancePresentation.message == "Launch at Login is only available after installing Wink.app in the Applications folder and reopening it.")
+    #expect(guidancePresentation.showsOpenSettingsButton == false)
 }
 
 @Test @MainActor
@@ -611,9 +769,16 @@ private func makeCaptureCoordinator() -> ShortcutCaptureCoordinator {
     )
 }
 
-private enum TestError: Error {
+private enum TestError: LocalizedError {
     case registerFailed
     case unregisterFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .registerFailed: "register denied by policy"
+        case .unregisterFailed: "unregister denied by policy"
+        }
+    }
 }
 
 private final class OpenSettingsRecorder: @unchecked Sendable {

--- a/Tests/WinkTests/LaunchAtLoginServiceTests.swift
+++ b/Tests/WinkTests/LaunchAtLoginServiceTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ServiceManagement
 import Testing
 @testable import Wink
@@ -56,4 +57,59 @@ func notFoundInsideApplicationsStaysConfigurationMissing() {
     ))
 
     #expect(service.snapshot.availability == LaunchAtLoginAvailability.missingConfiguration)
+}
+
+@Test
+func setEnabledReturnsNilWhenMutationSucceeds() {
+    let service = LaunchAtLoginService(client: .init(
+        status: { .notRegistered },
+        register: {},
+        unregister: {},
+        openSystemSettingsLoginItems: {}
+    ))
+
+    #expect(service.setEnabled(true) == nil)
+    #expect(service.setEnabled(false) == nil)
+}
+
+@Test
+func setEnabledReturnsRegisterFailureWhenRegisterThrows() {
+    let service = LaunchAtLoginService(client: .init(
+        status: { .notRegistered },
+        register: { throw MutationTestError.registerFailed },
+        unregister: {},
+        openSystemSettingsLoginItems: {}
+    ))
+
+    #expect(service.setEnabled(true) == LaunchAtLoginMutationFailure(
+        mutation: .register,
+        reason: MutationTestError.registerFailed.localizedDescription
+    ))
+}
+
+@Test
+func setEnabledReturnsUnregisterFailureWhenUnregisterThrows() {
+    let service = LaunchAtLoginService(client: .init(
+        status: { .enabled },
+        register: {},
+        unregister: { throw MutationTestError.unregisterFailed },
+        openSystemSettingsLoginItems: {}
+    ))
+
+    #expect(service.setEnabled(false) == LaunchAtLoginMutationFailure(
+        mutation: .unregister,
+        reason: MutationTestError.unregisterFailed.localizedDescription
+    ))
+}
+
+private enum MutationTestError: LocalizedError {
+    case registerFailed
+    case unregisterFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .registerFailed: "register denied by policy"
+        case .unregisterFailed: "unregister denied by policy"
+        }
+    }
 }


### PR DESCRIPTION
Fixes #327

## Summary
- `LaunchAtLoginService.setEnabled` now returns a structured `LaunchAtLoginMutationFailure?` (nil on success) instead of swallowing `SMAppService.register()`/`unregister()` errors after logging them; the diagnostic log lines are byte-identical and the full `SMAppService.Status` model is untouched.
- `AppPreferences` stores the failure as observable state: a later successful attempt clears it, and `refreshLaunchAtLoginStatus()` clears a stale failure once the observed status shows the failed mutation's intent was achieved externally (e.g. the user fixed it in System Settings). A fresh register failure (status still `.disabled`) and a fresh unregister failure (status still `.enabled`) keep the error visible.
- `launchAtLoginPresentation` overlays an actionable error banner only in the previously silent `.enabled`/`.disabled` branches — the toggle keeps the real post-attempt state, and the copy distinguishes the failed operation ("couldn't enable/disable Launch at Login: <reason>") with an Open Login Items Settings action. The `.requiresApproval` and `.notFound` presentations remain verbatim, so operation failures stay distinguishable from approval-pending and not-found states.
- No UI-layer change needed: `GeneralTabView`'s existing `WinkBanner` + settings-button wiring already renders the new presentation.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

Updated: `setLaunchAtLoginDoesNotUpdateStateWhenRegistrationFails` now also asserts the surfaced `.register` failure and error-banner presentation. New: unregister-failure surfacing, recovery-clears-failure for both operations, external-fix clearing via status refresh, `.requiresApproval`/`.notFound` presentation precedence with pinned strings, and direct service tests for the three `setEnabled` return shapes. Full suite: 489 tests / 44 suites, 0 failures. Live `SMAppService` failure injection on a packaged build was not exercised in this change window (needs a fault-injection package plus login-item state changes on the host); the service seam is fully covered by deterministic client-injected tests.

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.
- If the PR touches runtime-sensitive files, the PR metadata workflow will reject `Not runtime-sensitive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
