### PR TITLE
docs: recommend open -g for the URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ Always launch the packaged app with `open build/Wink.app` when testing permissio
 Wink exposes its toggle semantics on a `wink://` URL scheme, so Raycast, Karabiner, BetterTouchTool, Stream Deck, or plain shell scripts can drive it — including the SkyLight forced activation that scripts cannot perform themselves:
 
 ```bash
-open "wink://toggle?bundle=com.google.Chrome"   # toggle an installed app
-open "wink://pause"                             # pause all shortcuts
-open "wink://resume"                            # resume
+open -g "wink://toggle?bundle=com.google.Chrome"   # toggle an installed app
+open -g "wink://pause"                             # pause all shortcuts
+open -g "wink://resume"                            # resume
 ```
+
+Use `open -g` (background): a plain `open` activates Wink to deliver the URL, which makes the target count as "not frontmost" and turns every toggle into an activate.
 
 Unknown commands and uninstalled bundles are logged and ignored. Automation presses respect the per-bundle cooldown but never count toward Insights usage.
 


### PR DESCRIPTION
## Summary
- README: recommend `open -g` for the `wink://` scheme. A plain `open` activates Wink to deliver the URL, so the target never counts as frontmost and toggle-off is unreachable; background delivery preserves the caller's frontmost app. Verified on the packaged 0.6.2 build during batch runtime validation.

## Testing
- [x] Docs only
- [ ] Additional validation noted below when needed

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
