### PR TITLE
feat: wink:// URL scheme for scripted toggle, pause, and resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Useful packaging commands:
 
 Always launch the packaged app with `open build/Wink.app` when testing permissions. macOS ties Accessibility and Input Monitoring grants to the app identity, signature, and bundle path; launching the raw binary is not equivalent.
 
+## Automation
+
+Wink exposes its toggle semantics on a `wink://` URL scheme, so Raycast, Karabiner, BetterTouchTool, Stream Deck, or plain shell scripts can drive it — including the SkyLight forced activation that scripts cannot perform themselves:
+
+```bash
+open "wink://toggle?bundle=com.google.Chrome"   # toggle an installed app
+open "wink://pause"                             # pause all shortcuts
+open "wink://resume"                            # resume
+```
+
+Unknown commands and uninstalled bundles are logged and ignored. Automation presses respect the per-bundle cooldown but never count toward Insights usage.
+
 ## Technical Notes
 - Standard shortcuts use Carbon hotkeys.
 - Hyper-routed shortcuts use an active event tap.

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -239,6 +239,42 @@ final class AppController {
         shortcutManager.stop()
     }
 
+    /// wink:// URL scheme entry. Toggle reuses the full activation
+    /// pipeline via a synthetic shortcut but goes straight to the switcher
+    /// — automation presses never record usage (Insights stays a picture
+    /// of the user's own keystrokes). Pause/resume mirror the menu bar
+    /// toggle, capsule state included.
+    func handleURLs(_ urls: [URL]) {
+        for url in urls {
+            guard let command = WinkURLCommand.parse(url) else {
+                DiagnosticLog.log("URL: ignored unrecognized \(url.absoluteString)")
+                continue
+            }
+            switch command {
+            case .toggle(let bundleIdentifier):
+                guard appBundleLocator.applicationURL(for: bundleIdentifier) != nil else {
+                    DiagnosticLog.log("URL: toggle ignored, no installed app for \(bundleIdentifier)")
+                    continue
+                }
+                let name = appBundleLocator.applicationURL(for: bundleIdentifier)?
+                    .deletingPathExtension().lastPathComponent ?? bundleIdentifier
+                DiagnosticLog.log("URL: toggle \(bundleIdentifier)")
+                _ = appSwitcher.toggleApplication(for: AppShortcut(
+                    appName: name,
+                    bundleIdentifier: bundleIdentifier,
+                    keyEquivalent: "",
+                    modifierFlags: []
+                ))
+            case .pause:
+                DiagnosticLog.log("URL: pause")
+                appPreferences.setShortcutsPaused(true)
+            case .resume:
+                DiagnosticLog.log("URL: resume")
+                appPreferences.setShortcutsPaused(false)
+            }
+        }
+    }
+
     func openPrimarySettingsWindow() {
         openSettings()
     }

--- a/Sources/Wink/AppDelegate.swift
+++ b/Sources/Wink/AppDelegate.swift
@@ -42,6 +42,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         appController.openPrimarySettingsWindow()
     }
 
+    func application(_ application: NSApplication, open urls: [URL]) {
+        appController.handleURLs(urls)
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         appController.stop()
     }

--- a/Sources/Wink/Models/WinkURLCommand.swift
+++ b/Sources/Wink/Models/WinkURLCommand.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Commands accepted on the `wink://` URL scheme. Parsing is pure and
+/// side-effect free so the accepted grammar is fully unit-testable:
+///
+///     wink://toggle?bundle=<bundle-identifier>
+///     wink://pause
+///     wink://resume
+///
+/// Anything else — unknown hosts, missing/empty bundle, extra path
+/// segments — parses to nil and the caller logs and ignores it. The
+/// scheme is callable by any local process, which matches the threat
+/// model of every macOS URL scheme: it can do nothing a Dock click or
+/// the menu bar toggle cannot.
+enum WinkURLCommand: Equatable {
+    case toggle(bundleIdentifier: String)
+    case pause
+    case resume
+
+    static func parse(_ url: URL) -> WinkURLCommand? {
+        guard url.scheme?.lowercased() == "wink",
+              let host = url.host?.lowercased(),
+              url.path.isEmpty || url.path == "/" else {
+            return nil
+        }
+
+        switch host {
+        case "toggle":
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            guard let bundle = components?.queryItems?
+                    .first(where: { $0.name == "bundle" })?
+                    .value?
+                    .trimmingCharacters(in: .whitespaces),
+                  !bundle.isEmpty else {
+                return nil
+            }
+            return .toggle(bundleIdentifier: bundle)
+        case "pause":
+            return .pause
+        case "resume":
+            return .resume
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/Wink/Resources/Info.plist
+++ b/Sources/Wink/Resources/Info.plist
@@ -26,6 +26,17 @@
 	<string>9</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>Wink Automation</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>wink</string>
+			</array>
+		</dict>
+	</array>
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHighResolutionCapable</key>

--- a/Tests/WinkTests/WinkURLCommandTests.swift
+++ b/Tests/WinkTests/WinkURLCommandTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import Wink
+
+@Test func parsesToggleWithBundle() {
+    let url = URL(string: "wink://toggle?bundle=com.google.Chrome")!
+    #expect(WinkURLCommand.parse(url) == .toggle(bundleIdentifier: "com.google.Chrome"))
+}
+
+@Test func parsesPauseAndResumeCaseInsensitively() {
+    #expect(WinkURLCommand.parse(URL(string: "wink://pause")!) == .pause)
+    #expect(WinkURLCommand.parse(URL(string: "WINK://Resume")!) == .resume)
+}
+
+@Test func rejectsMalformedCommands() {
+    let rejected = [
+        "wink://toggle",                       // missing bundle
+        "wink://toggle?bundle=",               // empty bundle
+        "wink://toggle?bundle=%20%20",         // whitespace bundle
+        "wink://focus?bundle=com.apple.Mail",  // unknown host
+        "wink://pause/extra",                  // extra path segment
+        "https://toggle?bundle=com.apple.Mail" // wrong scheme
+    ]
+    for raw in rejected {
+        let url = URL(string: raw)!
+        #expect(WinkURLCommand.parse(url) == nil, "expected rejection for \(raw)")
+    }
+}


### PR DESCRIPTION
Fixes #355

## Summary
- New `wink://` URL scheme: `wink://toggle?bundle=<id>` runs the full toggle pipeline for any installed app (activate / hide / cycle per settings, SkyLight forced activation included — the capability Raycast/Karabiner/Stream Deck scripts cannot get themselves); `wink://pause` / `wink://resume` mirror the menu bar toggle including capsule state.
- Parsing is a pure `WinkURLCommand` grammar (unit-tested): unknown hosts, missing/empty bundles, extra path segments, and wrong schemes all reject to a logged no-op. Uninstalled bundles are ignored with a diagnostic line.
- Automation presses go straight to the switcher: they respect the per-bundle cooldown and re-entry guards but never record usage, keeping Insights a picture of the user's own keystrokes.
- README documents the scheme. The `wink-cli` wrapper from issue #355 is a follow-up (it would just shell out to `open`).

## Testing
- [x] `swift test` — 578 tests green (accept/reject grammar matrix)
- [ ] Additional validation noted below when needed

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Batch-end validation: `open "wink://toggle?bundle=..."` on the packaged app (scheme registration requires the bundled Info.plist), pause/resume capsule reflection, e2e smoke via the scheme.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.
- If the PR touches runtime-sensitive files, the PR metadata workflow will reject `Not runtime-sensitive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
