### PR TITLE
docs: layered PR review protocol as a repo skill

### DIFF
--- a/.claude/skills/babysit-prs/SKILL.md
+++ b/.claude/skills/babysit-prs/SKILL.md
@@ -83,7 +83,7 @@ Process each PR in order: **1b → 1c → 1a**.
 - PR was NOT created or pushed to in this iteration
 - No `needs-human-review` or `arch-decision` label
 
-If eligible: merge per pr-review-loop Layer 3. Note the branch ruleset blocks a plain `gh pr merge` — merging requires an account with the ruleset's bypass (`--admin`). If the active account lacks it, add label `needs-human-review` with a "merge-ready" comment instead of retrying.
+If eligible: merge per pr-review-loop Layer 3. Attempt the normal `gh pr merge <number> --squash --delete-branch` FIRST — a PR with a fresh approving review, resolved threads, and green checks satisfies the ruleset without any bypass. Only when the merge is rejected by base-branch policy (the common case for bot-reviewed-only PRs, which carry no approving review) does merging require an account with the ruleset bypass (`--admin`); if the active account lacks it, add label `needs-human-review` with a "merge-ready" comment instead of retrying.
 
 ### Step 2: Select Next Issue
 

--- a/.claude/skills/babysit-prs/SKILL.md
+++ b/.claude/skills/babysit-prs/SKILL.md
@@ -77,17 +77,13 @@ Process each PR in order: **1b → 1c → 1a**.
 
 **1b. CI failures**: Check `gh pr checks <number>`. Attempt fix (max 2 attempts). If still failing: add label `needs-human-review`, comment, move on. If you push a fix, leave the PR open for a later iteration.
 
-**1c. Review feedback**: Read `references/review-gates.md` for tool-specific rules. Read PR comments: `gh pr view <number> --comments`. Check session memory for `/codex:review` findings. All bot review findings (any priority) and high-confidence `/code-review` findings (≥80): must-fix. Only skip a finding if it is clearly a false positive or provides no actionable value — in that case, comment on the PR explaining why it was dismissed. If a review tool is unavailable, comment that the gate was unavailable and leave the PR open.
+**1c. Review feedback**: Load `.claude/skills/pr-review-loop/SKILL.md` — it is the single source of truth for bot-review mechanics (trigger semantics, the THREE terminal-signal forms, thread reply/resolve etiquette, rerunning the stale `Validate review state` check). `references/review-gates.md` adds the loop-specific tool tiers on top. Read PR comments: `gh pr view <number> --comments`. Check session memory for `/codex:review` findings. All bot review findings (any priority) and high-confidence `/code-review` findings (≥80): must-fix. Only skip a finding if it is clearly a false positive or provides no actionable value — in that case, comment on the PR explaining why it was dismissed. If a review tool is unavailable, comment that the gate was unavailable and leave the PR open.
 
-**1a. Merge eligible**: A PR is eligible when ALL true:
-- CI passes
-- No unresolved high-confidence `/code-review` findings (≥80)
-- No unresolved bot review findings (any priority)
-- No unresolved critical `/codex:review` findings in session memory
+**1a. Merge eligible**: Apply pr-review-loop's Layer 3 checklist (clean pass on the HEAD commit, zero unresolved actionable threads, runtime-validation label discipline) plus the loop-specific rules:
 - PR was NOT created or pushed to in this iteration
 - No `needs-human-review` or `arch-decision` label
 
-If eligible: `gh pr merge <number> --squash --delete-branch`.
+If eligible: merge per pr-review-loop Layer 3. Note the branch ruleset blocks a plain `gh pr merge` — merging requires an account with the ruleset's bypass (`--admin`). If the active account lacks it, add label `needs-human-review` with a "merge-ready" comment instead of retrying.
 
 ### Step 2: Select Next Issue
 
