### PR TITLE
refine: marigold heatmap tint and softer light focus ring

### DIFF
--- a/Sources/Wink/UI/DesignSystem/DesignTokens.swift
+++ b/Sources/Wink/UI/DesignSystem/DesignTokens.swift
@@ -76,6 +76,12 @@ enum WinkPalette {
 
         // Misc
         let heatmapEmpty: Color
+        /// Base color for occupied heatmap cells (applied at 0.18–0.90
+        /// opacity). Deliberately brighter than `accent` in light mode:
+        /// large fields of the deep AA-safe accent read coffee-brown, while
+        /// this marigold cut keeps the heatmap lively. No text sits on
+        /// heatmap cells, so it carries no contrast obligation.
+        let heatmapTint: Color
         let focusRing: Color
 
         /// Fixed neutral grey for the "no app chosen" placeholder swatch.
@@ -130,7 +136,8 @@ enum WinkPalette {
         amberBgSoft:      .winkSRGB(0xE0, 0x8A, 0x00, 0.10),
 
         heatmapEmpty:   .winkBlack(0.04),
-        focusRing:      .winkSRGB(0xE0, 0x8A, 0x00, 0.40),
+        heatmapTint:    .winkSRGB(0xE0, 0x8A, 0x00),
+        focusRing:      .winkSRGB(0xE0, 0x8A, 0x00, 0.35),
 
         appPlaceholderSwatchBg: .winkSRGB(0xD8, 0xD8, 0xD8)
     )
@@ -184,6 +191,7 @@ enum WinkPalette {
         amberBgSoft:      .winkSRGB(0xFF, 0xB4, 0x54, 0.15),
 
         heatmapEmpty:   .winkWhite(0.04),
+        heatmapTint:    .winkSRGB(0xFF, 0xB4, 0x54),
         focusRing:      .winkSRGB(0xFF, 0xB4, 0x54, 0.45),
 
         appPlaceholderSwatchBg: .winkSRGB(0x5A, 0x5A, 0x5C)

--- a/Sources/Wink/UI/Insights/InsightsHourlyHeatmap.swift
+++ b/Sources/Wink/UI/Insights/InsightsHourlyHeatmap.swift
@@ -102,7 +102,7 @@ struct InsightsHourlyHeatmap: View {
         }
 
         let normalized = Double(count) / Double(maxCount)
-        return palette.accent.opacity(0.18 + (normalized * 0.72))
+        return palette.heatmapTint.opacity(0.18 + (normalized * 0.72))
     }
 
     private func dayLabel(for dateString: String) -> String {

--- a/docs/design/v2/tokens.jsx
+++ b/docs/design/v2/tokens.jsx
@@ -52,7 +52,8 @@ const lightTheme = {
 
   // Misc
   heatmapBase: 'rgba(224,138,0,0.10)',
-  focusRing: 'rgba(224,138,0,0.40)',
+  heatmapTint: '#E08A00',       // occupied cells at 0.18–0.90 — marigold, not the deep AA accent
+  focusRing: 'rgba(224,138,0,0.35)',
 };
 
 const darkTheme = {
@@ -99,6 +100,7 @@ const darkTheme = {
   amberBgSoft: 'rgba(255,180,84,0.15)',
 
   heatmapBase: 'rgba(255,180,84,0.20)',
+  heatmapTint: '#FFB454',
   focusRing: 'rgba(255,180,84,0.45)',
 };
 


### PR DESCRIPTION
## Summary
- Follow-up polish to the amber rebrand after reviewing rendered light/dark app mockups: occupied heatmap cells move to a dedicated `heatmapTint` token (`#E08A00` light / `#FFB454` dark) — large fields of the deep AA-safe accent read coffee-brown in light mode, while the marigold cut keeps the heatmap lively; no text sits on cells so it carries no contrast obligation.
- Light focus ring returns to 0.35 opacity (the restraint the blue accent had), keeping rings noticeable but quiet.
- `docs/design/v2/tokens.jsx` mirror synced.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

574 tests in 47 suites, all passing. Rendered before/after mockups verified visually. Pure UI-token change.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.
- If the PR touches runtime-sensitive files, the PR metadata workflow will reject `Not runtime-sensitive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
