### PR TITLE
fix: suspend the Caps Lock mapping while capture is paused (#375)

### DIFF
--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -279,7 +279,15 @@ final class AppController {
             startUpdateService: { _ = updateService },
             loadShortcuts: { try persistenceService.load() },
             replaceShortcuts: { shortcutStore.replaceAll(with: $0) },
-            reapplyHyperIfNeeded: { hyperKeyService.reapplyIfNeeded() },
+            // "Deferred by an active pause" counts as armed: the routing
+            // decision below must reflect user intent, not the pause. With
+            // capture paused the tap isn't running anyway, and resume
+            // restores the mapping — disabling Hyper routing here instead
+            // would leave F19 mapped-but-unintercepted after resume until a
+            // manual Hyper off/on cycle.
+            reapplyHyperIfNeeded: {
+                hyperKeyService.reapplyIfNeeded() || hyperKeyService.isSuspended
+            },
             isHyperEnabled: { hyperKeyService.isEnabled },
             setHyperKeyEnabled: { shortcutManager.setHyperKeyEnabled($0) },
             preparePreferences: { _ = appPreferences },

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -224,9 +224,15 @@ final class AppController {
         }
         // Pause (manual or exception-rule) stops the Hyper provider without
         // an `ended` event; a presented sheet must not outlive capture.
+        // The hidutil mapping follows the same composed bit (#375): a paused
+        // Wink consumes no F19, so Caps Lock must revert to native behavior
+        // for the paused interval and come back on resume.
         shortcutManager.onCapturePauseStateChange = { [weak self] paused in
             if paused {
                 self?.cheatSheetHUD.reset()
+                self?.hyperKeyService.suspendMappingForPause()
+            } else {
+                self?.hyperKeyService.resumeMappingAfterPause()
             }
         }
 

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -36,15 +36,42 @@ final class AppController {
     private lazy var appSwitcher = AppSwitcher()
     private lazy var settingsLauncher = SettingsLauncher(userDefaults: userDefaults)
     private lazy var settingsShortcutStatusProvider = ShortcutStatusProvider()
-    private lazy var shortcutManager = ShortcutManager(
-        shortcutStore: shortcutStore,
-        persistenceService: persistenceService,
-        appSwitcher: appSwitcher,
-        usageTracker: usageTracker,
-        appBundleLocator: appBundleLocator,
-        automaticPermissionPromptingEnabled: ShortcutManager.defaultAutomaticPermissionPromptingEnabled(),
-        diagnosticClient: .live
-    )
+    private lazy var shortcutManager: ShortcutManager = {
+        let manager = ShortcutManager(
+            shortcutStore: shortcutStore,
+            persistenceService: persistenceService,
+            appSwitcher: appSwitcher,
+            usageTracker: usageTracker,
+            appBundleLocator: appBundleLocator,
+            automaticPermissionPromptingEnabled: ShortcutManager.defaultAutomaticPermissionPromptingEnabled(),
+            diagnosticClient: .live
+        )
+        // Installed HERE, not in start(): AppPreferences' initializer replays
+        // a persisted manual pause, and SwiftUI evaluates the scene services
+        // (which construct AppPreferences) before applicationDidFinishLaunching
+        // ever calls start(). Since AppPreferences takes this manager as an
+        // init argument, any path that constructs it forces this lazy block
+        // first — the handler is provably installed before the first pause
+        // transition can fire, whichever access path wins. Without that
+        // ordering, a launch into a paused state never suspends the hidutil
+        // mapping and the startup reapply re-arms Caps Lock → F19 with
+        // capture stopped (#375 at launch).
+        //
+        // Pause (manual or exception-rule) stops the Hyper provider without
+        // an `ended` event; a presented sheet must not outlive capture, and
+        // the mapping follows the same composed bit: a paused Wink consumes
+        // no F19, so Caps Lock reverts to native behavior for the paused
+        // interval and comes back on resume.
+        manager.onCapturePauseStateChange = { [weak self] paused in
+            if paused {
+                self?.cheatSheetHUD.reset()
+                self?.hyperKeyService.suspendMappingForPause()
+            } else {
+                self?.hyperKeyService.resumeMappingAfterPause()
+            }
+        }
+        return manager
+    }()
     private lazy var appPreferences = AppPreferences(
         shortcutManager: shortcutManager,
         hyperKeyService: hyperKeyService,
@@ -182,27 +209,10 @@ final class AppController {
             self?.updatePanelPresenter.dismiss()
         }
 
-        // Pause (manual or exception-rule) stops the Hyper provider without
-        // an `ended` event; a presented sheet must not outlive capture.
-        // The hidutil mapping follows the same composed bit (#375): a paused
-        // Wink consumes no F19, so Caps Lock must revert to native behavior
-        // for the paused interval and come back on resume.
-        //
-        // Installed BEFORE the first `appPreferences` access below: that
-        // lazy init replays a persisted manual pause, and the exception
-        // monitor configuration can auto-pause immediately. Those initial
-        // transitions must reach this handler — otherwise a launch into a
-        // paused state never suspends, the startup reapply re-arms the
-        // mapping, and Caps Lock stays a dead F19 key until the user
-        // toggles pause (the #375 failure, at launch).
-        shortcutManager.onCapturePauseStateChange = { [weak self] paused in
-            if paused {
-                self?.cheatSheetHUD.reset()
-                self?.hyperKeyService.suspendMappingForPause()
-            } else {
-                self?.hyperKeyService.resumeMappingAfterPause()
-            }
-        }
+        // The onCapturePauseStateChange handler is installed inside the
+        // shortcutManager lazy initializer, not here — SwiftUI's scene
+        // services construct AppPreferences before start() runs, and the
+        // initial pause replay must already see the handler.
 
         // Exception rules: configure from persisted preferences, follow
         // future edits, and start following frontmost changes.

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -182,6 +182,28 @@ final class AppController {
             self?.updatePanelPresenter.dismiss()
         }
 
+        // Pause (manual or exception-rule) stops the Hyper provider without
+        // an `ended` event; a presented sheet must not outlive capture.
+        // The hidutil mapping follows the same composed bit (#375): a paused
+        // Wink consumes no F19, so Caps Lock must revert to native behavior
+        // for the paused interval and come back on resume.
+        //
+        // Installed BEFORE the first `appPreferences` access below: that
+        // lazy init replays a persisted manual pause, and the exception
+        // monitor configuration can auto-pause immediately. Those initial
+        // transitions must reach this handler — otherwise a launch into a
+        // paused state never suspends, the startup reapply re-arms the
+        // mapping, and Caps Lock stays a dead F19 key until the user
+        // toggles pause (the #375 failure, at launch).
+        shortcutManager.onCapturePauseStateChange = { [weak self] paused in
+            if paused {
+                self?.cheatSheetHUD.reset()
+                self?.hyperKeyService.suspendMappingForPause()
+            } else {
+                self?.hyperKeyService.resumeMappingAfterPause()
+            }
+        }
+
         // Exception rules: configure from persisted preferences, follow
         // future edits, and start following frontmost changes.
         appPreferences.onFrontmostExceptionConfigurationChange = { [weak self] in
@@ -222,20 +244,6 @@ final class AppController {
         shortcutManager.onCaptureStatusChange = { [weak self] in
             self?.appPreferences.refreshPermissions()
         }
-        // Pause (manual or exception-rule) stops the Hyper provider without
-        // an `ended` event; a presented sheet must not outlive capture.
-        // The hidutil mapping follows the same composed bit (#375): a paused
-        // Wink consumes no F19, so Caps Lock must revert to native behavior
-        // for the paused interval and come back on resume.
-        shortcutManager.onCapturePauseStateChange = { [weak self] paused in
-            if paused {
-                self?.cheatSheetHUD.reset()
-                self?.hyperKeyService.suspendMappingForPause()
-            } else {
-                self?.hyperKeyService.resumeMappingAfterPause()
-            }
-        }
-
         // Hold events arrive on the tap thread; hop once to the main actor
         // via the main QUEUE, whose FIFO ordering keeps began/ended in
         // emission order (sibling Tasks carry no such guarantee, and a

--- a/Sources/Wink/Services/HyperKeyService.swift
+++ b/Sources/Wink/Services/HyperKeyService.swift
@@ -52,9 +52,12 @@ final class HyperKeyService {
         set { defaults.set(newValue, forKey: enabledKey) }
     }
 
-    /// True while the mapping is temporarily lifted for a capture pause.
-    /// Orthogonal to `isEnabled` (the persisted user intent): pause never
-    /// persists, so suspension must never touch the defaults-backed bit.
+    /// True while a capture pause is in effect. This records the PAUSE
+    /// INTERVAL itself, deliberately independent of `isEnabled`: the pause
+    /// can begin while Hyper is disabled, and Hyper can be toggled either
+    /// way mid-pause — in every combination, no mapping may be applied
+    /// until the pause ends. Orthogonal to the persisted `isEnabled` bit
+    /// (pause never persists).
     private(set) var isSuspended = false
 
     func enable() {
@@ -80,7 +83,9 @@ final class HyperKeyService {
             return
         }
         isEnabled = false
-        isSuspended = false
+        // isSuspended stays: it records the pause interval, which outlives
+        // an intent toggle. Re-enabling during the same pause must keep
+        // deferring the mapping; the resume transition alone ends it.
         logger.info("Hyper Key disabled")
         DiagnosticLog.log("Hyper Key disabled")
     }
@@ -109,13 +114,19 @@ final class HyperKeyService {
     /// desktop) the pause exists to protect. Mapping-only: `isEnabled`
     /// stays untouched, matching the never-persist rule for auto-pause.
     func suspendMappingForPause() {
-        guard isEnabled, !isSuspended else { return }
+        guard !isSuspended else { return }
+        // The pause fact is recorded unconditionally — even with Hyper
+        // disabled — so enabling Hyper mid-pause defers its mapping to
+        // resume instead of arming a dead F19 under the paused app.
+        isSuspended = true
+        guard isEnabled else { return }
         guard clearMapping() else {
+            // Mapping may still be armed during this pause; rare hidutil
+            // failure, logged. Resume re-applies over it harmlessly.
             logger.error("Failed to suspend Hyper Key mapping for pause")
             DiagnosticLog.log("Failed to suspend Hyper Key mapping for pause")
             return
         }
-        isSuspended = true
         logger.info("Hyper Key mapping suspended for pause")
         DiagnosticLog.log("Hyper Key mapping suspended for pause")
     }

--- a/Sources/Wink/Services/HyperKeyService.swift
+++ b/Sources/Wink/Services/HyperKeyService.swift
@@ -52,15 +52,25 @@ final class HyperKeyService {
         set { defaults.set(newValue, forKey: enabledKey) }
     }
 
+    /// True while the mapping is temporarily lifted for a capture pause.
+    /// Orthogonal to `isEnabled` (the persisted user intent): pause never
+    /// persists, so suspension must never touch the defaults-backed bit.
+    private(set) var isSuspended = false
+
     func enable() {
-        guard applyMapping() else {
-            logger.error("Failed to enable Hyper Key")
-            DiagnosticLog.log("Failed to enable Hyper Key")
-            return
+        // While suspended, applying the mapping would hand the paused
+        // foreground app a consumer-less F19 — the exact #375 failure. The
+        // intent persists; the mapping lands on resume.
+        if !isSuspended {
+            guard applyMapping() else {
+                logger.error("Failed to enable Hyper Key")
+                DiagnosticLog.log("Failed to enable Hyper Key")
+                return
+            }
         }
         isEnabled = true
-        logger.info("Hyper Key enabled")
-        DiagnosticLog.log("Hyper Key enabled")
+        logger.info("Hyper Key enabled (suspended=\(self.isSuspended))")
+        DiagnosticLog.log("Hyper Key enabled (suspended=\(isSuspended))")
     }
 
     func disable() {
@@ -70,6 +80,7 @@ final class HyperKeyService {
             return
         }
         isEnabled = false
+        isSuspended = false
         logger.info("Hyper Key disabled")
         DiagnosticLog.log("Hyper Key disabled")
     }
@@ -78,6 +89,10 @@ final class HyperKeyService {
     /// Returns whether the Hyper key mapping is actually applied after the call.
     func reapplyIfNeeded() -> Bool {
         guard isEnabled else { return false }
+        // Launching into a persisted pause suspends before this runs
+        // (AppPreferences init fires the pause transition); re-applying here
+        // would silently undo that suspension.
+        guard !isSuspended else { return false }
         guard applyMapping() else {
             logger.error("Failed to re-apply Hyper Key mapping on launch")
             DiagnosticLog.log("Failed to re-apply Hyper Key mapping on launch")
@@ -86,6 +101,36 @@ final class HyperKeyService {
         logger.info("Hyper Key mapping re-applied on launch")
         DiagnosticLog.log("Hyper Key mapping re-applied on launch")
         return true
+    }
+
+    /// Hands Caps Lock back to the system for the duration of a capture
+    /// pause (#375): a paused Wink consumes no F19, so leaving the mapping
+    /// applied turns Caps Lock into a dead key for the very app (VM, remote
+    /// desktop) the pause exists to protect. Mapping-only: `isEnabled`
+    /// stays untouched, matching the never-persist rule for auto-pause.
+    func suspendMappingForPause() {
+        guard isEnabled, !isSuspended else { return }
+        guard clearMapping() else {
+            logger.error("Failed to suspend Hyper Key mapping for pause")
+            DiagnosticLog.log("Failed to suspend Hyper Key mapping for pause")
+            return
+        }
+        isSuspended = true
+        logger.info("Hyper Key mapping suspended for pause")
+        DiagnosticLog.log("Hyper Key mapping suspended for pause")
+    }
+
+    func resumeMappingAfterPause() {
+        guard isSuspended else { return }
+        isSuspended = false
+        guard isEnabled else { return }
+        guard applyMapping() else {
+            logger.error("Failed to restore Hyper Key mapping after pause")
+            DiagnosticLog.log("Failed to restore Hyper Key mapping after pause")
+            return
+        }
+        logger.info("Hyper Key mapping restored after pause")
+        DiagnosticLog.log("Hyper Key mapping restored after pause")
     }
 
     /// Clear mapping on app exit to restore normal Caps Lock behavior.

--- a/Tests/WinkTests/HyperKeyServiceTests.swift
+++ b/Tests/WinkTests/HyperKeyServiceTests.swift
@@ -100,3 +100,110 @@ private final class HidutilRunnerRecorder: @unchecked Sendable {
         return returnValue
     }
 }
+
+// MARK: - Pause suspension (#375)
+
+@Test @MainActor
+func suspendClearsMappingAndResumeRestoresItWithoutTouchingPersistence() {
+    let suiteName = "HyperKeyServiceTests.suspend.roundTrip"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "hyperKeyEnabled")
+
+    let recorder = HidutilRunnerRecorder(returns: true)
+    let service = HyperKeyService(runner: recorder.run, defaults: defaults)
+
+    service.suspendMappingForPause()
+    #expect(service.isSuspended == true)
+    #expect(service.isEnabled == true, "suspension must never touch the persisted bit")
+    #expect(recorder.invocations.count == 1)
+    #expect(recorder.invocations.first?.last?.contains("\"UserKeyMapping\":[]") == true)
+    #expect(recorder.invocations.first?.last?.contains("\"CapsLockDelayOverride\":100") == true)
+
+    // Idempotent while suspended.
+    service.suspendMappingForPause()
+    #expect(recorder.invocations.count == 1)
+
+    service.resumeMappingAfterPause()
+    #expect(service.isSuspended == false)
+    #expect(recorder.invocations.count == 2)
+    #expect(recorder.invocations.last?.last?.contains("HIDKeyboardModifierMappingSrc") == true)
+}
+
+@Test @MainActor
+func suspendIsANoOpWhenHyperIsDisabled() {
+    let suiteName = "HyperKeyServiceTests.suspend.disabled"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+
+    let recorder = HidutilRunnerRecorder(returns: true)
+    let service = HyperKeyService(runner: recorder.run, defaults: defaults)
+
+    service.suspendMappingForPause()
+    service.resumeMappingAfterPause()
+
+    #expect(recorder.invocations.isEmpty, "no mapping exists to lift or restore")
+}
+
+@Test @MainActor
+func reapplyDuringSuspensionDoesNotUndoTheSuspension() {
+    // Launching into a persisted pause suspends during AppPreferences init,
+    // BEFORE the startup sequence's reapplyIfNeeded runs; re-applying there
+    // would hand the paused foreground app a consumer-less F19 again.
+    let suiteName = "HyperKeyServiceTests.suspend.reapply"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "hyperKeyEnabled")
+
+    let recorder = HidutilRunnerRecorder(returns: true)
+    let service = HyperKeyService(runner: recorder.run, defaults: defaults)
+
+    service.suspendMappingForPause()
+    let applied = service.reapplyIfNeeded()
+
+    #expect(applied == false)
+    #expect(recorder.invocations.count == 1, "only the suspension's clear may run")
+    #expect(service.isSuspended == true)
+}
+
+@Test @MainActor
+func enableDuringSuspensionDefersTheMappingToResume() {
+    let suiteName = "HyperKeyServiceTests.suspend.enable"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "hyperKeyEnabled")
+
+    let recorder = HidutilRunnerRecorder(returns: true)
+    let service = HyperKeyService(runner: recorder.run, defaults: defaults)
+
+    service.suspendMappingForPause()
+    service.enable()
+
+    #expect(service.isEnabled == true)
+    #expect(recorder.invocations.count == 1, "enable during a pause must not apply the mapping yet")
+
+    service.resumeMappingAfterPause()
+    #expect(recorder.invocations.count == 2)
+    #expect(recorder.invocations.last?.last?.contains("HIDKeyboardModifierMappingSrc") == true)
+}
+
+@Test @MainActor
+func disableDuringSuspensionClearsTheSuspendedFlag() {
+    let suiteName = "HyperKeyServiceTests.suspend.disable"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "hyperKeyEnabled")
+
+    let recorder = HidutilRunnerRecorder(returns: true)
+    let service = HyperKeyService(runner: recorder.run, defaults: defaults)
+
+    service.suspendMappingForPause()
+    service.disable()
+
+    #expect(service.isEnabled == false)
+    #expect(service.isSuspended == false)
+
+    // A later resume must not resurrect the mapping the user disabled.
+    service.resumeMappingAfterPause()
+    #expect(recorder.invocations.count == 2, "suspend clear + disable clear only")
+}

--- a/Tests/WinkTests/HyperKeyServiceTests.swift
+++ b/Tests/WinkTests/HyperKeyServiceTests.swift
@@ -131,7 +131,7 @@ func suspendClearsMappingAndResumeRestoresItWithoutTouchingPersistence() {
 }
 
 @Test @MainActor
-func suspendIsANoOpWhenHyperIsDisabled() {
+func suspendWithHyperDisabledRecordsThePauseWithoutTouchingHidutil() {
     let suiteName = "HyperKeyServiceTests.suspend.disabled"
     let defaults = UserDefaults(suiteName: suiteName)!
     defaults.removePersistentDomain(forName: suiteName)
@@ -139,10 +139,36 @@ func suspendIsANoOpWhenHyperIsDisabled() {
     let recorder = HidutilRunnerRecorder(returns: true)
     let service = HyperKeyService(runner: recorder.run, defaults: defaults)
 
+    // The pause fact must be recorded even with no mapping to lift —
+    // enabling Hyper mid-pause has to see it (see the dedicated test).
     service.suspendMappingForPause()
-    service.resumeMappingAfterPause()
+    #expect(service.isSuspended == true)
+    #expect(recorder.invocations.isEmpty, "no mapping exists to lift")
 
-    #expect(recorder.invocations.isEmpty, "no mapping exists to lift or restore")
+    service.resumeMappingAfterPause()
+    #expect(service.isSuspended == false)
+    #expect(recorder.invocations.isEmpty, "nothing to restore either")
+}
+
+@Test @MainActor
+func enablingHyperDuringAPauseThatStartedDisabledDefersToResume() {
+    let suiteName = "HyperKeyServiceTests.suspend.enableWhileDisabledPause"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+
+    let recorder = HidutilRunnerRecorder(returns: true)
+    let service = HyperKeyService(runner: recorder.run, defaults: defaults)
+
+    // Pause begins with Hyper off; the user enables Hyper mid-pause.
+    service.suspendMappingForPause()
+    service.enable()
+
+    #expect(service.isEnabled == true)
+    #expect(recorder.invocations.isEmpty, "the mapping must not arm a dead F19 under the paused app")
+
+    service.resumeMappingAfterPause()
+    #expect(recorder.invocations.count == 1)
+    #expect(recorder.invocations.last?.last?.contains("HIDKeyboardModifierMappingSrc") == true)
 }
 
 @Test @MainActor
@@ -188,7 +214,7 @@ func enableDuringSuspensionDefersTheMappingToResume() {
 }
 
 @Test @MainActor
-func disableDuringSuspensionClearsTheSuspendedFlag() {
+func disableDuringPauseKeepsThePauseAndBlocksAMidPauseReenableMapping() {
     let suiteName = "HyperKeyServiceTests.suspend.disable"
     let defaults = UserDefaults(suiteName: suiteName)!
     defaults.removePersistentDomain(forName: suiteName)
@@ -201,9 +227,33 @@ func disableDuringSuspensionClearsTheSuspendedFlag() {
     service.disable()
 
     #expect(service.isEnabled == false)
-    #expect(service.isSuspended == false)
+    #expect(service.isSuspended == true, "the pause interval outlives an intent toggle")
 
-    // A later resume must not resurrect the mapping the user disabled.
+    // Off→on inside the same pause must keep deferring the mapping.
+    service.enable()
+    #expect(recorder.invocations.count == 2, "suspend clear + disable clear; enable defers")
+
+    // Resume ends the pause; the (re-enabled) mapping applies now.
     service.resumeMappingAfterPause()
-    #expect(recorder.invocations.count == 2, "suspend clear + disable clear only")
+    #expect(recorder.invocations.count == 3)
+    #expect(recorder.invocations.last?.last?.contains("HIDKeyboardModifierMappingSrc") == true)
+    #expect(service.isSuspended == false)
+}
+
+@Test @MainActor
+func disableDuringPauseThenResumeDoesNotResurrectTheMapping() {
+    let suiteName = "HyperKeyServiceTests.suspend.disableStaysOff"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "hyperKeyEnabled")
+
+    let recorder = HidutilRunnerRecorder(returns: true)
+    let service = HyperKeyService(runner: recorder.run, defaults: defaults)
+
+    service.suspendMappingForPause()
+    service.disable()
+    service.resumeMappingAfterPause()
+
+    #expect(service.isSuspended == false)
+    #expect(recorder.invocations.count == 2, "suspend clear + disable clear only — no re-apply of a disabled mapping")
 }


### PR DESCRIPTION
Fixes #375

## Summary
- Exception auto-pause (and manual pause) stopped both capture providers but left the hidutil Caps Lock → F19 mapping plus `CapsLockDelayOverride=0` active, so the paused foreground app — the VM/remote-desktop apps exception rules exist to protect — received a consumer-less F19 instead of native Caps Lock for the entire paused interval (runtime evidence in #375).
- `HyperKeyService` gains a mapping-only suspension driven by the composed pause bit (`onCapturePauseStateChange`): pausing clears the mapping and restores the 100ms delay default; resuming re-applies it. The persisted `isEnabled` bit is never touched, preserving the auto-pause-never-persists rule.
- Lifecycle guards: `reapplyIfNeeded` skips while suspended (launching into a persisted pause suspends during `AppPreferences` init, before the startup reapply would otherwise re-arm the mapping); enabling Hyper during a pause persists the intent but defers the mapping to resume (applying it would recreate the exact defect); disabling during a pause clears the suspension so a later resume cannot resurrect a mapping the user turned off.
- Scope note: the fix deliberately covers manual pause too, not just exception auto-pause — both tear down every F19 consumer, so both previously turned Caps Lock into a dead key. "Paused" now consistently means the keyboard is fully handed back to the system.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

602 tests pass. Five new cases cover the suspend/resume round trip (mapping cleared with delay-default restore, persistence untouched, idempotency), disabled-Hyper no-op, reapply-during-suspension, enable-during-suspension deferral, and disable-during-suspension flag clearing.

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Pending physical item (per #375 reproduction): packaged build, Hyper enabled, exception app frontmost → `hidutil property --get UserKeyMapping` shows `[]` and `CapsLockDelayOverride` is 100 while paused; native Caps Lock toggles in the exception app; leaving it restores the F19 mapping and Hyper shortcuts. Same check once via the manual pause toggle. Unblocks #364's gate in #371.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

The AGENTS.md exception-rules paragraph stays accurate (pause bits and composition unchanged); this adds mapping lifetime to the same transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