@@ -146,7 +142,7 @@ EOF
 )" --base main
 ```
 
-**5d. Review gate (bounded)**: Fire reviews in parallel where possible:
+**5d. Review gate (bounded)**: For runtime-sensitive diffs (per AGENTS.md's definition), pr-review-loop's Layer 1 applies: run the local Codex deep review BEFORE the first push and fix confirmed findings — every post-push fix round costs a bot cycle. Then fire reviews in parallel where possible:
 1. `/codex:review --base main --background` first (async, if available)
 2. `/code-review` (sync, if available)
 3. Bot reviews arrive asynchronously — handled in Step 1c of a future iteration

--- a/.claude/skills/babysit-prs/SKILL.md
+++ b/.claude/skills/babysit-prs/SKILL.md
@@ -125,7 +125,7 @@ Max 3 fix-build-test cycles. If still failing → comment, **NEXT ITERATION**.
 
 **5b. Code quality**: If `/simplify` is available, run once before committing. If unavailable, note in PR body.
 
-**5c. Pre-push gate, commit, and create PR**: For runtime-sensitive diffs (per AGENTS.md's definition), pr-review-loop's Layer 1 applies HERE, before the push: run the local Codex deep review over the branch diff and fix confirmed findings first — every post-push fix round costs a bot cycle. Then:
+**5c. Pre-push gate, commit, and create PR**: If the diff matches ANY of pr-review-loop's Layer 1 categories — hot paths, persistence compatibility (shortcuts.json / .winkrecipe / usage.db), or concurrency boundaries (a strictly wider net than AGENTS.md's runtime-sensitive definition: persistence-only and lock/actor changes count too) — the gate applies HERE, before the push: run the local Codex deep review over the branch diff and fix confirmed findings first — every post-push fix round costs a bot cycle. Then:
 ```bash
 git add -A
 git commit -m "<type>: <concise description> (#<N>)"
@@ -142,7 +142,7 @@ EOF
 )" --base main
 ```
 
-**5d. Review gate (bounded)**: The pre-push local review already ran in 5c for runtime-sensitive diffs. Fire the remaining reviews in parallel where possible:
+**5d. Review gate (bounded)**: The pre-push local review already ran in 5c for Layer 1-category diffs. Fire the remaining reviews in parallel where possible:
 1. `/codex:review --base main --background` first (async, if available)
 2. `/code-review` (sync, if available)
 3. Bot reviews arrive asynchronously — handled in Step 1c of a future iteration

--- a/.claude/skills/babysit-prs/SKILL.md
+++ b/.claude/skills/babysit-prs/SKILL.md
@@ -125,7 +125,7 @@ Max 3 fix-build-test cycles. If still failing → comment, **NEXT ITERATION**.
 
 **5b. Code quality**: If `/simplify` is available, run once before committing. If unavailable, note in PR body.
 
-**5c. Commit and create PR**:
+**5c. Pre-push gate, commit, and create PR**: For runtime-sensitive diffs (per AGENTS.md's definition), pr-review-loop's Layer 1 applies HERE, before the push: run the local Codex deep review over the branch diff and fix confirmed findings first — every post-push fix round costs a bot cycle. Then:
 ```bash
 git add -A
 git commit -m "<type>: <concise description> (#<N>)"
