### PR TITLE
feat: hold-Hyper cheat sheet listing all bound shortcuts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ Before making large structural changes, read `docs/architecture.md`.
 
 - Secure Input detection: `IsSecureEventInputEnabled()` is probed lazily in `shortcutCaptureStatus()` and on the existing 3s permission poll (no new timers). It degrades every tap-dependent route — Hyper AND standard Fn+F-row bindings (their observer fails closed); the pill shows "Limited · Secure Input" instead of a false Ready. Detection is transparency-only — no auto-remediation, no culprit-process lookup.
 
+- The Hyper cheat sheet observes hold phases via `EventTapBox.onHyperHoldEvent` (began on F19 keyDown swallow — repeated under autorepeat, consumers dedupe; chordConsumed only on hyper-injected swallows; ended on every F19 keyUp swallow including the 80ms toggle-quirk tap). The callback fires on the tap thread outside the lock and must stay display-only — never feed it back into capture or toggle decisions.
+
 ## Concurrency and actor boundaries
 
 - Do not use `@MainActor` as the default for non-UI code

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -222,6 +222,13 @@ final class AppController {
         shortcutManager.onCaptureStatusChange = { [weak self] in
             self?.appPreferences.refreshPermissions()
         }
+        // Pause (manual or exception-rule) stops the Hyper provider without
+        // an `ended` event; a presented sheet must not outlive capture.
+        shortcutManager.onCapturePauseStateChange = { [weak self] paused in
+            if paused {
+                self?.cheatSheetHUD.reset()
+            }
+        }
 
         // Hold events arrive on the tap thread; hop once to the main actor
         // via the main QUEUE, whose FIFO ordering keeps began/ended in

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -220,11 +220,23 @@ final class AppController {
         }
 
         // Hold events arrive on the tap thread; hop once to the main actor
-        // where the cheat-sheet controller lives.
+        // via the main QUEUE, whose FIFO ordering keeps began/ended in
+        // emission order (sibling Tasks carry no such guarantee, and a
+        // reordered quick tap would arm a timer after its release).
         let cheatSheet = cheatSheetHUD
         shortcutManager.setHyperHoldObserver { event in
-            Task { @MainActor in
-                cheatSheet.handle(event)
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    cheatSheet.handle(event)
+                }
+            }
+        }
+        appPreferences.onHyperKeyEnabledChange = { [weak self] enabled in
+            if !enabled {
+                // Disabling Hyper mid-hold clears tap state without an
+                // `ended`; reset so no timer stays armed and no presented
+                // sheet sticks.
+                self?.cheatSheetHUD.reset()
             }
         }
 

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -67,6 +67,29 @@ final class AppController {
             self?.appPreferences.refreshPermissions()
         }
     )
