### PR TITLE
feat: Insights suggests shortcuts for frequently used unbound apps

### DIFF
--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -67,6 +67,11 @@ final class AppController {
             self?.appPreferences.refreshPermissions()
         }
     )
+    private lazy var appActivationRecorder = AppActivationRecorder(
+        onActivation: { [weak self] bundleIdentifier in
+            self?.recordAppActivation(bundleIdentifier)
+        }
+    )
     private lazy var insightsViewModel = InsightsViewModel(
         usageTracker: usageTracker,
         shortcutStore: shortcutStore
@@ -109,6 +114,11 @@ final class AppController {
         menuBarSceneServicesStorage
     }
 
+    private func recordAppActivation(_ bundleIdentifier: String) {
+        let tracker = usageTracker
+        Task { await tracker.recordAppActivation(bundleIdentifier: bundleIdentifier) }
+    }
+
     func start() {
         DiagnosticLog.rotateIfNeeded()
         DiagnosticLog.log("Wink starting, version \(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?")")
@@ -142,6 +152,16 @@ final class AppController {
             ruleBundleIdentifiers: appPreferences.frontmostExceptionRules
         )
         frontmostExceptionMonitor.startObservingWorkspaceNotifications()
+
+        appPreferences.onSuggestShortcutsConfigurationChange = { [weak self] enabled in
+            self?.appActivationRecorder.setEnabled(enabled)
+            if !enabled, let usageTracker = self?.usageTracker {
+                // The toggle is a privacy control: off means stop AND clear.
+                Task { await usageTracker.deleteAllAppActivations() }
+            }
+        }
+        appActivationRecorder.setEnabled(appPreferences.suggestShortcutsFromUsage)
+        appActivationRecorder.startObservingWorkspaceNotifications()
 
         // Configured BEFORE the startup sequence so launching while an
         // exception app is frontmost never lets capture (or permission

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -114,9 +114,26 @@ final class AppController {
         menuBarSceneServicesStorage
     }
 
+    /// FIFO chain over activation writes and the opt-out purge: unstructured
+    /// tasks have no mutual ordering, so a queued write could otherwise land
+    /// AFTER the purge (retaining data while disabled) or a queued purge
+    /// could erase rows recorded after a quick re-enable.
+    private var activationWriteChain: Task<Void, Never>?
+
     private func recordAppActivation(_ bundleIdentifier: String) {
         let tracker = usageTracker
-        Task { await tracker.recordAppActivation(bundleIdentifier: bundleIdentifier) }
+        activationWriteChain = Task { [previous = activationWriteChain] in
+            await previous?.value
+            await tracker.recordAppActivation(bundleIdentifier: bundleIdentifier)
+        }
+    }
+
+    private func purgeAppActivations() {
+        let tracker = usageTracker
+        activationWriteChain = Task { [previous = activationWriteChain] in
+            await previous?.value
+            await tracker.deleteAllAppActivations()
+        }
     }
 
     func start() {
@@ -154,10 +171,13 @@ final class AppController {
         frontmostExceptionMonitor.startObservingWorkspaceNotifications()
 
         appPreferences.onSuggestShortcutsConfigurationChange = { [weak self] enabled in
+            // Recorder disables synchronously before the purge enqueues, so
+            // the FIFO chain guarantees "stop AND clear": prior writes land
+            // first, no later writes exist, and post-re-enable writes queue
+            // after the purge.
             self?.appActivationRecorder.setEnabled(enabled)
-            if !enabled, let usageTracker = self?.usageTracker {
-                // The toggle is a privacy control: off means stop AND clear.
-                Task { await usageTracker.deleteAllAppActivations() }
+            if !enabled {
+                self?.purgeAppActivations()
             }
         }
         appActivationRecorder.setEnabled(appPreferences.suggestShortcutsFromUsage)

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -182,6 +182,12 @@ final class AppController {
         }
         appActivationRecorder.setEnabled(appPreferences.suggestShortcutsFromUsage)
         appActivationRecorder.startObservingWorkspaceNotifications()
+        if !appPreferences.suggestShortcutsFromUsage {
+            // Quitting before the async opt-out purge ran leaves rows on
+            // disk with the preference off; sweep them on every disabled
+            // startup so re-enabling never resurfaces pre-opt-out counts.
+            purgeAppActivations()
+        }
 
         // Configured BEFORE the startup sequence so launching while an
         // exception app is frontmost never lets capture (or permission

--- a/Sources/Wink/Protocols/UsageTracking.swift
+++ b/Sources/Wink/Protocols/UsageTracking.swift
@@ -79,6 +79,9 @@ protocol UsageTracking: Sendable {
     func streakDays(relativeTo now: Date) async -> Int
     func usageTimeZone() async -> TimeZone
     func lastUsedPerShortcut() async -> [UUID: Date]
+    // Async requirement satisfied by UsageTracker's sync actor method; NO
+    // extension default (see deleteUsage note below on the shadowing trap).
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)]
     func deleteUsage(shortcutId: UUID) async
     /// Returns nil when the surrounding task was cancelled; a cancelled
     /// refresh stops issuing further queries instead of completing the

--- a/Sources/Wink/Services/AppActivationRecorder.swift
+++ b/Sources/Wink/Services/AppActivationRecorder.swift
@@ -1,0 +1,57 @@
+import AppKit
+
+/// Counts foreground app activations (local-only) to power the Insights
+/// "Suggested shortcuts" card. Purely observational: one workspace
+/// notification, no TCC, no polling. Wink itself is never recorded;
+/// bound-vs-unbound filtering happens at query time because binding
+/// state changes over time.
+@MainActor
+final class AppActivationRecorder {
+    private let onActivation: @MainActor (String) -> Void
+    private var isEnabled = false
+
+    init(onActivation: @escaping @MainActor (String) -> Void) {
+        self.onActivation = onActivation
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        isEnabled = enabled
+    }
+
+    func handleActivation(bundleIdentifier: String?) {
+        guard isEnabled,
+              let bundleIdentifier,
+              bundleIdentifier != Bundle.main.bundleIdentifier else { return }
+        onActivation(bundleIdentifier)
+    }
+
+    // nonisolated(unsafe): written from MainActor start and from the
+    // nonisolated stop (called from deinit, where exclusivity comes from
+    // unique ownership); NotificationCenter.removeObserver is thread-safe.
+    private nonisolated(unsafe) var activationObserver: Any?
+
+    deinit {
+        stopObservingWorkspaceNotifications()
+    }
+
+    func startObservingWorkspaceNotifications() {
+        stopObservingWorkspaceNotifications()
+        activationObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let bundle = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?.bundleIdentifier
+            MainActor.assumeIsolated { [weak self] in
+                self?.handleActivation(bundleIdentifier: bundle)
+            }
+        }
+    }
+
+    nonisolated func stopObservingWorkspaceNotifications() {
+        if let activationObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(activationObserver)
+        }
+        activationObserver = nil
+    }
+}

--- a/Sources/Wink/Services/AppPreferences.swift
+++ b/Sources/Wink/Services/AppPreferences.swift
@@ -42,6 +42,7 @@ final class AppPreferences {
     static let shortcutsPausedDefaultsKey = "shortcutsPaused"
     static let frontmostExceptionsEnabledDefaultsKey = "frontmostExceptionsEnabled"
     static let frontmostExceptionRulesDefaultsKey = "frontmostExceptionRules"
+    static let suggestShortcutsFromUsageDefaultsKey = "suggestShortcutsFromUsage"
 
     private(set) var shortcutCaptureStatus: ShortcutCaptureStatus
     private(set) var launchAtLoginStatus: LaunchAtLoginStatus = .disabled
@@ -59,6 +60,10 @@ final class AppPreferences {
     private(set) var autoPauseTriggerAppName: String?
     /// Set by AppController wiring; called after rules/enabled change.
     var onFrontmostExceptionConfigurationChange: (@MainActor () -> Void)?
+    /// Local-only foreground-activation counting that powers the Insights
+    /// "Suggested" card. Disabling stops collection AND clears the data.
+    private(set) var suggestShortcutsFromUsage: Bool = true
+    var onSuggestShortcutsConfigurationChange: (@MainActor (_ enabled: Bool) -> Void)?
     /// Apple's own DTS guidance: `SMAppService.Status.notFound` is the normal
     /// pre-registration baseline ("the system has never seen your service"),
     /// not inherently an error — `.notRegistered` is only reached after a
@@ -209,6 +214,7 @@ final class AppPreferences {
         let initialExceptionsEnabled = userDefaults.object(forKey: Self.frontmostExceptionsEnabledDefaultsKey) as? Bool ?? false
         let initialExceptionRules = userDefaults.object(forKey: Self.frontmostExceptionRulesDefaultsKey) as? [String]
             ?? FrontmostExceptionMonitor.defaultRuleBundleIdentifiers
+        let initialSuggestFromUsage = userDefaults.object(forKey: Self.suggestShortcutsFromUsageDefaultsKey) as? Bool ?? true
         let initialFrontmostTargetBehavior: FrontmostTargetBehavior
         if let rawValue = userDefaults.string(forKey: Self.frontmostTargetBehaviorDefaultsKey),
            let storedBehavior = FrontmostTargetBehavior(rawValue: rawValue) {
@@ -229,6 +235,7 @@ final class AppPreferences {
         self.shortcutsPaused = initialShortcutsPaused
         self.frontmostExceptionsEnabled = initialExceptionsEnabled
         self.frontmostExceptionRules = initialExceptionRules
+        self.suggestShortcutsFromUsage = initialSuggestFromUsage
         self.frontmostTargetBehavior = initialFrontmostTargetBehavior
 
         shortcutManager.setFrontmostTargetBehavior(initialFrontmostTargetBehavior)
@@ -297,6 +304,13 @@ final class AppPreferences {
         frontmostExceptionRules.removeAll { $0 == bundleIdentifier }
         userDefaults.set(frontmostExceptionRules, forKey: Self.frontmostExceptionRulesDefaultsKey)
         onFrontmostExceptionConfigurationChange?()
+    }
+
+    func setSuggestShortcutsFromUsage(_ enabled: Bool) {
+        guard enabled != suggestShortcutsFromUsage else { return }
+        suggestShortcutsFromUsage = enabled
+        userDefaults.set(enabled, forKey: Self.suggestShortcutsFromUsageDefaultsKey)
+        onSuggestShortcutsConfigurationChange?(enabled)
     }
 
     func setAutoPauseTrigger(appName: String?) {

--- a/Sources/Wink/Services/UsageTracker.swift
+++ b/Sources/Wink/Services/UsageTracker.swift
@@ -23,6 +23,9 @@ actor UsageTracker: UsageTracking {
     private var dashboardPhaseHook: (@Sendable (String) -> Void)?
 
     private nonisolated(unsafe) var recordDailyUsageStmt: OpaquePointer?
+    private nonisolated(unsafe) var recordAppActivationStmt: OpaquePointer?
+    private nonisolated(unsafe) var appActivationTotalsStmt: OpaquePointer?
+    private nonisolated(unsafe) var deleteAppActivationsStmt: OpaquePointer?
     private nonisolated(unsafe) var recordHourlyUsageStmt: OpaquePointer?
     private nonisolated(unsafe) var deleteDailyUsageStmt: OpaquePointer?
     private nonisolated(unsafe) var deleteHourlyUsageStmt: OpaquePointer?
@@ -56,6 +59,9 @@ actor UsageTracker: UsageTracking {
     deinit {
         for stmt in [
             recordDailyUsageStmt,
+            recordAppActivationStmt,
+            appActivationTotalsStmt,
+            deleteAppActivationsStmt,
             recordHourlyUsageStmt,
             deleteDailyUsageStmt,
             deleteHourlyUsageStmt,
@@ -129,6 +135,73 @@ actor UsageTracker: UsageTracking {
             }
 
             return true
+        }
+    }
+
+    /// Foreground-activation counter feeding shortcut suggestions.
+    /// Additive `IF NOT EXISTS` table — deliberately outside the
+    /// user_version scheme so existing v3 files gain it without a reset.
+    /// One indexed UPSERT per activation; app switches are far too
+    /// infrequent to justify batching.
+    func recordAppActivation(bundleIdentifier: String) {
+        recordAppActivation(bundleIdentifier: bundleIdentifier, on: Date())
+    }
+
+    func recordAppActivation(bundleIdentifier: String, on date: Date) {
+        guard let db else { return }
+        let bucket = bucketComponents(for: date, in: timeZoneProvider())
+        let sql = """
+            INSERT INTO app_activations (bundle_id, date, count)
+            VALUES (?, ?, 1)
+            ON CONFLICT(bundle_id, date) DO UPDATE SET count = count + 1
+            """
+        guard let stmt = cachedStatement(&recordAppActivationStmt, sql: sql) else { return }
+        sqlite3_bind_text(stmt, 1, (bundleIdentifier as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, (bucket.date as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
+        if sqlite3_step(stmt) != SQLITE_DONE {
+            let message = "Failed to record app activation: \(String(cString: sqlite3_errmsg(db)))"
+            logger.error("\(message, privacy: .public)")
+            DiagnosticLog.log(message)
+        }
+    }
+
+    /// Per-bundle activation totals inside the window, descending. The
+    /// caller filters bound/excluded bundles — binding state changes over
+    /// time, so raw rows stay unfiltered.
+    func appActivationTotals(days: Int) -> [(bundleIdentifier: String, count: Int)] {
+        appActivationTotals(days: days, relativeTo: Date())
+    }
+
+    func appActivationTotals(days: Int, relativeTo now: Date) -> [(bundleIdentifier: String, count: Int)] {
+        recordQueryExecution("appActivationTotals")
+        let sql = """
+            SELECT bundle_id, SUM(count) AS total
+            FROM app_activations
+            WHERE date >= ? AND date <= ?
+            GROUP BY bundle_id
+            ORDER BY total DESC
+            """
+        guard let stmt = cachedStatement(&appActivationTotalsStmt, sql: sql) else { return [] }
+        let range = windowDateRange(days: days, relativeTo: now, in: timeZoneProvider())
+        sqlite3_bind_text(stmt, 1, (range.start as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, (range.end as NSString).utf8String, -1, Self.SQLITE_TRANSIENT)
+        var results: [(bundleIdentifier: String, count: Int)] = []
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let bundleC = sqlite3_column_text(stmt, 0) else { continue }
+            results.append((String(cString: bundleC), Int(sqlite3_column_int64(stmt, 1))))
+        }
+        return results
+    }
+
+    /// Disabling the suggestions preference clears collected data — the
+    /// toggle stops collection AND retention, not just display.
+    func deleteAllAppActivations() {
+        guard let db else { return }
+        guard let stmt = cachedStatement(&deleteAppActivationsStmt, sql: "DELETE FROM app_activations") else { return }
+        if sqlite3_step(stmt) != SQLITE_DONE {
+            let message = "Failed to delete app activations: \(String(cString: sqlite3_errmsg(db)))"
+            logger.error("\(message, privacy: .public)")
+            DiagnosticLog.log(message)
         }
     }
 
@@ -620,6 +693,14 @@ actor UsageTracker: UsageTracking {
                 ON usage_hourly(date, hour);
             CREATE INDEX IF NOT EXISTS idx_daily_usage_date
                 ON daily_usage(date);
+            CREATE TABLE IF NOT EXISTS app_activations (
+                bundle_id TEXT NOT NULL,
+                date      TEXT NOT NULL,
+                count     INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (bundle_id, date)
+            );
+            CREATE INDEX IF NOT EXISTS idx_app_activations_date
+                ON app_activations(date);
             """
 
         var errorMessage: UnsafeMutablePointer<CChar>?

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -217,6 +217,17 @@ struct GeneralTabView: View {
                 Divider().overlay(palette.hairline)
 
                 SettingsToggleRow(
+                    title: "Suggest shortcuts from app usage",
+                    subtitle: "Count app switches locally to suggest shortcuts in Insights. Turning this off also deletes the collected counts.",
+                    isOn: Binding(
+                        get: { preferences.suggestShortcutsFromUsage },
+                        set: { preferences.setSuggestShortcutsFromUsage($0) }
+                    )
+                )
+
+                Divider().overlay(palette.hairline)
+
+                SettingsToggleRow(
                     title: "Pause in exception apps",
                     subtitle: "Hand shortcuts back to the system while a listed app (VM, remote desktop) is frontmost.",
                     isOn: Binding(

--- a/Sources/Wink/UI/InsightsTabView.swift
+++ b/Sources/Wink/UI/InsightsTabView.swift
@@ -41,6 +41,28 @@ struct InsightsTabView: View {
             mostUsedCard
 
             InsightsUnusedNudge(appNames: viewModel.unusedShortcutNames)
+
+            if !viewModel.suggestedApps.isEmpty {
+                WinkCard(title: { Text("Suggested shortcuts") }) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Apps you switch to often that have no shortcut yet. Add one in Shortcuts.")
+                            .font(WinkType.labelSmall)
+                            .foregroundStyle(palette.textSecondary)
+                        ForEach(viewModel.suggestedApps) { suggestion in
+                            HStack(spacing: 8) {
+                                AppIconView(bundleIdentifier: suggestion.bundleIdentifier, size: 20)
+                                Text(suggestion.name)
+                                    .font(WinkType.bodyText)
+                                    .foregroundStyle(palette.textPrimary)
+                                Spacer(minLength: 8)
+                                Text("\(suggestion.count)× this period")
+                                    .font(WinkType.labelSmall)
+                                    .foregroundStyle(palette.textTertiary)
+                            }
+                        }
+                    }
+                }
+            }
         }
         .padding(.top, 18)
         .padding(.bottom, 22)

--- a/Sources/Wink/UI/InsightsViewModel.swift
+++ b/Sources/Wink/UI/InsightsViewModel.swift
@@ -144,10 +144,11 @@ final class InsightsViewModel {
 
         let boundBundles = Set(shortcutStore.shortcuts.map(\.bundleIdentifier))
         let activationTotals = await usageTracker.appActivationTotals(days: days, relativeTo: now)
-        let suggestions: [SuggestedApp] = activationTotals
+        // Resolve BEFORE limiting: an uninstalled app in the top three must
+        // yield its slot to the next resolvable one, not shrink the card.
+        let suggestions: [SuggestedApp] = Array(activationTotals
             .filter { !boundBundles.contains($0.bundleIdentifier) }
-            .prefix(3)
-            .compactMap { entry in
+            .compactMap { entry -> SuggestedApp? in
                 guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: entry.bundleIdentifier) else {
                     // Uninstalled or un-resolvable apps make poor suggestions.
                     return nil
@@ -158,6 +159,7 @@ final class InsightsViewModel {
                     count: entry.count
                 )
             }
+            .prefix(3))
 
         let reportingTimeZone = snapshot.timeZone
         let dailyCounts = snapshot.dailyCounts

--- a/Sources/Wink/UI/InsightsViewModel.swift
+++ b/Sources/Wink/UI/InsightsViewModel.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Observation
 
@@ -60,6 +61,16 @@ final class InsightsViewModel {
     var heatmapBuckets: [HourlyUsageBucket] = []
     var unusedShortcutNames: [String] = []
     var ranking: [RankedShortcut] = []
+    struct SuggestedApp: Equatable, Identifiable {
+        let bundleIdentifier: String
+        let name: String
+        let count: Int
+        var id: String { bundleIdentifier }
+    }
+    /// Top unbound apps by foreground activations in the period. Empty when
+    /// collection is disabled (the toggle also clears the data), so the
+    /// card simply disappears — no preference plumbing needed here.
+    var suggestedApps: [SuggestedApp] = []
     var appRows: [InsightsAppRowModel] = []
 
     private let usageTracker: (any UsageTracking)?
@@ -113,6 +124,7 @@ final class InsightsViewModel {
             unusedShortcutNames = []
             ranking = []
             appRows = []
+            suggestedApps = []
             return
         }
 
@@ -130,6 +142,23 @@ final class InsightsViewModel {
             return
         }
 
+        let boundBundles = Set(shortcutStore.shortcuts.map(\.bundleIdentifier))
+        let activationTotals = await usageTracker.appActivationTotals(days: days, relativeTo: now)
+        let suggestions: [SuggestedApp] = activationTotals
+            .filter { !boundBundles.contains($0.bundleIdentifier) }
+            .prefix(3)
+            .compactMap { entry in
+                guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: entry.bundleIdentifier) else {
+                    // Uninstalled or un-resolvable apps make poor suggestions.
+                    return nil
+                }
+                return SuggestedApp(
+                    bundleIdentifier: entry.bundleIdentifier,
+                    name: url.deletingPathExtension().lastPathComponent,
+                    count: entry.count
+                )
+            }
+
         let reportingTimeZone = snapshot.timeZone
         let dailyCounts = snapshot.dailyCounts
         let previousCounts = snapshot.previousCounts
@@ -139,6 +168,7 @@ final class InsightsViewModel {
         guard !Task.isCancelled else { return }
         guard generation == refreshGeneration else { return }
 
+        self.suggestedApps = suggestions
         self.totalCount = snapshot.totalCount
         self.previousPeriodTotal = snapshot.previousPeriodTotal
         self.currentStreakDays = snapshot.streakDays

--- a/Tests/WinkTests/AppControllerTests.swift
+++ b/Tests/WinkTests/AppControllerTests.swift
@@ -290,6 +290,10 @@ private func ensureAppKitApplication() {
 }
 
 private actor EmptyUsageTracker: UsageTracking {
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] {
+        []
+    }
     func deleteUsage(shortcutId: UUID) {}
     func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] { [:] }
     func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] { [:] }

--- a/Tests/WinkTests/InsightsViewModelTests.swift
+++ b/Tests/WinkTests/InsightsViewModelTests.swift
@@ -3,6 +3,10 @@ import Testing
 @testable import Wink
 
 actor DelayedUsageTracker: UsageTracking {
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] {
+        []
+    }
     func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
 
@@ -43,6 +47,10 @@ actor DelayedUsageTracker: UsageTracking {
 }
 
 actor BoundaryCrossingUsageTracker: UsageTracking {
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] {
+        []
+    }
     func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
 
@@ -80,6 +88,10 @@ actor BoundaryCrossingUsageTracker: UsageTracking {
 }
 
 actor TimeZoneAlignedUsageTracker: UsageTracking {
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] {
+        []
+    }
     func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
     let timeZone: TimeZone

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -799,6 +799,10 @@ private extension NSPoint {
 }
 
 private actor StaticUsageTracker: UsageTracking {
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] {
+        []
+    }
     func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
 
@@ -844,6 +848,10 @@ private actor StaticUsageTracker: UsageTracking {
 }
 
 private actor MultiShortcutUsageTracker: UsageTracking {
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] {
+        []
+    }
     func deleteUsage(shortcutId: UUID) {}
     private let counts: [UUID: Int]
     private let dailyCountsByShortcut: [String: [(date: String, count: Int)]]

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverSearchTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverSearchTests.swift
@@ -148,6 +148,10 @@ private final class SearchPopoverRuntimeState {
 }
 
 private actor SearchNoopUsageTracker: UsageTracking {
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] {
+        []
+    }
     func deleteUsage(shortcutId: UUID) {}
     func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] { [:] }
     func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] { [:] }

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
@@ -334,6 +334,10 @@ private final class PopoverRuntimeState {
 }
 
 private actor StaticUsageTracker: UsageTracking {
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] {
+        []
+    }
     func deleteUsage(shortcutId: UUID) {}
     let total: Int
 

--- a/Tests/WinkTests/ShortcutEditorStateTests.swift
+++ b/Tests/WinkTests/ShortcutEditorStateTests.swift
@@ -929,6 +929,10 @@ private func waitForPendingUsageCounts(on tracker: GatedUsageTracker, count: Int
 }
 
 private actor GatedUsageTracker: UsageTracking {
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] {
+        []
+    }
     func deleteUsage(shortcutId: UUID) {}
     private var pendingUsageCounts: [CheckedContinuation<[UUID: Int], Never>] = []
     private var lastUsedValue: [UUID: Date] = [:]

--- a/Tests/WinkTests/UsageDashboardSnapshotTests.swift
+++ b/Tests/WinkTests/UsageDashboardSnapshotTests.swift
@@ -216,6 +216,10 @@ struct UsageDashboardSnapshotTests {
 }
 
 private actor RecordingUsageTracker: UsageTracking {
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] {
+        []
+    }
     func deleteUsage(shortcutId: UUID) {}
     let shortcutId: UUID
     private var counts: [String: Int] = [:]

--- a/Tests/WinkTests/WinkTests.swift
+++ b/Tests/WinkTests/WinkTests.swift
@@ -1008,3 +1008,22 @@ struct UsageTrackerTests {
         #expect(entries?.isEmpty == false)
     }
 }
+
+@Test
+func appActivationRecordQueryAndClearRoundTrip() async {
+    let tracker = UsageTracker(databasePath: ":memory:")
+
+    await tracker.recordAppActivation(bundleIdentifier: "com.apple.Safari")
+    await tracker.recordAppActivation(bundleIdentifier: "com.apple.Safari")
+    await tracker.recordAppActivation(bundleIdentifier: "com.apple.mail")
+
+    let totals = await tracker.appActivationTotals(days: 1)
+    #expect(totals.first?.bundleIdentifier == "com.apple.Safari")
+    #expect(totals.first?.count == 2)
+    #expect(totals.count == 2)
+
+    // The privacy toggle's off-path clears everything.
+    await tracker.deleteAllAppActivations()
+    let cleared = await tracker.appActivationTotals(days: 1)
+    #expect(cleared.isEmpty)
+}

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -37,3 +37,7 @@ In those cases, network requests go to the configured update feed, release host,
 - it does not upload your usage-insights database as part of normal app behavior
 
 If the product gains new data collection or remote services later, update this document and the in-app link in `GeneralTabView.swift` in the same change.
+
+## App activation counts (Insights suggestions)
+
+When "Suggest shortcuts from app usage" is enabled (Settings > General), Wink counts foreground app activations — bundle identifier and per-day count only, in the same local `usage.db` — to suggest shortcuts for frequently used apps. Nothing leaves the device. Disabling the toggle stops collection and deletes the collected counts.


### PR DESCRIPTION
Fixes #354

## Summary
- Insights gains a **"Suggested shortcuts"** card: the top three apps you switch to most (foreground activations) that have no Wink shortcut yet — the reverse of the existing unused-shortcut nudge, and an asset no switcher competitor has.
- Recording is one workspace observer + one indexed UPSERT per app switch into a new `app_activations` table (bundle id + per-day count). The table is additive `IF NOT EXISTS`, deliberately outside the `user_version` scheme, so existing v3 databases gain it without the bootstrap's reset path.
- **Privacy**: local-only, documented in `docs/privacy.md`. The Settings > General toggle (default on) stops collection AND deletes collected counts when turned off; the card simply disappears when there is no data. Wink itself is never recorded; bound apps are filtered at query time (binding state changes over time).
- Uninstalled/unresolvable apps are dropped from suggestions. Deep-link from a suggestion into the shortcut composer is noted as a follow-up.

## Testing
- [x] `swift test` — 575 tests green (record/query/clear round-trip; all UsageTracking fakes extended)
- [ ] Additional validation noted below when needed

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Batch-end validation: real upgrade of an existing usage.db (table appears, no reset), card rendering, toggle-off data deletion.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.
- If the PR touches runtime-sensitive files, the PR metadata workflow will reject `Not runtime-sensitive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
