### PR TITLE
fix: exclude Split View divider and auxiliary AX elements from Cycle (#376)

### DIFF
--- a/Sources/Wink/Services/AppSwitcher.swift
+++ b/Sources/Wink/Services/AppSwitcher.swift
@@ -160,11 +160,15 @@ final class AppSwitcher: AppSwitching {
         /// with valid window IDs — most visibly the native Split View
         /// divider (role AXUnknown, ~13px wide, untitled, transient ID).
         /// Raising one moves the divider and resizes both panes (#376), so
-        /// rotation must only ever contain real content windows. A failed
-        /// role read counts as ineligible (fail closed): the windows list
-        /// itself was readable, and misclassifying a divider as a window is
-        /// destructive while dropping a window from one rotation is not.
-        let isContentWindow: (AXUIElement) -> Bool
+        /// rotation must only ever contain real content windows.
+        ///
+        /// Tri-state: `false` = the role read succeeded and the element is
+        /// definitively not a content window (excluded); `nil` = the role
+        /// read itself failed. The distinction matters mid-gesture: a
+        /// transient read failure must swallow the press like the
+        /// windows-read-failure path (never fall through to the hide lanes),
+        /// while a definitive auxiliary role is simply filtered out.
+        let isContentWindow: (AXUIElement) -> Bool?
         let raiseWindow: (AXUIElement) -> Void
         let unminimizeWindow: (AXUIElement) -> Void
         /// Seam over the WindowServer event post so tests never send real
@@ -1461,13 +1465,38 @@ final class AppSwitcher: AppSwitching {
         }
 
         var elementsByWindowID: [CGWindowID: AXUIElement] = [:]
+        var roleReadFailed = false
         for window in windows {
-            guard windowCycleClient.isContentWindow(window),
-                  let windowID = windowCycleClient.windowID(window),
+            switch windowCycleClient.isContentWindow(window) {
+            case true?:
+                break
+            case false?:
+                continue
+            case nil:
+                roleReadFailed = true
+                continue
+            }
+            guard let windowID = windowCycleClient.windowID(window),
                   elementsByWindowID[windowID] == nil else {
                 continue
             }
             elementsByWindowID[windowID] = window
+        }
+        if roleReadFailed,
+           windowCycleCoordinator.liveSession(for: shortcut.bundleIdentifier) != nil {
+            // Same invariant as the windows-read guard above: a transient AX
+            // failure mid-gesture (here: a role read on a window already in
+            // rotation) must swallow the press, not shrink the list below
+            // two and fall through to the hide lanes.
+            DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: CYCLE role read failed mid-gesture — press swallowed")
+            logToggleTrace(
+                family: .decision,
+                bundleIdentifier: shortcut.bundleIdentifier,
+                event: "cycle_read_failed",
+                reason: "role_read_failed_mid_gesture",
+                activationPath: nil
+            )
+            return true
         }
         // Rotation order is the sorted CGWindowID list: stable across
         // presses, unlike kAXWindows order, which reshuffles after a raise.
@@ -2392,7 +2421,7 @@ extension AppSwitcher.WindowCycleClient {
         isContentWindow: { element in
             var roleRef: CFTypeRef?
             let result = AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
-            guard result == .success, let role = roleRef as? String else { return false }
+            guard result == .success, let role = roleRef as? String else { return nil }
             return role == kAXWindowRole
         },
         raiseWindow: { element in

--- a/Sources/Wink/Services/AppSwitcher.swift
+++ b/Sources/Wink/Services/AppSwitcher.swift
@@ -156,6 +156,15 @@ final class AppSwitcher: AppSwitching {
     struct WindowCycleClient {
         let windowID: (AXUIElement) -> CGWindowID?
         let focusedWindowID: (pid_t) -> CGWindowID?
+        /// Cycle eligibility: `kAXWindows` also surfaces auxiliary elements
+        /// with valid window IDs — most visibly the native Split View
+        /// divider (role AXUnknown, ~13px wide, untitled, transient ID).
+        /// Raising one moves the divider and resizes both panes (#376), so
+        /// rotation must only ever contain real content windows. A failed
+        /// role read counts as ineligible (fail closed): the windows list
+        /// itself was readable, and misclassifying a divider as a window is
+        /// destructive while dropping a window from one rotation is not.
+        let isContentWindow: (AXUIElement) -> Bool
         let raiseWindow: (AXUIElement) -> Void
         let unminimizeWindow: (AXUIElement) -> Void
         /// Seam over the WindowServer event post so tests never send real
@@ -1453,7 +1462,8 @@ final class AppSwitcher: AppSwitching {
 
         var elementsByWindowID: [CGWindowID: AXUIElement] = [:]
         for window in windows {
-            guard let windowID = windowCycleClient.windowID(window),
+            guard windowCycleClient.isContentWindow(window),
+                  let windowID = windowCycleClient.windowID(window),
                   elementsByWindowID[windowID] == nil else {
                 continue
             }
@@ -2378,6 +2388,12 @@ extension AppSwitcher.WindowCycleClient {
                 return nil
             }
             return windowID
+        },
+        isContentWindow: { element in
+            var roleRef: CFTypeRef?
+            let result = AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
+            guard result == .success, let role = roleRef as? String else { return false }
+            return role == kAXWindowRole
         },
         raiseWindow: { element in
             AXUIElementPerformAction(element, kAXRaiseAction as CFString)

--- a/Sources/Wink/Services/AppSwitcher.swift
+++ b/Sources/Wink/Services/AppSwitcher.swift
@@ -1483,17 +1483,22 @@ final class AppSwitcher: AppSwitching {
             elementsByWindowID[windowID] = window
         }
         if roleReadFailed,
-           windowCycleCoordinator.liveSession(for: shortcut.bundleIdentifier) != nil {
-            // Same invariant as the windows-read guard above: a transient AX
-            // failure mid-gesture (here: a role read on a window already in
-            // rotation) must swallow the press, not shrink the list below
-            // two and fall through to the hide lanes.
-            DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: CYCLE role read failed mid-gesture — press swallowed")
+           windowCycleCoordinator.liveSession(for: shortcut.bundleIdentifier) != nil
+               || elementsByWindowID.count < 2 {
+            // Same invariant as the windows-read guard above, extended to the
+            // partial case: a transient role-read failure must never be the
+            // reason a cycle press falls through to the hide lanes. Covered
+            // both mid-gesture (session cursor preserved) and on a first
+            // press whose readable remainder dropped below two — hiding the
+            // active app because one role read hiccuped is worse than one
+            // dead press. With no failure, the <2 fallback to standard
+            // toggle is unchanged.
+            DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: CYCLE role read failed — press swallowed")
             logToggleTrace(
                 family: .decision,
                 bundleIdentifier: shortcut.bundleIdentifier,
                 event: "cycle_read_failed",
-                reason: "role_read_failed_mid_gesture",
+                reason: "role_read_failed",
                 activationPath: nil
             )
             return true

--- a/Tests/WinkTests/AppSwitcherCycleTests.swift
+++ b/Tests/WinkTests/AppSwitcherCycleTests.swift
@@ -39,9 +39,14 @@ private final class CycleActionRecorder {
 private struct CycleTestWindows {
     let elements: [AXUIElement]
     let idsByIndex: [CGWindowID]
+    /// IDs modeling auxiliary `kAXWindows` elements (Split View divider
+    /// class: non-AXWindow role, valid window ID) that the eligibility
+    /// filter must exclude from rotation (#376).
+    let ineligibleIDs: Set<CGWindowID>
 
-    init(ids: [CGWindowID]) {
+    init(ids: [CGWindowID], ineligibleIDs: Set<CGWindowID> = []) {
         self.idsByIndex = ids
+        self.ineligibleIDs = ineligibleIDs
         self.elements = (0..<ids.count).map { AXUIElementCreateApplication(pid_t(90_000 + $0)) }
     }
 
@@ -55,6 +60,11 @@ private struct CycleTestWindows {
     func element(for id: CGWindowID) -> AXUIElement? {
         guard let index = idsByIndex.firstIndex(of: id) else { return nil }
         return elements[index]
+    }
+
+    func isContentWindow(_ element: AXUIElement) -> Bool {
+        guard let id = windowID(for: element) else { return false }
+        return !ineligibleIDs.contains(id)
     }
 }
 
@@ -134,6 +144,9 @@ private func makeCycleSwitcher(
             },
             focusedWindowID: { _ in
                 focusedWindowID()
+            },
+            isContentWindow: { element in
+                windows.isContentWindow(element)
             },
             raiseWindow: { element in
                 if let id = windows.windowID(for: element) {
@@ -1059,4 +1072,95 @@ func hudAppearsFromSecondConsecutivePressWithPositionAndTitle() {
     #expect(recorder.hudPresentations.first?.targetWindowID == 103)
     #expect(recorder.hudPresentations.last?.stepIndex == 1)
     #expect(recorder.hudPresentations.last?.windowTitle == "Window 101")
+}
+
+// MARK: - Auxiliary-window eligibility (#376)
+
+@Test @MainActor
+func cycleExcludesAuxiliaryWindowsFromRotationAndHUD() {
+    guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
+          let bundleIdentifier = frontmostApp.bundleIdentifier else {
+        Issue.record("Expected a frontmost application with a bundle identifier for eligibility test")
+        return
+    }
+
+    let clock = CycleTestClock(time: 100)
+    let recorder = CycleActionRecorder()
+    // 103 models the Split View divider: a kAXWindows element with a valid
+    // window ID but a non-AXWindow role. Raising it resizes the panes, so
+    // it must never enter rotation, receive activation, or reach the HUD.
+    let windows = CycleTestWindows(ids: [101, 102, 103], ineligibleIDs: [103])
+    let switcher = makeCycleSwitcher(
+        frontmostApp: frontmostApp,
+        bundleIdentifier: bundleIdentifier,
+        windows: windows,
+        focusedWindowID: { 101 },
+        recorder: recorder,
+        clock: clock,
+        trackerBundle: bundleIdentifier
+    )
+    switcher.setFrontmostTargetBehavior(.cycleWindows)
+
+    let shortcut = AppShortcut(
+        appName: frontmostApp.localizedName ?? "Frontmost",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "c",
+        modifierFlags: ["command", "option"]
+    )
+
+    // Three presses over two eligible windows must wrap 102 → 101 → 102
+    // without ever touching 103.
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    clock.time += 0.2
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    clock.time += 0.2
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+
+    #expect(recorder.activatedWindowIDs == [102, 101, 102])
+    #expect(recorder.madeKeyWindowIDs == [102, 101, 102])
+    #expect(recorder.raisedWindowIDs == [102, 101, 102])
+    #expect(!recorder.activatedWindowIDs.contains(103))
+    #expect(!recorder.raisedWindowIDs.contains(103))
+    #expect(recorder.hudPresentations.allSatisfy { $0.windowCount == 2 })
+    #expect(recorder.hudPresentations.allSatisfy { $0.targetWindowID != 103 })
+    #expect(recorder.hideCalls == 0)
+}
+
+@Test @MainActor
+func cycleWithOneContentWindowPlusAuxiliaryFallsBackToStandardToggle() {
+    guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
+          let bundleIdentifier = frontmostApp.bundleIdentifier else {
+        Issue.record("Expected a frontmost application with a bundle identifier for eligibility fallback test")
+        return
+    }
+
+    let clock = CycleTestClock(time: 100)
+    let recorder = CycleActionRecorder()
+    // One real window + the divider: after filtering there is nothing to
+    // cycle through, so the press must take standard toggle semantics
+    // instead of "cycling" between a window and the divider.
+    let windows = CycleTestWindows(ids: [101, 102], ineligibleIDs: [102])
+    let switcher = makeCycleSwitcher(
+        frontmostApp: frontmostApp,
+        bundleIdentifier: bundleIdentifier,
+        windows: windows,
+        focusedWindowID: { 101 },
+        recorder: recorder,
+        clock: clock
+    )
+    switcher.setFrontmostTargetBehavior(.cycleWindows)
+
+    let shortcut = AppShortcut(
+        appName: frontmostApp.localizedName ?? "Frontmost",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "c",
+        modifierFlags: ["command", "option"]
+    )
+
+    _ = switcher.toggleApplication(for: shortcut)
+
+    #expect(recorder.raisedWindowIDs.isEmpty)
+    #expect(recorder.madeKeyWindowIDs.isEmpty)
+    #expect(!recorder.activatedWindowIDs.contains(102))
+    #expect(recorder.hudPresentations.isEmpty)
 }

--- a/Tests/WinkTests/AppSwitcherCycleTests.swift
+++ b/Tests/WinkTests/AppSwitcherCycleTests.swift
@@ -1224,3 +1224,48 @@ func transientRoleReadFailureMidGestureSwallowsThePress() {
     #expect(recorder.raisedWindowIDs == [102, 101])
     #expect(recorder.hideCalls == 0)
 }
+
+@Test @MainActor
+func firstPressRoleReadFailureBelowTwoWindowsSwallowsInsteadOfHiding() {
+    guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
+          let bundleIdentifier = frontmostApp.bundleIdentifier else {
+        Issue.record("Expected a frontmost application with a bundle identifier for first-press role-failure test")
+        return
+    }
+
+    let clock = CycleTestClock(time: 100)
+    let recorder = CycleActionRecorder()
+    let windows = CycleTestWindows(ids: [101, 102])
+    // No prior press: no live session exists. One of two real windows fails
+    // its role read transiently; the readable remainder (one window) must
+    // not be misread as "insufficient windows" and hide the active app.
+    windows.roleReadFailures.ids = [102]
+    let switcher = makeCycleSwitcher(
+        frontmostApp: frontmostApp,
+        bundleIdentifier: bundleIdentifier,
+        windows: windows,
+        focusedWindowID: { 101 },
+        recorder: recorder,
+        clock: clock,
+        trackerBundle: bundleIdentifier
+    )
+    switcher.setFrontmostTargetBehavior(.cycleWindows)
+
+    let shortcut = AppShortcut(
+        appName: frontmostApp.localizedName ?? "Frontmost",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "c",
+        modifierFlags: ["command", "option"]
+    )
+
+    #expect(switcher.toggleApplication(for: shortcut) == true, "press swallowed, not declined into the hide lanes")
+    #expect(recorder.hideCalls == 0)
+    #expect(recorder.raisedWindowIDs.isEmpty)
+
+    // Failure clears → the next press cycles normally.
+    windows.roleReadFailures.ids = []
+    clock.time += 0.5
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    #expect(recorder.raisedWindowIDs == [102])
+    #expect(recorder.hideCalls == 0)
+}

--- a/Tests/WinkTests/AppSwitcherCycleTests.swift
+++ b/Tests/WinkTests/AppSwitcherCycleTests.swift
@@ -43,6 +43,14 @@ private struct CycleTestWindows {
     /// class: non-AXWindow role, valid window ID) that the eligibility
     /// filter must exclude from rotation (#376).
     let ineligibleIDs: Set<CGWindowID>
+    /// IDs whose role read transiently fails (nil eligibility). A reference
+    /// box, not a struct field: the fixture closures capture this struct by
+    /// value, and a test must be able to establish a session first and THEN
+    /// inject the failure for the next press.
+    final class RoleFailureBox {
+        var ids: Set<CGWindowID> = []
+    }
+    let roleReadFailures = RoleFailureBox()
 
     init(ids: [CGWindowID], ineligibleIDs: Set<CGWindowID> = []) {
         self.idsByIndex = ids
@@ -62,8 +70,9 @@ private struct CycleTestWindows {
         return elements[index]
     }
 
-    func isContentWindow(_ element: AXUIElement) -> Bool {
+    func isContentWindow(_ element: AXUIElement) -> Bool? {
         guard let id = windowID(for: element) else { return false }
+        if roleReadFailures.ids.contains(id) { return nil }
         return !ineligibleIDs.contains(id)
     }
 }
@@ -1163,4 +1172,55 @@ func cycleWithOneContentWindowPlusAuxiliaryFallsBackToStandardToggle() {
     #expect(recorder.madeKeyWindowIDs.isEmpty)
     #expect(!recorder.activatedWindowIDs.contains(102))
     #expect(recorder.hudPresentations.isEmpty)
+}
+
+@Test @MainActor
+func transientRoleReadFailureMidGestureSwallowsThePress() {
+    guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
+          let bundleIdentifier = frontmostApp.bundleIdentifier else {
+        Issue.record("Expected a frontmost application with a bundle identifier for role-failure test")
+        return
+    }
+
+    let clock = CycleTestClock(time: 100)
+    let recorder = CycleActionRecorder()
+    let windows = CycleTestWindows(ids: [101, 102])
+    let switcher = makeCycleSwitcher(
+        frontmostApp: frontmostApp,
+        bundleIdentifier: bundleIdentifier,
+        windows: windows,
+        focusedWindowID: { 101 },
+        recorder: recorder,
+        clock: clock,
+        trackerBundle: bundleIdentifier
+    )
+    switcher.setFrontmostTargetBehavior(.cycleWindows)
+
+    let shortcut = AppShortcut(
+        appName: frontmostApp.localizedName ?? "Frontmost",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "c",
+        modifierFlags: ["command", "option"]
+    )
+
+    // Establish a live session, then make one in-rotation window's role
+    // read fail transiently on the next press.
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    #expect(recorder.raisedWindowIDs == [102])
+    windows.roleReadFailures.ids = [101]
+    clock.time += 0.2
+
+    // Same invariant as the windows-read-failure path: the press is
+    // swallowed — no hide, no raise, session preserved rather than
+    // collapsing to a sub-two-window standard toggle.
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    #expect(recorder.hideCalls == 0)
+    #expect(recorder.raisedWindowIDs == [102])
+
+    // Failure clears → the gesture continues from the preserved cursor.
+    windows.roleReadFailures.ids = []
+    clock.time += 0.2
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    #expect(recorder.raisedWindowIDs == [102, 101])
+    #expect(recorder.hideCalls == 0)
 }


### PR DESCRIPTION
Fixes #376

## Summary
- Native Split View's divider surfaces in `kAXWindows` as an auxiliary element (role `AXUnknown`, untitled, ~13px, valid transient window ID); the cycle path accepted every nonzero window ID, so a two-pane Split View cycled `1/3 → 2/3 → 3/3` with an untitled HUD entry, and raising the third "window" moved the divider and resized both panes (physical acceptance evidence in #376).
- Root cause: no eligibility filter between the AX windows read and rotation build. `WindowCycleClient` gains an `isContentWindow` seam; the live implementation requires a successful `kAXRole` read returning `AXWindow`. Fail closed on a failed role read: misclassifying a divider as a window is destructive (it resizes the user's layout), while dropping one window from one rotation is not.
- Filtering happens at rotation build, so the HUD count/title and the fewer-than-two-windows standard-toggle fallback correct themselves automatically. Minimized content windows keep role `AXWindow` and stay eligible/restorable.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

599 tests pass. Two new regressions: a rotation with two content windows plus an ineligible auxiliary element wraps `102 → 101 → 102` with HUD count locked at 2 and the auxiliary ID never activated/made-key/raised; one content window plus the auxiliary falls back to standard toggle semantics instead of "cycling" onto the divider.

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Pending physical item (per #376 acceptance): real full-screen Split View with two Firefox windows on the packaged final-SHA build — full rotation stays `/2`, pane ratio and divider position unchanged, HUD titles always name a real window. Unblocks the fullscreen acceptance gates for #359/#362 in #371.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

Cycle semantics in AGENTS.md remain accurate (rotation identity/cooldowns unchanged); the eligibility filter narrows which elements enter rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