+    private lazy var cheatSheetHUD = CheatSheetHUDController(
+        rowsProvider: { [weak self] in
+            guard let self else { return [] }
+            return self.shortcutStore.shortcuts
+                .filter(\.isEnabled)
+                .map { shortcut in
+                    CheatSheetRow(
+                        id: shortcut.id,
+                        appName: shortcut.appName,
+                        bundleIdentifier: shortcut.bundleIdentifier,
+                        keyDisplay: ModifierFormatting.displayText(
+                            modifierFlags: shortcut.modifierFlags,
+                            keyEquivalent: shortcut.keyEquivalent
+                        )
+                    )
+                }
+        },
+        isEnabled: { [weak self] in
+            guard let self else { return false }
+            return self.appPreferences.hyperCheatSheetEnabled
+                && self.appPreferences.hyperKeyEnabled
+        }
+    )
     private lazy var appActivationRecorder = AppActivationRecorder(
         onActivation: { [weak self] bundleIdentifier in
             self?.recordAppActivation(bundleIdentifier)
@@ -194,6 +217,15 @@ final class AppController {
         // prompts) fire ahead of the auto-pause.
         shortcutManager.onCaptureStatusChange = { [weak self] in
             self?.appPreferences.refreshPermissions()
+        }
+
+        // Hold events arrive on the tap thread; hop once to the main actor
+        // where the cheat-sheet controller lives.
+        let cheatSheet = cheatSheetHUD
+        shortcutManager.setHyperHoldObserver { event in
+            Task { @MainActor in
+                cheatSheet.handle(event)
+            }
         }
 
         Self.runStartupSequence(

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -86,8 +86,12 @@ final class AppController {
         },
         isEnabled: { [weak self] in
             guard let self else { return false }
+            // The sheet rides F19 events from the interception tap, which
+            // only runs when at least one Hyper shortcut is enabled — a
+            // display toggle must not become an Input Monitoring demand.
             return self.appPreferences.hyperCheatSheetEnabled
                 && self.appPreferences.hyperKeyEnabled
+                && self.appPreferences.shortcutCaptureStatus.eventTapActive
         }
     )
     private lazy var appActivationRecorder = AppActivationRecorder(

--- a/Sources/Wink/Protocols/EventTapManaging.swift
+++ b/Sources/Wink/Protocols/EventTapManaging.swift
@@ -16,4 +16,11 @@ protocol EventTapManaging {
     func stop()
     func updateRegisteredShortcuts(_ keyPresses: Set<KeyPress>)
     func setHyperKeyEnabled(_ enabled: Bool)
+    func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?)
+}
+
+extension EventTapManaging {
+    // Sync no-op default (sync requirement + sync default: no async
+    // overload-shadowing hazard); display-only consumers are optional.
+    func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?) {}
 }

--- a/Sources/Wink/Protocols/ShortcutCaptureProvider.swift
+++ b/Sources/Wink/Protocols/ShortcutCaptureProvider.swift
@@ -75,4 +75,11 @@ extension ShortcutCaptureProvider {
 @MainActor
 protocol HyperShortcutCaptureProvider: ShortcutCaptureProvider {
     func setHyperKeyEnabled(_ enabled: Bool)
+    func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?)
+}
+
+extension HyperShortcutCaptureProvider {
+    // Sync no-op default; only the live event-tap provider surfaces
+    // Hyper hold phases.
+    func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?) {}
 }

--- a/Sources/Wink/Services/AppPreferences.swift
+++ b/Sources/Wink/Services/AppPreferences.swift
@@ -67,6 +67,8 @@ final class AppPreferences {
     /// Idle-hold Hyper cheat sheet (display-only overlay).
     private(set) var hyperCheatSheetEnabled: Bool = true
     var onSuggestShortcutsConfigurationChange: (@MainActor (_ enabled: Bool) -> Void)?
+    /// Set by AppController wiring; called after the Hyper key toggles.
+    var onHyperKeyEnabledChange: (@MainActor (_ enabled: Bool) -> Void)?
     /// Apple's own DTS guidance: `SMAppService.Status.notFound` is the normal
     /// pre-registration baseline ("the system has never seen your service"),
     /// not inherently an error — `.notRegistered` is only reached after a
@@ -443,6 +445,7 @@ final class AppPreferences {
         }
         hyperKeyEnabled = hyperKeyService.isEnabled
         shortcutManager.setHyperKeyEnabled(hyperKeyEnabled)
+        onHyperKeyEnabledChange?(hyperKeyEnabled)
         refreshPermissions()
     }
 

--- a/Sources/Wink/Services/AppPreferences.swift
+++ b/Sources/Wink/Services/AppPreferences.swift
@@ -43,6 +43,7 @@ final class AppPreferences {
     static let frontmostExceptionsEnabledDefaultsKey = "frontmostExceptionsEnabled"
     static let frontmostExceptionRulesDefaultsKey = "frontmostExceptionRules"
     static let suggestShortcutsFromUsageDefaultsKey = "suggestShortcutsFromUsage"
+    static let hyperCheatSheetEnabledDefaultsKey = "hyperCheatSheetEnabled"
 
     private(set) var shortcutCaptureStatus: ShortcutCaptureStatus
     private(set) var launchAtLoginStatus: LaunchAtLoginStatus = .disabled
@@ -63,6 +64,8 @@ final class AppPreferences {
     /// Local-only foreground-activation counting that powers the Insights
     /// "Suggested" card. Disabling stops collection AND clears the data.
     private(set) var suggestShortcutsFromUsage: Bool = true
+    /// Idle-hold Hyper cheat sheet (display-only overlay).
+    private(set) var hyperCheatSheetEnabled: Bool = true
     var onSuggestShortcutsConfigurationChange: (@MainActor (_ enabled: Bool) -> Void)?
     /// Apple's own DTS guidance: `SMAppService.Status.notFound` is the normal
     /// pre-registration baseline ("the system has never seen your service"),
@@ -215,6 +218,7 @@ final class AppPreferences {
         let initialExceptionRules = userDefaults.object(forKey: Self.frontmostExceptionRulesDefaultsKey) as? [String]
             ?? FrontmostExceptionMonitor.defaultRuleBundleIdentifiers
         let initialSuggestFromUsage = userDefaults.object(forKey: Self.suggestShortcutsFromUsageDefaultsKey) as? Bool ?? true
+        let initialCheatSheetEnabled = userDefaults.object(forKey: Self.hyperCheatSheetEnabledDefaultsKey) as? Bool ?? true
         let initialFrontmostTargetBehavior: FrontmostTargetBehavior
         if let rawValue = userDefaults.string(forKey: Self.frontmostTargetBehaviorDefaultsKey),
            let storedBehavior = FrontmostTargetBehavior(rawValue: rawValue) {
@@ -236,6 +240,7 @@ final class AppPreferences {
         self.frontmostExceptionsEnabled = initialExceptionsEnabled
         self.frontmostExceptionRules = initialExceptionRules
         self.suggestShortcutsFromUsage = initialSuggestFromUsage
+        self.hyperCheatSheetEnabled = initialCheatSheetEnabled
         self.frontmostTargetBehavior = initialFrontmostTargetBehavior
 
         shortcutManager.setFrontmostTargetBehavior(initialFrontmostTargetBehavior)
@@ -304,6 +309,12 @@ final class AppPreferences {
         frontmostExceptionRules.removeAll { $0 == bundleIdentifier }
         userDefaults.set(frontmostExceptionRules, forKey: Self.frontmostExceptionRulesDefaultsKey)
         onFrontmostExceptionConfigurationChange?()
+    }
+
+    func setHyperCheatSheetEnabled(_ enabled: Bool) {
+        guard enabled != hyperCheatSheetEnabled else { return }
+        hyperCheatSheetEnabled = enabled
+        userDefaults.set(enabled, forKey: Self.hyperCheatSheetEnabledDefaultsKey)
     }
 
     func setSuggestShortcutsFromUsage(_ enabled: Bool) {

--- a/Sources/Wink/Services/EventTapCaptureProvider.swift
+++ b/Sources/Wink/Services/EventTapCaptureProvider.swift
@@ -47,4 +47,8 @@ final class EventTapCaptureProvider: HyperShortcutCaptureProvider {
         pendingHyperKeyEnabled = enabled
         manager.setHyperKeyEnabled(enabled)
     }
+
+    func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?) {
+        manager.setHyperHoldObserver(observer)
+    }
 }

--- a/Sources/Wink/Services/EventTapManager.swift
+++ b/Sources/Wink/Services/EventTapManager.swift
@@ -151,7 +151,7 @@ func handleEventTapEvent(
             DispatchQueue.global(qos: .utility).async {
                 DiagnosticLog.log("HYPER_F19_DOWN: keyCode=\(keyCode) flags=\(modifierFlags.rawValue) ts=\(eventTimestamp)")
             }
-            box.onHyperHoldEvent?(.began)
+            box.notifyHyperHoldEvent(.began)
             return nil
         }
 
@@ -192,7 +192,7 @@ func handleEventTapEvent(
                 )
             }
             if injectHyper {
-                box.onHyperHoldEvent?(.chordConsumed)
+                box.notifyHyperHoldEvent(.chordConsumed)
             }
             box.onKeyPress?(keyPress)
             return nil
@@ -227,7 +227,7 @@ func handleEventTapEvent(
             }
             // Sent for the 80ms toggle-quirk case too: a tap (not a hold)
             // must cancel the consumer's hold timer.
-            box.onHyperHoldEvent?(.ended)
+            box.notifyHyperHoldEvent(.ended)
         }
         box.recordObservedEvent(
             type: .keyUp,
@@ -247,6 +247,7 @@ func handleEventTapEvent(
             from: NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
         )
         let hasCapsLock = event.flags.contains(.maskAlphaShift)
+        var flagsHoldTransition: HyperHoldEvent?
         let swallowFlags = box.withLock { () -> Bool in
             guard box._hyperKeyEnabled && flagsKeyCode == HyperKeyService.f19KeyCode else {
                 return false
@@ -264,10 +265,16 @@ func handleEventTapEvent(
             box._prevCapsLockFlag = hasCapsLock
             if changed {
                 box._isHyperHeld = !box._isHyperHeld
+                // This path performed the hold transition, so it owns the
+                // observer notification (the keyDown/keyUp sites never ran).
+                flagsHoldTransition = box._isHyperHeld ? .began : .ended
             }
             return true
         }
         if swallowFlags {
+            if let flagsHoldTransition {
+                box.notifyHyperHoldEvent(flagsHoldTransition)
+            }
             box.recordObservedEvent(
                 type: .flagsChanged,
                 keyCode: flagsKeyCode,
@@ -408,7 +415,7 @@ final class EventTapManager: EventTapManaging {
                   | (1 << CGEventType.flagsChanged.rawValue)
 
         let box = EventTapBox()
-        box.onHyperHoldEvent = hyperHoldObserver
+        box.setHyperHoldObserver(hyperHoldObserver)
         box.onKeyPress = MatchedShortcutDelivery.makeHandler { [weak self] keyPress in
             self?.handleAsync(keyPress, generation: generation)
         }
@@ -508,7 +515,7 @@ final class EventTapManager: EventTapManaging {
 
     func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?) {
         hyperHoldObserver = observer
-        owner?.box.onHyperHoldEvent = observer
+        owner?.box.setHyperHoldObserver(observer)
     }
 
     /// Enable or disable Hyper Key (F19) interception in the event tap callback.
@@ -1057,8 +1064,19 @@ final class EventTapBox: @unchecked Sendable {
     var reenableTap: (@Sendable () -> Void)?
     /// Background-safe closure that hops to the main actor before invoking app logic.
     var onKeyPress: (@Sendable (KeyPress) -> Void)?
-    /// Display-only observer; invoked on the tap thread outside the lock.
-    var onHyperHoldEvent: (@Sendable (HyperHoldEvent) -> Void)?
+    /// Display-only observer. Written under the lock (it can be swapped
+    /// after the tap is live); read via `notifyHyperHoldEvent`, which
+    /// snapshots under the lock and invokes outside it.
+    private var _onHyperHoldEvent: (@Sendable (HyperHoldEvent) -> Void)?
+
+    func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?) {
+        withLock { _onHyperHoldEvent = observer }
+    }
+
+    func notifyHyperHoldEvent(_ event: HyperHoldEvent) {
+        let observer = withLock { _onHyperHoldEvent }
+        observer?(event)
+    }
     /// Background-safe closure for asynchronous timeout diagnostics.
     var onTapDisabled: (@Sendable (EventTapDiagnosticsSnapshot) -> Void)?
     /// Background-safe closure dispatched when the lifecycle tracker decides

--- a/Sources/Wink/Services/EventTapManager.swift
+++ b/Sources/Wink/Services/EventTapManager.swift
@@ -35,6 +35,16 @@ struct EventTapDiagnosticsSnapshot: Equatable, Sendable {
     }
 }
 
+/// Hyper (F19) hold-gesture phases observed by the tap callback, delivered
+/// off the hot path for display-only consumers (the cheat-sheet HUD). An
+/// idle hold emits `began` (repeated on autorepeat — consumers dedupe);
+/// a consumed chord or the key release ends the gesture.
+enum HyperHoldEvent: Equatable, Sendable {
+    case began
+    case chordConsumed
+    case ended
+}
+
 enum MatchedShortcutDelivery {
     static func makeHandler(
         _ handler: @escaping @MainActor @Sendable (KeyPress) -> Void
@@ -141,6 +151,7 @@ func handleEventTapEvent(
             DispatchQueue.global(qos: .utility).async {
                 DiagnosticLog.log("HYPER_F19_DOWN: keyCode=\(keyCode) flags=\(modifierFlags.rawValue) ts=\(eventTimestamp)")
             }
+            box.onHyperHoldEvent?(.began)
             return nil
         }
 
@@ -180,6 +191,9 @@ func handleEventTapEvent(
                     )
                 )
             }
+            if injectHyper {
+                box.onHyperHoldEvent?(.chordConsumed)
+            }
             box.onKeyPress?(keyPress)
             return nil
         }
@@ -211,6 +225,9 @@ func handleEventTapEvent(
             DispatchQueue.global(qos: .utility).async {
                 DiagnosticLog.log("HYPER_F19_UP: keyCode=\(keyCode) elapsed=\(elapsed) deferred=\(deferred)")
             }
+            // Sent for the 80ms toggle-quirk case too: a tap (not a hold)
+            // must cancel the consumer's hold timer.
+            box.onHyperHoldEvent?(.ended)
         }
         box.recordObservedEvent(
             type: .keyUp,
@@ -301,6 +318,9 @@ final class EventTapManager: EventTapManaging {
     typealias ShortcutHandler = @MainActor (KeyPress) -> Bool
 
     private let runtimeFactory: EventTapRuntimeFactory
+    /// Stored so every generation's box (start and recovery recreation both
+    /// route through `start()`) inherits the observer.
+    private var hyperHoldObserver: (@Sendable (HyperHoldEvent) -> Void)?
     #if WINK_EVENT_TAP_FAULT_INJECTION
     private let validationDriver: EventTapFaultInjectionDriver?
     #endif
@@ -388,6 +408,7 @@ final class EventTapManager: EventTapManaging {
                   | (1 << CGEventType.flagsChanged.rawValue)
 
         let box = EventTapBox()
+        box.onHyperHoldEvent = hyperHoldObserver
         box.onKeyPress = MatchedShortcutDelivery.makeHandler { [weak self] keyPress in
             self?.handleAsync(keyPress, generation: generation)
         }
@@ -484,6 +505,11 @@ final class EventTapManager: EventTapManaging {
 
     private var registeredKeyPresses: Set<KeyPress> = []
     private var hyperKeyEnabled = false
+
+    func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?) {
+        hyperHoldObserver = observer
+        owner?.box.onHyperHoldEvent = observer
+    }
 
     /// Enable or disable Hyper Key (F19) interception in the event tap callback.
     func setHyperKeyEnabled(_ enabled: Bool) {
@@ -1031,6 +1057,8 @@ final class EventTapBox: @unchecked Sendable {
     var reenableTap: (@Sendable () -> Void)?
     /// Background-safe closure that hops to the main actor before invoking app logic.
     var onKeyPress: (@Sendable (KeyPress) -> Void)?
+    /// Display-only observer; invoked on the tap thread outside the lock.
+    var onHyperHoldEvent: (@Sendable (HyperHoldEvent) -> Void)?
     /// Background-safe closure for asynchronous timeout diagnostics.
     var onTapDisabled: (@Sendable (EventTapDiagnosticsSnapshot) -> Void)?
     /// Background-safe closure dispatched when the lifecycle tracker decides

--- a/Sources/Wink/Services/ShortcutCaptureCoordinator.swift
+++ b/Sources/Wink/Services/ShortcutCaptureCoordinator.swift
@@ -110,6 +110,10 @@ final class ShortcutCaptureCoordinator {
         syncProviders(retryStandardProvider: standardProvider.inputMonitoringRequired)
     }
 
+    func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?) {
+        hyperProvider.setHyperHoldObserver(observer)
+    }
+
     func setCapturePaused(_ paused: Bool) {
         guard capturePaused != paused else { return }
         capturePaused = paused

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -165,6 +165,10 @@ final class ShortcutManager {
         appSwitcher.setFrontmostTargetBehavior(behavior)
     }
 
+    func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?) {
+        captureCoordinator.setHyperHoldObserver(observer)
+    }
+
     func setShortcutsPaused(_ paused: Bool) {
         guard shortcutsPaused != paused else {
             return

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -45,6 +45,9 @@ final class ShortcutManager {
     /// changed (permissions, secure input) so observers can re-pull
     /// `shortcutCaptureStatus()` without their own timers.
     var onCaptureStatusChange: (@MainActor () -> Void)?
+    /// Fires whenever the composed pause state transitions (manual pause,
+    /// exception auto-pause, either direction).
+    var onCapturePauseStateChange: (@MainActor (_ paused: Bool) -> Void)?
 
     private var effectivePaused: Bool {
         shortcutsPaused || autoPausedByException
@@ -198,6 +201,7 @@ final class ShortcutManager {
 
     private func applyEffectivePauseTransition() {
         let paused = effectivePaused
+        onCapturePauseStateChange?(paused)
         if !paused {
             _ = refreshShortcutAvailabilityIfNeeded()
         }

--- a/Sources/Wink/UI/CheatSheetHUD.swift
+++ b/Sources/Wink/UI/CheatSheetHUD.swift
@@ -1,0 +1,172 @@
+import AppKit
+import SwiftUI
+
+struct CheatSheetRow: Equatable, Identifiable {
+    let id: UUID
+    let appName: String
+    let bundleIdentifier: String
+    let keyDisplay: String
+}
+
+/// Idle-hold Hyper cheat sheet: hold Caps Lock ≥600ms without pressing a
+/// chord key and a display-only panel lists every enabled shortcut (icon,
+/// name, keycap). Any consumed chord or the Hyper release hides it. The
+/// timer runs on the main actor; hold events arrive from the tap thread
+/// and hop here once.
+@MainActor
+final class CheatSheetHUDController {
+    static let holdThreshold: TimeInterval = 0.6
+
+    private let rowsProvider: @MainActor () -> [CheatSheetRow]
+    private let isEnabled: @MainActor () -> Bool
+    private let present: @MainActor ([CheatSheetRow]) -> Void
+    private let dismiss: @MainActor () -> Void
+    private let schedule: @MainActor (TimeInterval, @escaping @MainActor () -> Void) -> Void
+
+    private var pendingHoldGeneration = 0
+    private var holdTimerActive = false
+    private(set) var isPresented = false
+
+    init(
+        rowsProvider: @escaping @MainActor () -> [CheatSheetRow],
+        isEnabled: @escaping @MainActor () -> Bool,
+        present: (@MainActor ([CheatSheetRow]) -> Void)? = nil,
+        dismiss: (@MainActor () -> Void)? = nil,
+        schedule: (@MainActor (TimeInterval, @escaping @MainActor () -> Void) -> Void)? = nil
+    ) {
+        self.rowsProvider = rowsProvider
+        self.isEnabled = isEnabled
+        self.present = present ?? { rows in
+            CheatSheetPanelController.shared.show(rows: rows)
+        }
+        self.dismiss = dismiss ?? {
+            CheatSheetPanelController.shared.hide()
+        }
+        self.schedule = schedule ?? { delay, operation in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                MainActor.assumeIsolated {
+                    operation()
+                }
+            }
+        }
+    }
+
+    func handle(_ event: HyperHoldEvent) {
+        switch event {
+        case .began:
+            // Autorepeat re-delivers began while held: one timer per gesture.
+            guard isEnabled(), !holdTimerActive, !isPresented else { return }
+            holdTimerActive = true
+            pendingHoldGeneration += 1
+            let generation = pendingHoldGeneration
+            schedule(Self.holdThreshold) { [weak self] in
+                guard let self,
+                      self.holdTimerActive,
+                      self.pendingHoldGeneration == generation else { return }
+                self.holdTimerActive = false
+                let rows = self.rowsProvider()
+                guard !rows.isEmpty else { return }
+                self.isPresented = true
+                self.present(rows)
+            }
+        case .chordConsumed, .ended:
+            holdTimerActive = false
+            pendingHoldGeneration += 1
+            if isPresented {
+                isPresented = false
+                dismiss()
+            }
+        }
+    }
+}
+
+/// Display-only panel host, same never-key posture as the cycle HUD.
+@MainActor
+final class CheatSheetPanelController {
+    static let shared = CheatSheetPanelController()
+
+    private var panel: NSPanel?
+    private var hostingView: NSHostingView<CheatSheetView>?
+
+    func show(rows: [CheatSheetRow]) {
+        let view = CheatSheetView(rows: rows)
+        if let hostingView {
+            hostingView.rootView = view
+        } else {
+            let hosting = NSHostingView(rootView: view)
+            let panel = NSPanel(
+                contentRect: .zero,
+                styleMask: [.borderless, .nonactivatingPanel],
+                backing: .buffered,
+                defer: true
+            )
+            panel.isFloatingPanel = true
+            panel.level = .popUpMenu
+            panel.backgroundColor = .clear
+            panel.isOpaque = false
+            panel.hasShadow = true
+            panel.ignoresMouseEvents = true
+            panel.hidesOnDeactivate = false
+            panel.collectionBehavior = [.canJoinAllSpaces, .transient, .fullScreenAuxiliary]
+            panel.contentView = hosting
+            self.panel = panel
+            self.hostingView = hosting
+        }
+
+        guard let panel, let hostingView else { return }
+        let size = hostingView.fittingSize
+        // Anchor to the display holding the pointer — the best available
+        // attention proxy for a keyboard gesture with no target window.
+        let mouse = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(mouse) }
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        let frame = screen?.visibleFrame ?? .zero
+        let origin = NSPoint(
+            x: frame.midX - size.width / 2,
+            y: frame.midY - size.height / 2
+        )
+        panel.setFrame(NSRect(origin: origin, size: size), display: true)
+        panel.orderFrontRegardless()
+    }
+
+    func hide() {
+        panel?.orderOut(nil)
+    }
+}
+
+private struct CheatSheetView: View {
+    let rows: [CheatSheetRow]
+
+    private var columns: [[CheatSheetRow]] {
+        // Cap the panel height by flowing into columns of at most 9 rows.
+        stride(from: 0, to: rows.count, by: 9).map {
+            Array(rows[$0..<min($0 + 9, rows.count)])
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 20) {
+            ForEach(Array(columns.enumerated()), id: \.offset) { _, column in
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(column) { row in
+                        HStack(spacing: 8) {
+                            AppIconView(bundleIdentifier: row.bundleIdentifier, size: 18)
+                            Text(row.appName)
+                                .font(.system(size: 12))
+                                .lineLimit(1)
+                                .frame(maxWidth: 140, alignment: .leading)
+                            Spacer(minLength: 4)
+                            Text(row.keyDisplay)
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .fixedSize()
+    }
+}

--- a/Sources/Wink/UI/CheatSheetHUD.swift
+++ b/Sources/Wink/UI/CheatSheetHUD.swift
@@ -51,6 +51,12 @@ final class CheatSheetHUDController {
         }
     }
 
+    /// Cancels any armed timer and dismisses a presented sheet. Used when
+    /// configuration changes cut the gesture short with no `ended` event.
+    func reset() {
+        handle(.ended)
+    }
+
     func handle(_ event: HyperHoldEvent) {
         switch event {
         case .began:
@@ -62,7 +68,11 @@ final class CheatSheetHUDController {
             schedule(Self.holdThreshold) { [weak self] in
                 guard let self,
                       self.holdTimerActive,
-                      self.pendingHoldGeneration == generation else { return }
+                      self.pendingHoldGeneration == generation,
+                      // Re-checked at fire time: Hyper (or the sheet) may
+                      // have been disabled mid-hold, and the tap clears its
+                      // state without emitting `ended`.
+                      self.isEnabled() else { return }
                 self.holdTimerActive = false
                 let rows = self.rowsProvider()
                 guard !rows.isEmpty else { return }

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -218,11 +218,7 @@ struct GeneralTabView: View {
 
                 SettingsToggleRow(
                     title: "Hyper cheat sheet",
-                    subtitle: preferences.hyperCheatSheetEnabled
-                        && preferences.hyperKeyEnabled
-                        && !preferences.shortcutCaptureStatus.eventTapActive
-                        ? "Hold Caps Lock without a second key to see all shortcuts. Needs at least one enabled Hyper shortcut."
-                        : "Hold Caps Lock without a second key to see all shortcuts.",
+                    subtitle: hyperCheatSheetSubtitle,
                     isOn: Binding(
                         get: { preferences.hyperCheatSheetEnabled },
                         set: { preferences.setHyperCheatSheetEnabled($0) }
@@ -282,6 +278,18 @@ struct GeneralTabView: View {
                 }
             }
         }
+    }
+
+    private var hyperCheatSheetSubtitle: String {
+        let base = "Hold Caps Lock without a second key to see all shortcuts."
+        guard preferences.hyperCheatSheetEnabled else { return base }
+        if !preferences.hyperKeyEnabled {
+            return base + " Needs Hyper Key enabled."
+        }
+        if !preferences.shortcutCaptureStatus.eventTapActive {
+            return base + " Needs at least one enabled Hyper shortcut."
+        }
+        return base
     }
 
     private func addExceptionApp() {

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -217,6 +217,17 @@ struct GeneralTabView: View {
                 Divider().overlay(palette.hairline)
 
                 SettingsToggleRow(
+                    title: "Hyper cheat sheet",
+                    subtitle: "Hold Caps Lock without a second key to see all shortcuts.",
+                    isOn: Binding(
+                        get: { preferences.hyperCheatSheetEnabled },
+                        set: { preferences.setHyperCheatSheetEnabled($0) }
+                    )
+                )
+
+                Divider().overlay(palette.hairline)
+
+                SettingsToggleRow(
                     title: "Suggest shortcuts from app usage",
                     subtitle: "Count app switches locally to suggest shortcuts in Insights. Turning this off also deletes the collected counts.",
                     isOn: Binding(

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -218,7 +218,11 @@ struct GeneralTabView: View {
 
                 SettingsToggleRow(
                     title: "Hyper cheat sheet",
-                    subtitle: "Hold Caps Lock without a second key to see all shortcuts.",
+                    subtitle: preferences.hyperCheatSheetEnabled
+                        && preferences.hyperKeyEnabled
+                        && !preferences.shortcutCaptureStatus.eventTapActive
+                        ? "Hold Caps Lock without a second key to see all shortcuts. Needs at least one enabled Hyper shortcut."
+                        : "Hold Caps Lock without a second key to see all shortcuts.",
                     isOn: Binding(
                         get: { preferences.hyperCheatSheetEnabled },
                         set: { preferences.setHyperCheatSheetEnabled($0) }

--- a/Tests/WinkTests/CheatSheetHUDControllerTests.swift
+++ b/Tests/WinkTests/CheatSheetHUDControllerTests.swift
@@ -99,3 +99,26 @@ func chordWhilePresentedDismisses() {
     #expect(harness.dismissals == 1)
     #expect(!harness.controller.isPresented)
 }
+
+@Test @MainActor
+func timerFireRechecksEnabledStateAfterMidHoldDisable() {
+    let harness = CheatSheetHarness()
+    harness.controller.handle(.began)
+    // Hyper (or the sheet) disabled mid-hold: the tap clears its state
+    // without emitting `ended`, so the armed timer must not present.
+    harness.enabled = false
+    harness.fireTimer()
+    #expect(harness.presented.isEmpty)
+}
+
+@Test @MainActor
+func resetDismissesPresentedSheetAndCancelsTimer() {
+    let harness = CheatSheetHarness()
+    harness.controller.handle(.began)
+    harness.fireTimer()
+    #expect(harness.controller.isPresented)
+
+    harness.controller.reset()
+    #expect(harness.dismissals == 1)
+    #expect(!harness.controller.isPresented)
+}

--- a/Tests/WinkTests/CheatSheetHUDControllerTests.swift
+++ b/Tests/WinkTests/CheatSheetHUDControllerTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import Wink
+
+@MainActor
+private final class CheatSheetHarness {
+    var rows: [CheatSheetRow] = [
+        CheatSheetRow(id: UUID(), appName: "Safari", bundleIdentifier: "com.apple.Safari", keyDisplay: "⌃⌥⇧⌘S")
+    ]
+    var enabled = true
+    var presented: [[CheatSheetRow]] = []
+    var dismissals = 0
+    var scheduled: [(delay: TimeInterval, fire: @MainActor () -> Void)] = []
+
+    lazy var controller = CheatSheetHUDController(
+        rowsProvider: { [unowned self] in self.rows },
+        isEnabled: { [unowned self] in self.enabled },
+        present: { [unowned self] rows in self.presented.append(rows) },
+        dismiss: { [unowned self] in self.dismissals += 1 },
+        schedule: { [unowned self] delay, fire in self.scheduled.append((delay, fire)) }
+    )
+
+    func fireTimer(_ index: Int = 0) {
+        scheduled[index].fire()
+    }
+}
+
+@Test @MainActor
+func idleHoldPresentsAfterThresholdOnly() {
+    let harness = CheatSheetHarness()
+    harness.controller.handle(.began)
+    #expect(harness.presented.isEmpty)
+    #expect(harness.scheduled.count == 1)
+    #expect(harness.scheduled[0].delay == CheatSheetHUDController.holdThreshold)
+
+    harness.fireTimer()
+    #expect(harness.presented.count == 1)
+    #expect(harness.controller.isPresented)
+
+    harness.controller.handle(.ended)
+    #expect(harness.dismissals == 1)
+    #expect(!harness.controller.isPresented)
+}
+
+@Test @MainActor
+func chordBeforeThresholdCancelsWithoutPresenting() {
+    let harness = CheatSheetHarness()
+    harness.controller.handle(.began)
+    harness.controller.handle(.chordConsumed)
+    harness.fireTimer()
+    #expect(harness.presented.isEmpty)
+    #expect(harness.dismissals == 0)
+}
+
+@Test @MainActor
+func autorepeatBeganDoesNotStackTimers() {
+    let harness = CheatSheetHarness()
+    harness.controller.handle(.began)
+    harness.controller.handle(.began)
+    harness.controller.handle(.began)
+    #expect(harness.scheduled.count == 1)
+}
+
+@Test @MainActor
+func staleTimerFromPreviousGestureNeverFires() {
+    let harness = CheatSheetHarness()
+    harness.controller.handle(.began)
+    harness.controller.handle(.ended)
+    // A new gesture starts before the old timer fires.
+    harness.controller.handle(.began)
+    harness.fireTimer(0)
+    #expect(harness.presented.isEmpty)
+    harness.fireTimer(1)
+    #expect(harness.presented.count == 1)
+}
+
+@Test @MainActor
+func disabledPreferenceAndEmptyRowsShowNothing() {
+    let harness = CheatSheetHarness()
+    harness.enabled = false
+    harness.controller.handle(.began)
+    #expect(harness.scheduled.isEmpty)
+
+    harness.enabled = true
+    harness.rows = []
+    harness.controller.handle(.began)
+    harness.fireTimer()
+    #expect(harness.presented.isEmpty)
+}
+
+@Test @MainActor
+func chordWhilePresentedDismisses() {
+    let harness = CheatSheetHarness()
+    harness.controller.handle(.began)
+    harness.fireTimer()
+    #expect(harness.controller.isPresented)
+
+    harness.controller.handle(.chordConsumed)
+    #expect(harness.dismissals == 1)
+    #expect(!harness.controller.isPresented)
+}


### PR DESCRIPTION
Fixes #357

## Summary
- **Hyper cheat sheet**: hold Caps Lock ≥600ms without pressing a chord key and a display-only panel lists every enabled shortcut (icon, name, keycap), anchored to the pointer's display; any consumed chord or the release hides it. Settings toggle in General (default on; requires Hyper enabled). Standard-route shortcuts are listed too — the sheet teaches all bindings, triggered by the one held modifier Wink owns end-to-end.
- The tap callback gains a single display-only observation seam — `EventTapBox.onHyperHoldEvent` (`began` / `chordConsumed` / `ended`) — threaded through the capture chain with sync no-op protocol defaults. Emission points: F19 keyDown swallow (autorepeat re-emits; the consumer dedupes), hyper-injected chord swallows, every F19 keyUp swallow (the 80ms Caps-Lock toggle-quirk tap emits `ended`, so a tap never leaves a timer armed), and — per the pre-push review — the flagsChanged-path transitions the hidutil remap can produce instead of keyDown/keyUp.
- A codex pre-push review over the tap changes found and this PR fixes: the flagsChanged path emitting nothing, an unprotected observer set-after-start data race (now written under the box lock and snapshotted before invocation), sibling-Task reordering that could arm a timer after a quick tap's release (delivery now rides the FIFO main queue), and a stuck/ghost sheet when Hyper is disabled mid-hold (fire-time isEnabled recheck + controller reset on the hyper-key change hook).

## Testing
- [x] `swift test` — 586 tests green (controller timer/generation/dedupe/disable matrix incl. mid-hold disable and reset)
- [ ] Additional validation noted below when needed

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Physical validation (tracked in #371's follow-up): idle Caps-Lock hold shows the sheet at 600ms with no added chord latency; chord before threshold cancels cleanly; quirk tap never shows it; sheet on the pointer's display.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.
- If the PR touches runtime-sensitive files, the PR metadata workflow will reject `Not runtime-sensitive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
