### PR TITLE
feat: replace cheat-sheet microsite with the Wink landing page

### DIFF
--- a/docs/design/landing/index.html
+++ b/docs/design/landing/index.html
@@ -1,6 +1,4 @@
-// Wink landing page — generated from docs/design/landing/index.html
-// Regenerate by re-escaping that file (\ ` ${) into this template literal.
-const html = `<!doctype html>
+<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -750,7 +748,7 @@ const html = `<!doctype html>
         <div class="show-copy">
           <p class="eyebrow">01 · cycle</p>
           <h3>Press again.<br>Walk the windows.</h3>
-          <p>Repeat the chord and Wink steps through that app's windows — <strong>minimized ones included</strong>, which <kbd>⌘\`</kbd> never manages. A HUD keeps count so you're never lost. And one chord can cycle whatever app you're in, wherever you are.</p>
+          <p>Repeat the chord and Wink steps through that app's windows — <strong>minimized ones included</strong>, which <kbd>⌘`</kbd> never manages. A HUD keeps count so you're never lost. And one chord can cycle whatever app you're in, wherever you are.</p>
         </div>
         <div class="show-mock">
           <div class="cyc" aria-hidden="true">
@@ -1224,15 +1222,3 @@ const html = `<!doctype html>
 </script>
 </body>
 </html>
-`;
-
-export default {
-  async fetch(): Promise<Response> {
-    return new Response(html, {
-      headers: {
-        "content-type": "text/html;charset=UTF-8",
-        "cache-control": "public, max-age=3600",
-      },
-    });
-  },
-};


### PR DESCRIPTION
## Summary
- Replaces the personal cheat-sheet microsite served at wink.aixie.de with a full Wink product landing page (interactive summon/dismiss hero demo, Hyper keyboard map, numbered feature showcases with animated HTML UI mocks, Insights section, principles strip, download CTA).
- Canonical page source is `docs/design/landing/index.html` (self-contained, dual light/dark theme, zero external requests); `worker/src/index.ts` embeds it as an escaped template literal and keeps the existing fetch handler/caching unchanged.

## Testing
- [ ] `swift test`
- [x] Additional validation noted below when needed

`npx wrangler deploy --dry-run` builds clean (54.32 KiB / 13.08 KiB gzip). No Swift sources touched.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.
- If the PR touches runtime-sensitive files, the PR metadata workflow will reject `Not runtime-sensitive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
