### PR TITLE
feat: surface Secure Input degradation instead of failing silently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Before making large structural changes, read `docs/architecture.md`.
 
 - Exception rules (`FrontmostExceptionMonitor`) auto-pause capture while a listed bundle is frontmost (VM/remote-desktop factory defaults). Manual pause and exception auto-pause are independent bits composed by OR in `ShortcutManager` — resuming one while the other holds must keep capture paused, auto-pause never persists and never mutates the manual bit, and the menu bar pill names the triggering app ("Paused · Parallels Desktop").
 
-- Secure Input detection: `IsSecureEventInputEnabled()` is probed lazily in `shortcutCaptureStatus()` and on the existing 3s permission poll (no new timers). It degrades the Hyper/event-tap route only; the pill shows "Limited · Secure Input" instead of a false Ready. Detection is transparency-only — no auto-remediation, no culprit-process lookup.
+- Secure Input detection: `IsSecureEventInputEnabled()` is probed lazily in `shortcutCaptureStatus()` and on the existing 3s permission poll (no new timers). It degrades every tap-dependent route — Hyper AND standard Fn+F-row bindings (their observer fails closed); the pill shows "Limited · Secure Input" instead of a false Ready. Detection is transparency-only — no auto-remediation, no culprit-process lookup.
 
 ## Concurrency and actor boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ Before making large structural changes, read `docs/architecture.md`.
 
 - Exception rules (`FrontmostExceptionMonitor`) auto-pause capture while a listed bundle is frontmost (VM/remote-desktop factory defaults). Manual pause and exception auto-pause are independent bits composed by OR in `ShortcutManager` — resuming one while the other holds must keep capture paused, auto-pause never persists and never mutates the manual bit, and the menu bar pill names the triggering app ("Paused · Parallels Desktop").
 