@@ -142,7 +142,7 @@ EOF
 )" --base main
 ```
 
-**5d. Review gate (bounded)**: For runtime-sensitive diffs (per AGENTS.md's definition), pr-review-loop's Layer 1 applies: run the local Codex deep review BEFORE the first push and fix confirmed findings — every post-push fix round costs a bot cycle. Then fire reviews in parallel where possible:
+**5d. Review gate (bounded)**: The pre-push local review already ran in 5c for runtime-sensitive diffs. Fire the remaining reviews in parallel where possible:
 1. `/codex:review --base main --background` first (async, if available)
 2. `/code-review` (sync, if available)
 3. Bot reviews arrive asynchronously — handled in Step 1c of a future iteration

--- a/.claude/skills/babysit-prs/SKILL.md
+++ b/.claude/skills/babysit-prs/SKILL.md
@@ -77,7 +77,7 @@ Process each PR in order: **1b → 1c → 1a**.
 
 **1b. CI failures**: Check `gh pr checks <number>`. Attempt fix (max 2 attempts). If still failing: add label `needs-human-review`, comment, move on. If you push a fix, leave the PR open for a later iteration.
 
-**1c. Review feedback**: Load `.claude/skills/pr-review-loop/SKILL.md` — it is the single source of truth for bot-review mechanics (trigger semantics, the THREE terminal-signal forms, thread reply/resolve etiquette, rerunning the stale `Validate review state` check). `references/review-gates.md` adds the loop-specific tool tiers on top. Read PR comments: `gh pr view <number> --comments`. Check session memory for `/codex:review` findings. All bot review findings (any priority) and high-confidence `/code-review` findings (≥80): must-fix. Only skip a finding if it is clearly a false positive or provides no actionable value — in that case, comment on the PR explaining why it was dismissed. If a review tool is unavailable, comment that the gate was unavailable and leave the PR open.
+**1c. Review feedback**: Load `.claude/skills/pr-review-loop/SKILL.md` — it is the single source of truth for bot-review mechanics (trigger semantics, the THREE terminal-signal forms, thread reply/resolve etiquette, rerunning the stale `Validate review state` check). `references/review-gates.md` adds the loop-specific tool tiers on top. Read PR comments: `gh pr view <number> --comments`. Check session memory for `/codex:review` findings. All bot review findings (any priority) and high-confidence `/code-review` findings (≥80): must-fix. Only skip a finding if it is clearly a false positive or provides no actionable value — in that case, comment on the PR explaining why it was dismissed. After pushing fixes for bot findings: reply on each thread with the commit hash, resolve it, and post `@codex review` to obtain a fresh verdict on the new HEAD — a push alone does NOT re-trigger the bot, and Layer 3 requires the clean pass on the current head. Leave the PR open for a later iteration to read that verdict. If a review tool is unavailable, comment that the gate was unavailable and leave the PR open.
 
 **1a. Merge eligible**: Apply pr-review-loop's Layer 3 checklist (clean pass on the HEAD commit, zero unresolved actionable threads, runtime-validation label discipline) plus the loop-specific rules:
 - PR was NOT created or pushed to in this iteration
@@ -138,9 +138,24 @@ Closes #<N>
 
 ## Verification
 - Automated: swift build, swift test, swift build -c release
+
+## Validation Status
+- [ ] Not runtime-sensitive
+- [ ] macOS runtime validation pending
+- [ ] macOS runtime validation complete
+
+## Docs Sync Check (issue #230)
+- [ ] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
+- [ ] No new references to `docs/archive/` as a current source of truth.
 EOF
 )" --base main
 ```
+
+Check EXACTLY ONE `Validation Status` box before submitting: the
+`Validate PR metadata` gate rejects zero or multiple selections and
+computes runtime-sensitive paths server-side, rejecting
+`Not runtime-sensitive` for diffs touching them — those PRs check
+`macOS runtime validation pending` and carry the matching label.
 
 **5d. Review gate (bounded)**: The pre-push local review already ran in 5c for Layer 1-category diffs. Fire the remaining reviews in parallel where possible:
 1. `/codex:review --base main --background` first (async, if available)

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -63,14 +63,21 @@ costs a bot review cycle and pollutes the PR timeline.
 
 ## Layer 3 — merge checklist
 
+- The PR body satisfies the `Validate PR metadata` gate: a closing
+  keyword (`Fixes #N`) linking an issue, and the template's three
+  `Validation Status` checklist lines kept verbatim with EXACTLY ONE
+  checked. The gate computes runtime-sensitive paths itself and rejects
+  `Not runtime-sensitive` for them — the checkbox is what it enforces;
+  no label substitutes for it.
 - All checks green on the HEAD commit (a clean bot pass on an older
   commit does not count).
 - Zero unresolved actionable threads.
