### PR TITLE
Refresh Settings usage data when Wink becomes active

### DIFF
--- a/Sources/Wink/Protocols/UsageTracking.swift
+++ b/Sources/Wink/Protocols/UsageTracking.swift
@@ -79,6 +79,7 @@ protocol UsageTracking: Sendable {
     func streakDays(relativeTo now: Date) async -> Int
     func usageTimeZone() async -> TimeZone
     func lastUsedPerShortcut() async -> [UUID: Date]
+    func deleteUsage(shortcutId: UUID) async
     /// Returns nil when the surrounding task was cancelled; a cancelled
     /// refresh stops issuing further queries instead of completing the
     /// remaining phases.
@@ -113,6 +114,11 @@ extension UsageTracking {
     func lastUsedPerShortcut() async -> [UUID: Date] {
         [:]
     }
+
+    // deleteUsage deliberately has NO extension default: an async default
+    // alongside UsageTracker's synchronous actor method would create a
+    // sync/async overload pair, and async contexts prefer the async
+    // candidate — silently routing concrete calls to a no-op.
 
     /// Serial composition over the individual query methods with a
     /// cancellation check before each phase and the 7-day datasets

--- a/Sources/Wink/Services/ShortcutEditorState.swift
+++ b/Sources/Wink/Services/ShortcutEditorState.swift
@@ -83,7 +83,8 @@ final class ShortcutEditorState {
 
     private let shortcutStore: ShortcutStore
     private let shortcutManager: ShortcutManager
-    private let usageTracker: UsageTracker?
+    private let usageTracker: (any UsageTracking)?
+    @ObservationIgnored private var usageRefreshGeneration: UInt64 = 0
     private let onShortcutConfigurationChange: @MainActor () -> Void
     private let shortcutValidator = ShortcutValidator()
     private let recipeCodec: WinkRecipeCodec
@@ -94,7 +95,7 @@ final class ShortcutEditorState {
     init(
         shortcutStore: ShortcutStore,
         shortcutManager: ShortcutManager,
-        usageTracker: UsageTracker? = nil,
+        usageTracker: (any UsageTracking)? = nil,
         recipeCodec: WinkRecipeCodec = WinkRecipeCodec(),
         recipeImportPlanner: WinkRecipeImportPlanner = WinkRecipeImportPlanner(),
         recipeTransferClient: RecipeTransferClient = .live,
@@ -323,12 +324,25 @@ final class ShortcutEditorState {
         pendingRecipeImport = nil
     }
 
+    /// Fire-and-forget wrapper for lifecycle triggers (tab selection, app
+    /// reactivation) that have no async context of their own.
+    func scheduleUsageRefresh() {
+        Task { await refreshUsageCounts() }
+    }
+
     func refreshUsageCounts() async {
         guard let usageTracker else { return }
+        usageRefreshGeneration &+= 1
+        let generation = usageRefreshGeneration
         async let counts = usageTracker.usageCounts(days: 7)
         async let lastUsedMap = usageTracker.lastUsedPerShortcut()
-        usageCounts = await counts
-        lastUsed = await lastUsedMap
+        let fetchedCounts = await counts
+        let fetchedLastUsed = await lastUsedMap
+        // A newer refresh owns the published maps; dropping the stale result
+        // keeps usageCounts/lastUsed from mixing two different fetches.
+        guard generation == usageRefreshGeneration else { return }
+        usageCounts = fetchedCounts
+        lastUsed = fetchedLastUsed
     }
 
     /// Saves through the manager (disk first, then in-memory store). On

--- a/Sources/Wink/UI/SettingsView.swift
+++ b/Sources/Wink/UI/SettingsView.swift
@@ -18,8 +18,15 @@ final class SettingsUsageRefreshCoalescer {
 
     func shouldRefresh() -> Bool {
         let timestamp = now()
-        if let lastRefreshAt, timestamp.timeIntervalSince(lastRefreshAt) < Self.minimumInterval {
-            return false
+        if let lastRefreshAt {
+            let interval = timestamp.timeIntervalSince(lastRefreshAt)
+            // A negative interval means the wall clock stepped backwards;
+            // treating it as "inside the window" would suppress every
+            // refresh until the clock re-passes the old stamp, so it counts
+            // as outside the window instead.
+            if interval >= 0 && interval < Self.minimumInterval {
+                return false
+            }
         }
 
         lastRefreshAt = timestamp

--- a/Sources/Wink/UI/SettingsView.swift
+++ b/Sources/Wink/UI/SettingsView.swift
@@ -1,9 +1,53 @@
 import AppKit
 import SwiftUI
 
+/// Collapses bursts of reactivation notifications into at most one usage
+/// refresh per window. Held as view `@State` so the window survives across
+/// body evaluations; only dispatched refreshes consume the window, so a
+/// suppressed tab (General) never blocks a later real refresh.
+@MainActor
+final class SettingsUsageRefreshCoalescer {
+    static let minimumInterval: TimeInterval = 1.0
+
+    private let now: @Sendable () -> Date
+    private var lastRefreshAt: Date?
+
+    nonisolated init(now: @escaping @Sendable () -> Date = Date.init) {
+        self.now = now
+    }
+
+    func shouldRefresh() -> Bool {
+        let timestamp = now()
+        if let lastRefreshAt, timestamp.timeIntervalSince(lastRefreshAt) < Self.minimumInterval {
+            return false
+        }
+
+        lastRefreshAt = timestamp
+        return true
+    }
+}
+
 @MainActor
 struct SettingsViewLifecycleHandler {
     let preferences: AppPreferences
+    var usageRefreshCoalescer: SettingsUsageRefreshCoalescer
+    var selectedTab: () -> SettingsTab
+    var refreshInsightsUsage: () -> Void
+    var refreshShortcutsUsage: () -> Void
+
+    init(
+        preferences: AppPreferences,
+        usageRefreshCoalescer: SettingsUsageRefreshCoalescer = SettingsUsageRefreshCoalescer(),
+        selectedTab: @escaping () -> SettingsTab = { .shortcuts },
+        refreshInsightsUsage: @escaping () -> Void = {},
+        refreshShortcutsUsage: @escaping () -> Void = {}
+    ) {
+        self.preferences = preferences
+        self.usageRefreshCoalescer = usageRefreshCoalescer
+        self.selectedTab = selectedTab
+        self.refreshInsightsUsage = refreshInsightsUsage
+        self.refreshShortcutsUsage = refreshShortcutsUsage
+    }
 
     func handleAppear() {
         preferences.refreshPermissions()
@@ -13,6 +57,22 @@ struct SettingsViewLifecycleHandler {
     func handleAppDidBecomeActive() {
         preferences.refreshPermissions()
         preferences.refreshLaunchAtLoginStatus()
+        refreshUsageForSelectedTab()
+    }
+
+    /// Reactivation refreshes only the visible tab's usage model; the hidden
+    /// tab gets its own fresh query when it is selected (issue #326).
+    private func refreshUsageForSelectedTab() {
+        switch selectedTab() {
+        case .insights:
+            guard usageRefreshCoalescer.shouldRefresh() else { return }
+            refreshInsightsUsage()
+        case .shortcuts:
+            guard usageRefreshCoalescer.shouldRefresh() else { return }
+            refreshShortcutsUsage()
+        case .general:
+            break
+        }
     }
 }
 
@@ -27,9 +87,16 @@ struct SettingsView: View {
     @Bindable var settingsLauncher: SettingsLauncher
 
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    @State private var usageRefreshCoalescer = SettingsUsageRefreshCoalescer()
 
     private var lifecycleHandler: SettingsViewLifecycleHandler {
-        SettingsViewLifecycleHandler(preferences: preferences)
+        SettingsViewLifecycleHandler(
+            preferences: preferences,
+            usageRefreshCoalescer: usageRefreshCoalescer,
+            selectedTab: { settingsLauncher.selectedTab },
+            refreshInsightsUsage: { insightsViewModel.scheduleRefresh() },
+            refreshShortcutsUsage: { editor.scheduleUsageRefresh() }
+        )
     }
 
     var body: some View {
@@ -76,8 +143,13 @@ struct SettingsView: View {
             }
         }
         .onChange(of: settingsLauncher.selectedTab) { _, newTab in
-            if newTab == .insights {
+            switch newTab {
+            case .insights:
                 insightsViewModel.scheduleRefresh()
+            case .shortcuts:
+                editor.scheduleUsageRefresh()
+            case .general:
+                break
             }
         }
         .onAppear {

--- a/Tests/WinkTests/AppControllerTests.swift
+++ b/Tests/WinkTests/AppControllerTests.swift
@@ -290,6 +290,7 @@ private func ensureAppKitApplication() {
 }
 
 private actor EmptyUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] { [:] }
     func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] { [:] }
     func totalSwitches(days: Int, relativeTo now: Date) async -> Int { 0 }

--- a/Tests/WinkTests/InsightsViewModelTests.swift
+++ b/Tests/WinkTests/InsightsViewModelTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import Wink
 
 actor DelayedUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
 
     init(shortcutId: UUID) {
@@ -42,6 +43,7 @@ actor DelayedUsageTracker: UsageTracking {
 }
 
 actor BoundaryCrossingUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
 
     init(shortcutId: UUID) {
@@ -78,6 +80,7 @@ actor BoundaryCrossingUsageTracker: UsageTracking {
 }
 
 actor TimeZoneAlignedUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
     let timeZone: TimeZone
 

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -799,6 +799,7 @@ private extension NSPoint {
 }
 
 private actor StaticUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
 
     init(shortcutId: UUID) {
@@ -843,6 +844,7 @@ private actor StaticUsageTracker: UsageTracking {
 }
 
 private actor MultiShortcutUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     private let counts: [UUID: Int]
     private let dailyCountsByShortcut: [String: [(date: String, count: Int)]]
     private let hourlyBuckets: [HourlyUsageBucket]

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverSearchTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverSearchTests.swift
@@ -148,6 +148,7 @@ private final class SearchPopoverRuntimeState {
 }
 
 private actor SearchNoopUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] { [:] }
     func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] { [:] }
     func totalSwitches(days: Int, relativeTo now: Date) async -> Int { 0 }

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
@@ -334,6 +334,7 @@ private final class PopoverRuntimeState {
 }
 
 private actor StaticUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let total: Int
 
     init(total: Int) {

--- a/Tests/WinkTests/SettingsViewTests.swift
+++ b/Tests/WinkTests/SettingsViewTests.swift
@@ -65,6 +65,160 @@ func handleAppDidBecomeActiveRefreshesShortcutCaptureAndLaunchAtLoginStatus() {
     #expect(preferences.launchAtLoginStatus == .enabled)
 }
 
+@Test @MainActor
+func didBecomeActiveWithInsightsSelectedRefreshesInsightsUsageOnly() {
+    let counters = UsageRefreshCounters()
+    let handler = makeLifecycleHandler(selectedTab: .insights, counters: counters)
+
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 1)
+    #expect(counters.shortcuts == 0)
+}
+
+@Test @MainActor
+func didBecomeActiveWithShortcutsSelectedRefreshesShortcutsUsageOnly() {
+    let counters = UsageRefreshCounters()
+    let handler = makeLifecycleHandler(selectedTab: .shortcuts, counters: counters)
+
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 0)
+    #expect(counters.shortcuts == 1)
+}
+
+@Test @MainActor
+func didBecomeActiveWithGeneralSelectedRefreshesNoUsage() {
+    let counters = UsageRefreshCounters()
+    let handler = makeLifecycleHandler(selectedTab: .general, counters: counters)
+
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 0)
+    #expect(counters.shortcuts == 0)
+}
+
+@Test @MainActor
+func reactivationBurstCoalescesToOneUsageRefreshPerWindow() {
+    let counters = UsageRefreshCounters()
+    let clock = MutableDateBox(date: Date(timeIntervalSinceReferenceDate: 0))
+    let handler = makeLifecycleHandler(
+        selectedTab: .insights,
+        counters: counters,
+        coalescer: SettingsUsageRefreshCoalescer(now: { clock.date })
+    )
+
+    handler.handleAppDidBecomeActive()
+    clock.date = Date(timeIntervalSinceReferenceDate: 0.2)
+    handler.handleAppDidBecomeActive()
+    clock.date = Date(timeIntervalSinceReferenceDate: 0.9)
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 1)
+
+    clock.date = Date(timeIntervalSinceReferenceDate: 1.5)
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 2)
+}
+
+@Test @MainActor
+func generalTabActivationDoesNotConsumeTheCoalescingWindow() {
+    let counters = UsageRefreshCounters()
+    let clock = MutableDateBox(date: Date(timeIntervalSinceReferenceDate: 0))
+    let selectedTab = MutableTabBox(tab: .general)
+    let coalescer = SettingsUsageRefreshCoalescer(now: { clock.date })
+    let handler = SettingsViewLifecycleHandler(
+        preferences: makePreferences(
+            permissionState: MutablePermissionState(ax: false, input: false),
+            launchAtLoginState: MutableLaunchAtLoginState(status: .notRegistered)
+        ),
+        usageRefreshCoalescer: coalescer,
+        selectedTab: { selectedTab.tab },
+        refreshInsightsUsage: { counters.insights += 1 },
+        refreshShortcutsUsage: { counters.shortcuts += 1 }
+    )
+
+    handler.handleAppDidBecomeActive()
+    #expect(counters.insights == 0)
+
+    // A suppressed General activation must not start the window; a refresh
+    // 0.2s later on Insights still runs.
+    selectedTab.tab = .insights
+    clock.date = Date(timeIntervalSinceReferenceDate: 0.2)
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 1)
+}
+
+@Test @MainActor
+func didBecomeActiveStillRefreshesPermissionsAndLaunchAtLoginAlongsideUsage() {
+    let permissionState = MutablePermissionState(ax: false, input: false)
+    let launchAtLoginState = MutableLaunchAtLoginState(status: .requiresApproval)
+    let counters = UsageRefreshCounters()
+    let preferences = makePreferences(
+        permissionState: permissionState,
+        launchAtLoginState: launchAtLoginState
+    )
+    let handler = SettingsViewLifecycleHandler(
+        preferences: preferences,
+        selectedTab: { .insights },
+        refreshInsightsUsage: { counters.insights += 1 },
+        refreshShortcutsUsage: { counters.shortcuts += 1 }
+    )
+
+    permissionState.ax = true
+    permissionState.input = true
+    launchAtLoginState.statusValue = .enabled
+
+    handler.handleAppDidBecomeActive()
+
+    #expect(preferences.launchAtLoginStatus == .enabled)
+    #expect(preferences.shortcutCaptureStatus.accessibilityGranted)
+    #expect(counters.insights == 1)
+}
+
+@MainActor
+private func makeLifecycleHandler(
+    selectedTab: SettingsTab,
+    counters: UsageRefreshCounters,
+    coalescer: SettingsUsageRefreshCoalescer = SettingsUsageRefreshCoalescer()
+) -> SettingsViewLifecycleHandler {
+    SettingsViewLifecycleHandler(
+        preferences: makePreferences(
+            permissionState: MutablePermissionState(ax: false, input: false),
+            launchAtLoginState: MutableLaunchAtLoginState(status: .notRegistered)
+        ),
+        usageRefreshCoalescer: coalescer,
+        selectedTab: { selectedTab },
+        refreshInsightsUsage: { counters.insights += 1 },
+        refreshShortcutsUsage: { counters.shortcuts += 1 }
+    )
+}
+
+@MainActor
+private final class UsageRefreshCounters {
+    var insights = 0
+    var shortcuts = 0
+}
+
+private final class MutableDateBox: @unchecked Sendable {
+    var date: Date
+
+    init(date: Date) {
+        self.date = date
+    }
+}
+
+@MainActor
+private final class MutableTabBox {
+    var tab: SettingsTab
+
+    init(tab: SettingsTab) {
+        self.tab = tab
+    }
+}
+
 @MainActor
 private func makePreferences(
     permissionState: MutablePermissionState,

--- a/Tests/WinkTests/SettingsViewTests.swift
+++ b/Tests/WinkTests/SettingsViewTests.swift
@@ -123,6 +123,35 @@ func reactivationBurstCoalescesToOneUsageRefreshPerWindow() {
 }
 
 @Test @MainActor
+func backwardClockJumpDoesNotSuppressReactivationRefreshes() {
+    let counters = UsageRefreshCounters()
+    let clock = MutableDateBox(date: Date(timeIntervalSinceReferenceDate: 600))
+    let handler = makeLifecycleHandler(
+        selectedTab: .insights,
+        counters: counters,
+        coalescer: SettingsUsageRefreshCoalescer(now: { clock.date })
+    )
+
+    handler.handleAppDidBecomeActive()
+    #expect(counters.insights == 1)
+
+    // The wall clock steps back 10 minutes; the stale stamp must not
+    // suppress refreshes until the clock re-passes it.
+    clock.date = Date(timeIntervalSinceReferenceDate: 0)
+    handler.handleAppDidBecomeActive()
+
+    #expect(counters.insights == 2)
+
+    // The window restarts from the new (earlier) stamp.
+    clock.date = Date(timeIntervalSinceReferenceDate: 0.5)
+    handler.handleAppDidBecomeActive()
+    #expect(counters.insights == 2)
+    clock.date = Date(timeIntervalSinceReferenceDate: 1.5)
+    handler.handleAppDidBecomeActive()
+    #expect(counters.insights == 3)
+}
+
+@Test @MainActor
 func generalTabActivationDoesNotConsumeTheCoalescingWindow() {
     let counters = UsageRefreshCounters()
     let clock = MutableDateBox(date: Date(timeIntervalSinceReferenceDate: 0))

--- a/Tests/WinkTests/ShortcutEditorStateTests.swift
+++ b/Tests/WinkTests/ShortcutEditorStateTests.swift
@@ -862,3 +862,124 @@ private func makeEditorContext(
 
     return (editor, manager, shortcutStore, harness, callbackCount)
 }
+
+@Test @MainActor
+func staleUsageRefreshCannotOverwriteNewerPublishedUsageData() async {
+    let shortcutStore = ShortcutStore()
+    let manager = ShortcutManager(
+        shortcutStore: shortcutStore,
+        persistenceService: TestPersistenceHarness().makePersistenceService(),
+        appSwitcher: FakeAppSwitcher(),
+        captureCoordinator: ShortcutCaptureCoordinator(
+            standardProvider: FakeCaptureProvider(),
+            hyperProvider: FakeHyperCaptureProvider()
+        ),
+        permissionService: FakePermissionService(ax: true, input: false),
+        diagnosticClient: .init(log: { _ in })
+    )
+    let tracker = GatedUsageTracker()
+    let editor = ShortcutEditorState(
+        shortcutStore: shortcutStore,
+        shortcutManager: manager,
+        usageTracker: tracker
+    )
+    let shortcutID = UUID()
+
+    // Drain the init-scheduled refresh so the scenario owns the gate.
+    await waitForPendingUsageCounts(on: tracker, count: 1)
+    await tracker.releaseFirstUsageCounts(returning: [:])
+    await waitForPendingUsageCounts(on: tracker, count: 0)
+
+    let staleLastUsed = [shortcutID: Date(timeIntervalSinceReferenceDate: 100)]
+    let freshLastUsed = [shortcutID: Date(timeIntervalSinceReferenceDate: 900)]
+
+    await tracker.setLastUsedValue(staleLastUsed)
+    let staleRefresh = Task { await editor.refreshUsageCounts() }
+    await waitForPendingUsageCounts(on: tracker, count: 1)
+
+    await tracker.setLastUsedValue(freshLastUsed)
+    let freshRefresh = Task { await editor.refreshUsageCounts() }
+    await waitForPendingUsageCounts(on: tracker, count: 2)
+
+    // The newer refresh completes first and publishes.
+    await tracker.releaseLastUsageCounts(returning: [shortcutID: 9])
+    await freshRefresh.value
+
+    #expect(editor.usageCounts == [shortcutID: 9])
+    #expect(editor.lastUsed == freshLastUsed)
+
+    // The superseded refresh finishes afterwards; its stale result must be
+    // discarded instead of tearing the published usage maps.
+    await tracker.releaseFirstUsageCounts(returning: [shortcutID: 1])
+    await staleRefresh.value
+
+    #expect(editor.usageCounts == [shortcutID: 9])
+    #expect(editor.lastUsed == freshLastUsed)
+}
+
+@MainActor
+private func waitForPendingUsageCounts(on tracker: GatedUsageTracker, count: Int) async {
+    for _ in 0..<5000 {
+        if await tracker.pendingUsageCountsCount() == count {
+            return
+        }
+        await Task.yield()
+    }
+    Issue.record("timed out waiting for \(count) pending usageCounts calls")
+}
+
+private actor GatedUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
+    private var pendingUsageCounts: [CheckedContinuation<[UUID: Int], Never>] = []
+    private var lastUsedValue: [UUID: Date] = [:]
+
+    func setLastUsedValue(_ value: [UUID: Date]) {
+        lastUsedValue = value
+    }
+
+    func pendingUsageCountsCount() -> Int {
+        pendingUsageCounts.count
+    }
+
+    func releaseFirstUsageCounts(returning value: [UUID: Int]) {
+        guard !pendingUsageCounts.isEmpty else { return }
+        pendingUsageCounts.removeFirst().resume(returning: value)
+    }
+
+    func releaseLastUsageCounts(returning value: [UUID: Int]) {
+        guard !pendingUsageCounts.isEmpty else { return }
+        pendingUsageCounts.removeLast().resume(returning: value)
+    }
+
+    func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] {
+        await withCheckedContinuation { pendingUsageCounts.append($0) }
+    }
+
+    func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] {
+        [:]
+    }
+
+    func totalSwitches(days: Int, relativeTo now: Date) async -> Int {
+        0
+    }
+
+    func hourlyCounts(days: Int, relativeTo now: Date) async -> [HourlyUsageBucket] {
+        []
+    }
+
+    func previousPeriodTotal(days: Int, relativeTo now: Date) async -> Int {
+        0
+    }
+
+    func streakDays(relativeTo now: Date) async -> Int {
+        0
+    }
+
+    func usageTimeZone() async -> TimeZone {
+        .current
+    }
+
+    func lastUsedPerShortcut() async -> [UUID: Date] {
+        lastUsedValue
+    }
+}

--- a/Tests/WinkTests/UsageDashboardSnapshotTests.swift
+++ b/Tests/WinkTests/UsageDashboardSnapshotTests.swift
@@ -216,6 +216,7 @@ struct UsageDashboardSnapshotTests {
 }
 
 private actor RecordingUsageTracker: UsageTracking {
+    func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
     private var counts: [String: Int] = [:]
 


### PR DESCRIPTION
Fixes #326

## Summary
- Reactivating Wink while Settings stays open now refreshes the usage model for the currently selected tab only: Insights re-runs its snapshot refresh through the existing generation-owned `scheduleRefresh()` path; the Shortcuts tab re-fetches usage counts and last-used metadata. The General tab triggers no usage work, and the #136 permission/launch-at-login refresh on reactivation is unchanged.
- Selecting the other tab later triggers that tab's own fresh query: the tab-change handler now also refreshes editor usage when switching to Shortcuts (Insights already refreshed on selection).
- Reactivation bursts are coalesced by a view-state `SettingsUsageRefreshCoalescer` (1s window). Only a dispatched refresh consumes the window, so a suppressed General-tab activation cannot block a real refresh moments later.
- `ShortcutEditorState` moves to `any UsageTracking` (with `deleteUsage` promoted to a protocol requirement) and guards `refreshUsageCounts()` with a generation so a superseded refresh can never tear or overwrite newer published usage maps. `deleteUsage` deliberately has no async extension default: async contexts prefer async overloads, so a default next to the tracker's synchronous actor method would silently route concrete calls to a no-op (caught by test; fakes implement the one-line stub explicitly).

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

New coverage: per-tab reactivation refresh (Insights-selected refreshes Insights only, Shortcuts-selected refreshes Shortcuts only, General refreshes none), burst coalescing to one refresh per window with a later notification starting a new one, General activations not consuming the coalescing window, permissions + launch-at-login still refreshed alongside usage, and a gated-tracker editor test proving a stale overlapping refresh is discarded after a newer one publishes. Full suite: 506 tests / 47 suites, 0 failures.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.
- If the PR touches runtime-sensitive files, the PR metadata workflow will reject `Not runtime-sensitive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