+- Secure Input detection: `IsSecureEventInputEnabled()` is probed lazily in `shortcutCaptureStatus()` and on the existing 3s permission poll (no new timers). It degrades the Hyper/event-tap route only; the pill shows "Limited · Secure Input" instead of a false Ready. Detection is transparency-only — no auto-remediation, no culprit-process lookup.
+
 ## Concurrency and actor boundaries
 
 - Do not use `@MainActor` as the default for non-UI code

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -146,6 +146,10 @@ final class AppController {
         // Configured BEFORE the startup sequence so launching while an
         // exception app is frontmost never lets capture (or permission
         // prompts) fire ahead of the auto-pause.
+        shortcutManager.onCaptureStatusChange = { [weak self] in
+            self?.appPreferences.refreshPermissions()
+        }
+
         Self.runStartupSequence(
             startUpdateService: { _ = updateService },
             loadShortcuts: { try persistenceService.load() },

--- a/Sources/Wink/Models/ShortcutCaptureStatus.swift
+++ b/Sources/Wink/Models/ShortcutCaptureStatus.swift
@@ -11,6 +11,10 @@ struct ShortcutCaptureStatus: Equatable, Sendable {
     let registeredStandardShortcutCount: Int
     let standardHandlerState: ShortcutCaptureHandlerState
     let standardRegistrationFailures: [ShortcutCaptureRegistrationFailure]
+    /// macOS Secure Event Input is engaged (password field, secure prompt):
+    /// the Hyper/event-tap route stops receiving key events until it ends.
+    /// Surfaced so degradation is visible instead of silent.
+    let secureInputActive: Bool
 
     init(
         accessibilityGranted: Bool,
@@ -24,10 +28,12 @@ struct ShortcutCaptureStatus: Equatable, Sendable {
         standardShortcutCount: Int = 0,
         registeredStandardShortcutCount: Int = 0,
         standardHandlerState: ShortcutCaptureHandlerState = .installed,
-        standardRegistrationFailures: [ShortcutCaptureRegistrationFailure] = []
+        standardRegistrationFailures: [ShortcutCaptureRegistrationFailure] = [],
+        secureInputActive: Bool = false
     ) {
         self.accessibilityGranted = accessibilityGranted
         self.inputMonitoringGranted = inputMonitoringGranted
+        self.secureInputActive = secureInputActive
         self.inputMonitoringRequired = inputMonitoringRequired
         self.carbonHotKeysRegistered = carbonHotKeysRegistered
         self.eventTapActive = eventTapActive

--- a/Sources/Wink/Services/ShortcutCaptureCoordinator.swift
+++ b/Sources/Wink/Services/ShortcutCaptureCoordinator.swift
@@ -122,7 +122,8 @@ final class ShortcutCaptureCoordinator {
 
     func status(
         accessibilityGranted: Bool,
-        inputMonitoringGranted: Bool
+        inputMonitoringGranted: Bool,
+        secureInputActive: Bool = false
     ) -> ShortcutCaptureStatus {
         let standardRegistrationState = standardProvider.registrationState
         let standardShortcutCount = standardRegistrationState.desiredShortcutCount
@@ -154,7 +155,8 @@ final class ShortcutCaptureCoordinator {
             standardShortcutCount: standardShortcutCount,
             registeredStandardShortcutCount: standardRegistrationState.registeredShortcutCount,
             standardHandlerState: standardRegistrationState.handlerState,
-            standardRegistrationFailures: standardRegistrationState.failures
+            standardRegistrationFailures: standardRegistrationState.failures,
+            secureInputActive: secureInputActive
         )
     }
 

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 import Foundation
 import UserNotifications
 import os.log
@@ -38,6 +39,12 @@ final class ShortcutManager {
     private var hyperKeyEnabled = false
     private var shortcutsPaused = false
     private var autoPausedByException = false
+    private let secureInputProbe: () -> Bool
+    private var lastSecureInputState = false
+    /// Invoked from the 3s poll when observed capture-relevant state
+    /// changed (permissions, secure input) so observers can re-pull
+    /// `shortcutCaptureStatus()` without their own timers.
+    var onCaptureStatusChange: (@MainActor () -> Void)?
 
     private var effectivePaused: Bool {
         shortcutsPaused || autoPausedByException
@@ -54,6 +61,7 @@ final class ShortcutManager {
         usageTracker: UsageTracker? = nil,
         appBundleLocator: AppBundleLocator = AppBundleLocator(),
         automaticPermissionPromptingEnabled: Bool = shortcutManagerAutomaticPermissionPromptingEnabled(),
+        secureInputProbe: @escaping () -> Bool = { IsSecureEventInputEnabled() },
         diagnosticClient: DiagnosticClient
     ) {
         self.shortcutStore = shortcutStore
@@ -65,6 +73,7 @@ final class ShortcutManager {
         self.appBundleLocator = appBundleLocator
         self.diagnosticClient = diagnosticClient
         self.automaticPermissionPromptingEnabled = automaticPermissionPromptingEnabled
+        self.secureInputProbe = secureInputProbe
     }
 
     func start() {
@@ -133,7 +142,8 @@ final class ShortcutManager {
     func shortcutCaptureStatus() -> ShortcutCaptureStatus {
         captureCoordinator.status(
             accessibilityGranted: permissionService.isAccessibilityTrusted(),
-            inputMonitoringGranted: permissionService.isInputMonitoringTrusted()
+            inputMonitoringGranted: permissionService.isInputMonitoringTrusted(),
+            secureInputActive: secureInputProbe()
         )
     }
 
@@ -233,6 +243,14 @@ final class ShortcutManager {
     func checkPermissionChange() {
         let axGranted = permissionService.isAccessibilityTrusted()
         var imGranted = permissionService.isInputMonitoringTrusted()
+        let secureInput = secureInputProbe()
+        if secureInput != lastSecureInputState {
+            lastSecureInputState = secureInput
+            diagnosticClient.log(secureInput
+                ? "Secure Input engaged — Hyper/event-tap shortcuts degraded until it ends"
+                : "Secure Input ended — shortcut capture back to normal")
+            onCaptureStatusChange?()
+        }
         let snapshot = captureCoordinator.snapshot()
         let accessibilityChanged = axGranted != lastAccessibilityState
         let inputMonitoringChanged = imGranted != lastInputMonitoringState

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -61,7 +61,12 @@ final class ShortcutManager {
         usageTracker: UsageTracker? = nil,
         appBundleLocator: AppBundleLocator = AppBundleLocator(),
         automaticPermissionPromptingEnabled: Bool = shortcutManagerAutomaticPermissionPromptingEnabled(),
-        secureInputProbe: @escaping () -> Bool = { IsSecureEventInputEnabled() },
+        // Optional with a nil default instead of a closure-literal default:
+        // the CI toolchain (Xcode 16.4, Swift 6.1.2) SILGen crashes while
+        // lowering complex default-argument thunks for this initializer
+        // (same class as the WindowCycleClient `.live` default); a nil
+        // literal is trivially emitted and the closure moves into the body.
+        secureInputProbe: (() -> Bool)? = nil,
         diagnosticClient: DiagnosticClient
     ) {
         self.shortcutStore = shortcutStore
@@ -73,7 +78,7 @@ final class ShortcutManager {
         self.appBundleLocator = appBundleLocator
         self.diagnosticClient = diagnosticClient
         self.automaticPermissionPromptingEnabled = automaticPermissionPromptingEnabled
-        self.secureInputProbe = secureInputProbe
+        self.secureInputProbe = secureInputProbe ?? { IsSecureEventInputEnabled() }
     }
 
     func start() {

--- a/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
+++ b/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
@@ -92,6 +92,10 @@ final class MenuBarPopoverModel {
         preferences.autoPauseTriggerAppName
     }
 
+    var secureInputActive: Bool {
+        preferences.shortcutCaptureStatus.secureInputActive
+    }
+
     var isCheckForUpdatesEnabled: Bool {
         preferences.updatePresentation.checkForUpdatesEnabled
     }
@@ -310,7 +314,8 @@ struct MenuBarPopoverView: View {
 
             MenuBarStatusPill(
                 paused: model.shortcutsPaused || model.autoPauseTriggerAppName != nil,
-                autoPausedBy: model.autoPauseTriggerAppName
+                autoPausedBy: model.autoPauseTriggerAppName,
+                secureInputActive: model.secureInputActive
             )
         }
     }
@@ -461,9 +466,14 @@ private struct MenuBarStatusPill: View {
 
     let paused: Bool
     var autoPausedBy: String?
+    var secureInputActive: Bool = false
 
     private var title: String {
-        guard paused else { return "Ready" }
+        guard paused else {
+            // Secure Input silently starves the Hyper/event-tap route;
+            // name it instead of showing a false "Ready".
+            return secureInputActive ? "Limited · Secure Input" : "Ready"
+        }
         // Exception auto-pause names its trigger so "my shortcuts are
         // dead" never reads as a mystery.
         if let autoPausedBy {
@@ -472,16 +482,23 @@ private struct MenuBarStatusPill: View {
         return "Paused"
     }
 
+    private var degraded: Bool {
+        paused || secureInputActive
+    }
+
     private var background: Color {
-        paused ? palette.amberBgSoft : palette.greenSoft
+        degraded ? palette.amberBgSoft : palette.greenSoft
     }
 
     private var foreground: Color {
-        paused ? palette.amber : palette.green
+        degraded ? palette.amber : palette.green
     }
 
     var body: some View {
         Text(title)
+            .help(secureInputActive && !paused
+                ? "A password field or secure prompt is capturing keyboard input. Hyper shortcuts may not fire until it ends; standard shortcuts keep working."
+                : "")
             .font(WinkType.labelSmall.weight(.semibold))
             .foregroundStyle(foreground)
             .padding(.horizontal, 8)

--- a/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
+++ b/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
@@ -497,7 +497,7 @@ private struct MenuBarStatusPill: View {
     var body: some View {
         Text(title)
             .help(secureInputActive && !paused
-                ? "A password field or secure prompt is capturing keyboard input. Hyper shortcuts may not fire until it ends; standard shortcuts keep working."
+                ? "A password field or secure prompt is capturing keyboard input. Hyper and Fn-based shortcuts may not fire until it ends; other standard shortcuts keep working."
                 : "")
             .font(WinkType.labelSmall.weight(.semibold))
             .foregroundStyle(foreground)

--- a/Tests/WinkTests/ShortcutEditorStateTests.swift
+++ b/Tests/WinkTests/ShortcutEditorStateTests.swift
@@ -1066,3 +1066,39 @@ func manualAndExceptionPausesComposeWithManualWinning() {
     manager.setAutoPausedByException(false)
     #expect(manager.shortcutCaptureStatus().shortcutsPaused == false)
 }
+
+@Test @MainActor
+func captureStatusReflectsSecureInputProbeAndPollNotifiesOnChange() {
+    let shortcutStore = ShortcutStore()
+    var secureInput = false
+    var statusChangeNotifications = 0
+    let manager = ShortcutManager(
+        shortcutStore: shortcutStore,
+        persistenceService: TestPersistenceHarness().makePersistenceService(),
+        appSwitcher: FakeAppSwitcher(),
+        captureCoordinator: ShortcutCaptureCoordinator(
+            standardProvider: FakeCaptureProvider(),
+            hyperProvider: FakeHyperCaptureProvider()
+        ),
+        permissionService: FakePermissionService(ax: true, input: false),
+        secureInputProbe: { secureInput },
+        diagnosticClient: .init(log: { _ in })
+    )
+    manager.onCaptureStatusChange = {
+        statusChangeNotifications += 1
+    }
+
+    #expect(manager.shortcutCaptureStatus().secureInputActive == false)
+
+    secureInput = true
+    #expect(manager.shortcutCaptureStatus().secureInputActive == true)
+
+    // The 3s poll notifies exactly once per transition, both directions.
+    manager.checkPermissionChange()
+    #expect(statusChangeNotifications == 1)
+    manager.checkPermissionChange()
+    #expect(statusChangeNotifications == 1)
+    secureInput = false
+    manager.checkPermissionChange()
+    #expect(statusChangeNotifications == 2)
+}


### PR DESCRIPTION
Fixes #353

## Summary
- Wink now detects macOS **Secure Event Input** (password fields, secure prompts) and surfaces the degradation instead of failing silently — the failure mode behind AltTab's highest-reaction bug ever (#3117, open for years as unactionable).
- Detection is a lazy `IsSecureEventInputEnabled()` probe (public API, no TCC) in `shortcutCaptureStatus()` plus the existing 3s permission poll — zero new timers; the poll notifies once per transition through a new `onCaptureStatusChange` hook that refreshes the observable status.
- The menu bar pill shows **"Limited · Secure Input"** (amber) with a route-accurate tooltip: the Hyper/event-tap route degrades, standard Carbon shortcuts keep working. Flips back to Ready automatically.
- Transparency only: no auto-remediation, no culprit-process lookup (dropped per issue guidance — would need fragile ioreg parsing).

## Testing
- [x] `swift test` — 574 tests green (probe-driven status + once-per-transition poll notification, both directions)
- [ ] Additional validation noted below when needed

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Batch-end validation (per issue #353): empirically confirm the degradation matrix on macOS 15 (Carbon vs tap under Secure Input, e.g. focused password field in Safari) and adjust tooltip copy if the matrix differs.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.
- If the PR touches runtime-sensitive files, the PR metadata workflow will reject `Not runtime-sensitive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