-- Runtime-sensitive PRs (per AGENTS.md's definition) carry the
-  `macOS runtime validation pending` label and enumerate their physical
-  validation items in the PR body; the label flips to complete only after
-  on-device validation, typically batched (see the batch-validation
-  issues, e.g. #371).
+- Runtime-sensitive PRs (per AGENTS.md's definition) ADDITIONALLY carry
+  the `macOS runtime validation pending` label (tracking convention on
+  top of the enforced checkbox) and enumerate their physical validation
+  items in the PR body; the label flips to complete only after on-device
+  validation, typically batched (see the batch-validation issues, e.g.
+  #371).
 - Bot findings verify against source before accepting: the bot has been
   wrong about liveness before (a "dead" catalog key with a real consumer)
   — confirm each finding the same way you'd confirm a human reviewer's.

--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: pr-review-loop
+description: Wink's layered PR review protocol — local Codex pre-push review for runtime-sensitive changes, the GitHub Codex bot's trigger/terminal semantics, thread etiquette, and the merge checklist. Load before opening, updating, or shepherding any PR in this repository.
+---
+
+# Wink PR Review Loop
+
+The repository's review protocol is layered. Each layer has caught real
+defects the previous layers missed (calibration data: 2026-07-22, PRs
+#374–#379); skipping a layer is how plausible-but-wrong code merges.
+
+## Layer 0 — author self-check
+
+Beyond `swift build` / `swift test`:
+
+- Diff-based review cannot see lines that SHOULD have changed but didn't.
+  For sweeping changes, run a task-specific reverse audit (e.g. the #374
+  localization pass needed catalog-vs-source orphan checks in both
+  directions: keys without live call sites AND call sites bypassing the
+  catalog).
+- Check every new value against dual-use: does it feed an identifier,
+  persistence key, comparison, or notification identity? Localized or
+  session-scoped values must never reach those (see AGENTS.md and the
+  #323/#375 lessons).
+
+## Layer 1 — local Codex review BEFORE the first push (hard gate)
+
+If the change touches any of: hot paths (event tap, Carbon handlers,
+toggle/dispatch), persistence compatibility (shortcuts.json, .winkrecipe,
+usage.db), or concurrency boundaries (locks, queued deliveries, actor
+hops) — run a local Codex deep review over the full branch diff before
+pushing. Purely presentational changes may skip this.
+
+Prompt it with the diff range, the architectural context, and an explicit
+list of already-known findings to exclude. Full-repo local review sees
+cross-file lifecycle interactions that per-diff bot review repeatedly
+misses (measured: 4 P2 + 2 P3 found locally after four clean-ish bot
+rounds on #379, including generation-binding and deadline-timing holes).
+
+Fix confirmed findings before the first push: every post-push fix round
+costs a bot review cycle and pollutes the PR timeline.
+
+## Layer 2 — the GitHub Codex bot
+
+- Triggers: opening a PR, marking a draft ready, or commenting
+  `@codex review`.
+- Working signal: 👀 reaction on the trigger. Do not conclude anything
+  (and do not re-trigger) while 👀 is present.
+- Terminal signals — THREE forms, any one of them:
+  1. a review object with inline threads (findings);
+  2. a 👍 reaction on the trigger (clean pass, common on first rounds);
+  3. a top-level comment "Codex Review: Didn't find any major issues"
+     (clean pass, common on re-reviews).
+  A watcher that only checks two of the three will misread "still
+  running" and waste a quota round on a duplicate trigger.
+- After pushing fixes: reply on each thread with the commit hash and what
+  changed, resolve the thread, and trigger a fresh round. Repeat until a
+  clean pass on the current head commit. Never resolve a thread whose fix
+  is not on the branch.
+- The `Review Gate / Validate review state` check fails while actionable
+  threads are unresolved; after resolving, rerun the stale check run
+  (requires repository admin).
+
+## Layer 3 — merge checklist
+
+- All checks green on the HEAD commit (a clean bot pass on an older
+  commit does not count).
+- Zero unresolved actionable threads.
+- Runtime-sensitive PRs (per AGENTS.md's definition) carry the
+  `macOS runtime validation pending` label and enumerate their physical
+  validation items in the PR body; the label flips to complete only after
+  on-device validation, typically batched (see the batch-validation
+  issues, e.g. #371).
+- Bot findings verify against source before accepting: the bot has been
+  wrong about liveness before (a "dead" catalog key with a real consumer)
+  — confirm each finding the same way you'd confirm a human reviewer's.
+
+## Escalation pattern observed
+
+The bot presses progressively deeper on the same seam across rounds
+(e.g. #378: handler-install order inside start() → SwiftUI scene
+construction preceding start() entirely → suspension-state coupling).
+Treat each round's finding as a pointer to a CLASS of defect and sweep
+the class yourself before re-triggering, or the next round finds the
+sibling you left behind.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ Use this file as a concise operating guide. Treat the detailed repository docs a
 - `docs/handoff-notes.md` for recent validation status and open follow-up work
 - `docs/lessons-learned.md` for operational and troubleshooting lessons
 - `docs/loop-prompt.md` and `docs/loop-job-guide.md` for review gates and automation workflow
+- `.claude/skills/pr-review-loop/SKILL.md` for the layered PR review protocol (local Codex pre-push gate, bot semantics, merge checklist)
 
 ## Environment and platform constraints
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This directory maps the maintainer-facing docs for Wink. Last reviewed: 2026-04-
 - [`pr-governance-rollout.md`](./pr-governance-rollout.md) — one-time rollout runbook for the review gate and `main` ruleset apply sequence
 - [`loop-prompt.md`](./loop-prompt.md) — reference and migration note; active automation is the `/babysit-prs` skill
 - [`loop-job-guide.md`](./loop-job-guide.md) — how to run and manage loop jobs with `/loop 30m /babysit-prs`
+- [`../.claude/skills/pr-review-loop/SKILL.md`](../.claude/skills/pr-review-loop/SKILL.md) — the layered PR review protocol (local pre-push review gate, Codex bot semantics, merge checklist); source of truth for babysit-prs' review/merge steps
 - [`agent-workflow-harnesses`](https://github.com/xrf9268-hue/agent-workflow-harnesses) — external maintainer workflow harness repo for cross-session issue handoff, PR watch, and reusable automation templates across Wink and related repos
 
 ## Subdirectories

--- a/docs/loop-job-guide.md
+++ b/docs/loop-job-guide.md
@@ -16,7 +16,7 @@ In a Claude Code interactive session, run:
 /loop 30m /babysit-prs
 ```
 
-This schedules a recurring task that fires every 30 minutes. Each iteration follows the pipeline defined in the `babysit-prs` skill (`.claude/skills/babysit-prs/SKILL.md` in this repo).
+This schedules a recurring task that fires every 30 minutes. Each iteration follows the pipeline defined in the `babysit-prs` skill (`.claude/skills/babysit-prs/SKILL.md` in this repo); its review and merge steps apply the layered protocol in `.claude/skills/pr-review-loop/SKILL.md` (local pre-push review for runtime-sensitive diffs, bot semantics, merge checklist).
 
 ## How /loop Works
 

--- a/docs/loop-prompt.md
+++ b/docs/loop-prompt.md
@@ -13,7 +13,7 @@ Core repository state sync now lives in GitHub Actions:
 /loop 30m /babysit-prs
 ```
 
-The skill lives at `.claude/skills/babysit-prs/SKILL.md` (in this repo) and uses progressive disclosure:
+The skill lives at `.claude/skills/babysit-prs/SKILL.md` (in this repo). Review and merge mechanics are delegated to `.claude/skills/pr-review-loop/SKILL.md` — the single source of truth for the local pre-push review gate on runtime-sensitive diffs, the Codex bot's trigger/terminal semantics, thread etiquette, and the merge checklist. babysit-prs keeps the loop-specific machinery and uses progressive disclosure:
 
 - `SKILL.md` — main pipeline: safety constraints, iteration guard, workflow steps
 - `references/review-gates.md` — three-tier review tool behavior and degraded-tooling rules


### PR DESCRIPTION
Fixes #381

## Summary
- Captures the layered PR review protocol proven across this batch (#374–#379) as a repo skill at `.claude/skills/pr-review-loop/SKILL.md`, so it survives session/agent boundaries instead of living in one assistant's memory: author self-check with task-specific reverse audits, the hard local-Codex-review gate before the first push of runtime-sensitive changes (with the measured 4 P2 + 2 P3 rationale from #379), the GitHub Codex bot's trigger semantics and all three terminal-signal forms, thread etiquette + the review-state check rerun, the merge checklist, and the observed escalation pattern across bot rounds.
- AGENTS.md's system-of-record list links the skill.

## Testing
- [x] `swift test`
- [ ] Additional validation noted below when needed

Docs-only; no code paths changed.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)