### PR TITLE
feat: search-to-switch palette with a dedicated trigger shortcut (#356)

### DIFF
--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -108,6 +108,9 @@ final class AppController {
                 runningBundleIdentifiers: runningBundleIdentifiers
             )
         },
+        recentBundleIdentifiersProvider: { [weak self] in
+            self?.appListProvider.recentBundleIDs ?? []
+        },
         activate: { [weak self] entry in
             guard let self else { return false }
             // NOT toggleApplication's default semantics: a plain call would
@@ -121,13 +124,27 @@ final class AppController {
             // matches the wink:// URL scheme's .toggle handling below: this
             // ad hoc shortcut has no persisted id, so recording "usage"
             // against it would just orphan a UUID no UI ever shows.
-            return self.appSwitcher.toggleApplication(for: AppShortcut(
-                appName: entry.name,
-                bundleIdentifier: entry.bundleIdentifier,
-                keyEquivalent: "",
-                modifierFlags: [],
-                frontmostBehaviorOverride: .focus
-            ))
+            //
+            // bypassCooldown: true — a palette commit is a direct, one-shot
+            // user choice ("activate this app right now"), not a repeated
+            // key-chord press. Without this, hiding an app via its real
+            // shortcut and then committing the SAME app from the palette
+            // within the 400ms cooldown window would silently drop the
+            // commit after the palette already dismissed, leaving the app
+            // hidden with no feedback. The re-entry guard and cooldown STAMP
+            // stay intact (see AppSwitcher.toggleApplication) — only the
+            // early cooldown *check* is skipped, and the stamp this call
+            // writes still protects the very next real shortcut press.
+            return self.appSwitcher.toggleApplication(
+                for: AppShortcut(
+                    appName: entry.name,
+                    bundleIdentifier: entry.bundleIdentifier,
+                    keyEquivalent: "",
+                    modifierFlags: [],
+                    frontmostBehaviorOverride: .focus
+                ),
+                bypassCooldown: true
+            )
         }
     )
     private lazy var appPreferences = AppPreferences(
@@ -348,7 +365,13 @@ final class AppController {
         // list now (not on first open) so a trigger pressed any time after
         // launch sees an already-scanned, cached `AppListProvider.allApps`
         // — the open-to-first-keystroke latency budget has no room for a
-        // synchronous filesystem scan.
+        // synchronous filesystem scan. The scan is still async, though: a
+        // trigger pressed before it lands must not leave the palette stuck
+        // empty until dismiss/reopen, so the palette also self-heals once
+        // the scan (this one or any later one) actually completes.
+        appListProvider.onRefreshCompleted = { [weak self] in
+            self?.searchPaletteHUD.refreshCandidatesIfPresented()
+        }
         appListProvider.refreshIfNeeded()
         shortcutManager.onSearchPaletteTriggered = { [weak self] in
             self?.searchPaletteHUD.present()

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -135,6 +135,13 @@ final class AppController {
             // stay intact (see AppSwitcher.toggleApplication) — only the
             // early cooldown *check* is skipped, and the stamp this call
             // writes still protects the very next real shortcut press.
+            //
+            // Recency at request time (same semantics as AppPickerPopover's
+            // selection path): the palette's own empty-query list is ordered
+            // by recentBundleIDs, so a committed pick must feed it — noted
+            // even if activation later fails, matching the picker's
+            // request-time convention.
+            self.appListProvider.noteRecentApp(bundleIdentifier: entry.bundleIdentifier)
             return self.appSwitcher.toggleApplication(
                 for: AppShortcut(
                     appName: entry.name,

--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -66,6 +66,7 @@ final class AppController {
             if paused {
                 self?.cheatSheetHUD.reset()
                 self?.windowPickerHUD.dismiss()
+                self?.searchPaletteHUD.dismiss()
                 self?.hyperKeyService.suspendMappingForPause()
             } else {
                 self?.hyperKeyService.resumeMappingAfterPause()
@@ -79,6 +80,54 @@ final class AppController {
         },
         focusWindow: { [weak self] windowID, session in
             self?.appSwitcher.focusPickedWindow(windowID: windowID, session: session) ?? false
+        }
+    )
+    /// Search-to-switch palette (#356). Shares the exact single-flag gate
+    /// #352 wired for the window picker (`setInteractivePanelSessionActive`)
+    /// — since both controllers read/write the SAME shared bool and each
+    /// panel's own trigger keypress is swallowed by `ShortcutManager`
+    /// whenever that bool is already true, only one of the two panels can
+    /// ever be open at a time with no extra coordination code: whichever
+    /// trigger fires first wins, and the other's trigger keypress is a
+    /// silent no-op (consumed, no dispatch) until the first panel closes.
+    private lazy var searchPaletteHUD = SearchPaletteHUDController(
+        onSessionStateChange: { [weak self] active in
+            self?.shortcutManager.setInteractivePanelSessionActive(active)
+        },
+        candidatesProvider: { [weak self] in
+            guard let self else { return [] }
+            // A workspace snapshot taken once per open, not re-queried per
+            // keystroke — see SearchPaletteMatcher.swift for the latency
+            // rationale behind building candidates once up front.
+            let runningBundleIdentifiers = Set(
+                NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier)
+            )
+            return SearchPaletteCandidateBuilder.build(
+                apps: self.appListProvider.allApps,
+                shortcuts: self.shortcutStore.shortcuts,
+                runningBundleIdentifiers: runningBundleIdentifiers
+            )
+        },
+        activate: { [weak self] entry in
+            guard let self else { return false }
+            // NOT toggleApplication's default semantics: a plain call would
+            // hide the target if it's already frontmost (real toggle-off),
+            // which is wrong for "type a name, land on that app". Forcing
+            // `.focus` makes the already-frontmost branch a pure re-focus
+            // (see AppSwitcher.performFrontmostFocus) — activation only,
+            // independent of whatever frontmost behavior the user may have
+            // separately configured for a real shortcut targeting the same
+            // app. Calling AppSwitcher directly (not shortcutManager.trigger)
+            // matches the wink:// URL scheme's .toggle handling below: this
+            // ad hoc shortcut has no persisted id, so recording "usage"
+            // against it would just orphan a UUID no UI ever shows.
+            return self.appSwitcher.toggleApplication(for: AppShortcut(
+                appName: entry.name,
+                bundleIdentifier: entry.bundleIdentifier,
+                keyEquivalent: "",
+                modifierFlags: [],
+                frontmostBehaviorOverride: .focus
+            ))
         }
     )
     private lazy var appPreferences = AppPreferences(
@@ -293,6 +342,16 @@ final class AppController {
                 return
             }
             self.windowPickerHUD.present(session: session)
+        }
+        // Search-to-switch palette (#356): a plain key-down match on the
+        // dedicated trigger shortcut opens the palette. Pre-warm the app
+        // list now (not on first open) so a trigger pressed any time after
+        // launch sees an already-scanned, cached `AppListProvider.allApps`
+        // — the open-to-first-keystroke latency budget has no room for a
+        // synchronous filesystem scan.
+        appListProvider.refreshIfNeeded()
+        shortcutManager.onSearchPaletteTriggered = { [weak self] in
+            self?.searchPaletteHUD.present()
         }
 
         Self.runStartupSequence(

--- a/Sources/Wink/Models/AppShortcut.swift
+++ b/Sources/Wink/Models/AppShortcut.swift
@@ -1,10 +1,14 @@
 import Foundation
 
 /// What a shortcut points at. `nil`/`.app` targets the app named by
-/// `bundleIdentifier`; `.frontmostApp` resolves the target at press time.
+/// `bundleIdentifier`; `.frontmostApp` resolves the target at press time;
+/// `.searchPalette` is the #356 search-to-switch trigger — it names no app
+/// at all and is dispatched by `ShortcutManager` through
+/// `onSearchPaletteTriggered` instead of `AppSwitcher.toggleApplication`.
 enum ShortcutTarget: String, Codable, CaseIterable, Equatable, Sendable {
     case app
     case frontmostApp
+    case searchPalette
 }
 
 /// What holding a shortcut chord past the hold threshold does. `nil` keeps
@@ -43,6 +47,24 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
         String(localized: "Current App", bundle: WinkResourceBundle.bundle)
     }
 
+    /// Sentinel `bundleIdentifier` for the #356 search-palette trigger.
+    /// Names no installed app, on purpose — same pattern as
+    /// `frontmostTargetSentinelBundleIdentifier` — so a build that predates
+    /// `target` decodes this row as a normal shortcut that the availability
+    /// filter silently disables instead of misdispatching it.
+    static let searchPaletteTargetSentinelBundleIdentifier = "wink.target.search-palette"
+
+    /// Locale-stable name persisted into `appName` for the search-palette
+    /// trigger shortcut. Never localize this constant; see
+    /// `frontmostTargetStableName` for the same principle.
+    static let searchPaletteTargetStableName = "Search Palette"
+
+    /// Localized label for the search-palette trigger. Display-only — never
+    /// persist this; see `searchPaletteTargetStableName`.
+    static var searchPaletteTargetDisplayName: String {
+        String(localized: "Search Palette", bundle: WinkResourceBundle.bundle)
+    }
+
     let id: UUID
     var appName: String
     var bundleIdentifier: String
@@ -64,16 +86,29 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
         target == .frontmostApp
     }
 
-    /// `appName` resolved for display: the frontmost-app pseudo-target's
-    /// persisted stable name renders as its localized label; every other
-    /// shortcut's `appName` is already display-ready (an installed app's
-    /// real name) and passes through unchanged. Use this at every UI site
-    /// that renders a shortcut's app name — never render `appName` directly
-    /// where a pseudo-target might appear.
+    /// True for the #356 search-palette trigger shortcut. Its sentinel
+    /// bundle names no app, so every site that resolves a real target
+    /// (activation, the app icon cache, the per-app shortcut list) must
+    /// check this before treating `bundleIdentifier` as an installed app.
+    var isSearchPaletteTarget: Bool {
+        target == .searchPalette
+    }
+
+    /// `appName` resolved for display: a pseudo-target's persisted stable
+    /// name renders as its localized label; every other shortcut's
+    /// `appName` is already display-ready (an installed app's real name)
+    /// and passes through unchanged. Use this at every UI site that renders
+    /// a shortcut's app name — never render `appName` directly where a
+    /// pseudo-target might appear.
     var displayAppName: String {
-        bundleIdentifier == Self.frontmostTargetSentinelBundleIdentifier
-            ? Self.frontmostTargetDisplayName
-            : appName
+        switch bundleIdentifier {
+        case Self.frontmostTargetSentinelBundleIdentifier:
+            return Self.frontmostTargetDisplayName
+        case Self.searchPaletteTargetSentinelBundleIdentifier:
+            return Self.searchPaletteTargetDisplayName
+        default:
+            return appName
+        }
     }
 
     init(

--- a/Sources/Wink/Protocols/AppSwitching.swift
+++ b/Sources/Wink/Protocols/AppSwitching.swift
@@ -3,8 +3,12 @@ import Foundation
 
 @MainActor
 protocol AppSwitching {
+    /// - Parameter bypassCooldown: see `AppSwitcher.toggleApplication` — the
+    ///   re-entry guard and confirmation/recovery pipeline stay fully
+    ///   active either way; only the early per-bundle cooldown check is
+    ///   skipped, and the cooldown is still stamped afterward.
     @discardableResult
-    func toggleApplication(for shortcut: AppShortcut) -> Bool
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool
 
     func setFrontmostTargetBehavior(_ behavior: FrontmostTargetBehavior)
 
@@ -29,6 +33,13 @@ protocol AppSwitching {
 }
 
 extension AppSwitching {
+    /// Convenience for the overwhelmingly common case — a real shortcut
+    /// press always keeps the cooldown active.
+    @discardableResult
+    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+        toggleApplication(for: shortcut, bypassCooldown: false)
+    }
+
     func setFrontmostTargetBehavior(_ behavior: FrontmostTargetBehavior) {}
 
     func invalidateWindowCycleSession(reason: String) {}

--- a/Sources/Wink/Resources/Localizable.xcstrings
+++ b/Sources/Wink/Resources/Localizable.xcstrings
@@ -4074,6 +4074,74 @@
           }
         }
       }
+    },
+    "Search Palette": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search Palette"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索面板"
+          }
+        }
+      }
+    },
+    "Type an app name and press Return to switch to it.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Type an app name and press Return to switch to it."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入应用名称，按下 Return 键即可切换到该应用。"
+          }
+        }
+      }
+    },
+    "Search apps…": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search apps…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索应用…"
+          }
+        }
+      }
+    },
+    "No matching apps": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching apps"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有匹配的应用"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sources/Wink/Resources/Localized/en.lproj/Localizable.strings
+++ b/Sources/Wink/Resources/Localized/en.lproj/Localizable.strings
@@ -246,6 +246,8 @@
 	<string>No change</string>
 	<key>No change versus the previous period.</key>
 	<string>No change versus the previous period.</string>
+	<key>No matching apps</key>
+	<string>No matching apps</string>
 	<key>No shortcuts configured</key>
 	<string>No shortcuts configured</string>
 	<key>No shortcuts match your filter</key>
@@ -322,8 +324,12 @@
 	<string>Routes global shortcuts.</string>
 	<key>Running</key>
 	<string>Running</string>
+	<key>Search Palette</key>
+	<string>Search Palette</string>
 	<key>Search apps...</key>
 	<string>Search apps...</string>
+	<key>Search apps…</key>
+	<string>Search apps…</string>
 	<key>Search shortcuts</key>
 	<string>Search shortcuts</string>
 	<key>Settings…</key>
@@ -392,6 +398,8 @@
 	<string>Toggle Sidebar</string>
 	<key>Toggle apps with global shortcuts</key>
 	<string>Toggle apps with global shortcuts</string>
+	<key>Type an app name and press Return to switch to it.</key>
+	<string>Type an app name and press Return to switch to it.</string>
 	<key>Unresolved</key>
 	<string>Unresolved</string>
 	<key>Unresolved apps without conflicts will still be imported using their recipe app name and bundle identifier.</key>

--- a/Sources/Wink/Resources/Localized/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Wink/Resources/Localized/zh-Hans.lproj/Localizable.strings
@@ -250,6 +250,8 @@
 	<string>无变化</string>
 	<key>No change versus the previous period.</key>
 	<string>相较上一时段无变化。</string>
+	<key>No matching apps</key>
+	<string>没有匹配的应用</string>
 	<key>No shortcuts configured</key>
 	<string>尚未配置快捷键</string>
 	<key>No shortcuts match your filter</key>
@@ -326,8 +328,12 @@
 	<string>用于路由全局快捷键。</string>
 	<key>Running</key>
 	<string>运行中</string>
+	<key>Search Palette</key>
+	<string>搜索面板</string>
 	<key>Search apps...</key>
 	<string>搜索应用...</string>
+	<key>Search apps…</key>
+	<string>搜索应用…</string>
 	<key>Search shortcuts</key>
 	<string>搜索快捷键</string>
 	<key>Settings…</key>
@@ -396,6 +402,8 @@
 	<string>切换侧边栏</string>
 	<key>Toggle apps with global shortcuts</key>
 	<string>使用全局快捷键切换应用</string>
+	<key>Type an app name and press Return to switch to it.</key>
+	<string>输入应用名称，按下 Return 键即可切换到该应用。</string>
 	<key>Unresolved</key>
 	<string>未解析</string>
 	<key>Unresolved apps without conflicts will still be imported using their recipe app name and bundle identifier.</key>

--- a/Sources/Wink/Services/AppListProvider.swift
+++ b/Sources/Wink/Services/AppListProvider.swift
@@ -51,6 +51,14 @@ final class AppListProvider {
     private var lastScanTime: Date?
     private var allAppsByID: [String: AppEntry] = [:]
 
+    /// Fires whenever a scan (forced or `refreshIfNeeded`-triggered)
+    /// completes and `allApps` is updated. The #356 search palette uses this
+    /// to stay resilient to a trigger fired before the first scan lands:
+    /// if it's presented when this fires, it rebuilds its candidates and
+    /// re-renders instead of staying on a stale/empty snapshot until
+    /// dismiss/reopen.
+    var onRefreshCompleted: (@MainActor () -> Void)?
+
     var recentApps: [AppEntry] {
         recentBundleIDs.compactMap { allAppsByID[$0] }
     }
@@ -187,6 +195,7 @@ final class AppListProvider {
         loadRecents(from: runningApplications)
         isScanning = false
         refreshTask = nil
+        onRefreshCompleted?()
     }
 
     nonisolated private static func scanDirectory(_ dir: URL, into entries: inout [AppEntry], seen: inout Set<String>, depth: Int) {
@@ -199,9 +208,7 @@ final class AppListProvider {
                 if let bundle = Bundle(url: url),
                    let bid = bundle.bundleIdentifier,
                    !seen.contains(bid) {
-                    let name = (bundle.infoDictionary?["CFBundleName"] as? String)
-                        ?? (bundle.infoDictionary?["CFBundleDisplayName"] as? String)
-                        ?? url.deletingPathExtension().lastPathComponent
+                    let name = localizedAppName(for: bundle) ?? url.deletingPathExtension().lastPathComponent
                     entries.append(AppEntry(id: bid, name: name, url: url))
                     seen.insert(bid)
                 }
@@ -213,6 +220,24 @@ final class AppListProvider {
                 }
             }
         }
+    }
+
+    /// Prefers the bundle's LOCALIZED display name/name (reads the
+    /// `.lproj` `InfoPlist.strings` the app itself ships) over the base
+    /// `infoDictionary`'s development-language values — matters for the
+    /// #356 search palette's CJK containment claim: `bundle.infoDictionary`
+    /// alone would return an app's English name even under a zh-Hans system
+    /// language, so "微信" would never match WeChat by name for a zh-Hans
+    /// user. Also improves `AppPickerPopover`'s search, which reads the same
+    /// `AppListProvider.allApps` snapshot. Reads from the already-loaded
+    /// `Bundle` object (no extra filesystem walk beyond what `Bundle(url:)`
+    /// already performs), so this doesn't add a distinguishable scan-perf
+    /// cost.
+    nonisolated private static func localizedAppName(for bundle: Bundle) -> String? {
+        (bundle.localizedInfoDictionary?["CFBundleDisplayName"] as? String)
+            ?? (bundle.localizedInfoDictionary?["CFBundleName"] as? String)
+            ?? (bundle.infoDictionary?["CFBundleName"] as? String)
+            ?? (bundle.infoDictionary?["CFBundleDisplayName"] as? String)
     }
 
     // MARK: - Recents persistence

--- a/Sources/Wink/Services/AppSwitcher.swift
+++ b/Sources/Wink/Services/AppSwitcher.swift
@@ -799,8 +799,19 @@ final class AppSwitcher: AppSwitching {
         return message
     }
 
+    /// - Parameter bypassCooldown: skips ONLY the per-bundle cooldown gate
+    ///   below — the re-entry guard (`isToggling`) and everything downstream
+    ///   of it (confirmation/recovery pipeline) stay fully active either
+    ///   way. The cooldown is still STAMPED on a bypassed call (the `defer`
+    ///   block is unconditional), so a bypassed commit still protects the
+    ///   very next real shortcut press on the same bundle. Exists for the
+    ///   #356 search palette: a palette commit is a direct user choice ("I
+    ///   picked this app right now"), not a repeated key-chord press, so it
+    ///   must not be silently dropped just because a real shortcut recently
+    ///   toggled the same bundle — see `AppController`'s `activate` closure
+    ///   for the only caller that sets this `true`.
     @discardableResult
-    func toggleApplication(for requestedShortcut: AppShortcut) -> Bool {
+    func toggleApplication(for requestedShortcut: AppShortcut, bypassCooldown: Bool = false) -> Bool {
         let shortcut: AppShortcut
         // Keeps the exact frontmost process across the later
         // running-applications lookup: with multiple instances sharing a
@@ -842,7 +853,8 @@ final class AppSwitcher: AppSwitching {
         // chosen, so the Cycle relaxation needs its own cheap frontmost
         // pre-check here (workspace snapshot only — no AX on this path).
         let effectiveCooldown = effectiveToggleCooldown(for: shortcut)
-        if let lastTime = lastToggleTimeByBundle[shortcut.bundleIdentifier],
+        if !bypassCooldown,
+           let lastTime = lastToggleTimeByBundle[shortcut.bundleIdentifier],
            attemptStartedAt - lastTime < effectiveCooldown {
             let elapsed = Int((attemptStartedAt - lastTime) * 1000)
             DiagnosticLog.log("TOGGLE[\(shortcut.appName)]: BLOCKED cooldown elapsedMs=\(elapsed) limit=\(Int(effectiveCooldown * 1000))ms")

--- a/Sources/Wink/Services/SearchPaletteMatcher.swift
+++ b/Sources/Wink/Services/SearchPaletteMatcher.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// One row candidate for the #356 search-to-switch palette. Built once per
+/// palette open (`SearchPaletteCandidateBuilder.build`) from the already-warm
+/// `AppListProvider` snapshot, never per keystroke — the per-keystroke cost
+/// is only `SearchPaletteRanking.rank` scoring against this precomputed
+/// array, which is what keeps typing latency structurally bounded (see
+/// `SearchPaletteHUD.swift`).
+struct SearchPaletteCandidate: Identifiable, Equatable {
+    let entry: AppEntry
+    /// Lowercased once at build time so every keystroke's re-scoring never
+    /// repeats the same `.lowercased()` work across the whole app list.
+    let normalizedName: String
+    /// Display text for a bound, enabled, real-app shortcut targeting this
+    /// bundle (#356 constraint: "bound apps show their keycap"). `nil` when
+    /// no such shortcut exists.
+    let keycap: String?
+    let isRunning: Bool
+
+    var id: String { entry.bundleIdentifier }
+}
+
+enum SearchPaletteCandidateBuilder {
+    /// - Parameters:
+    ///   - apps: `AppListProvider.allApps` — installed + running, already
+    ///     the #356 scope (installed/running apps only, no window/file
+    ///     enumeration).
+    ///   - shortcuts: the full shortcut store; pseudo-targets (frontmost-app,
+    ///     the palette trigger itself) never contribute a keycap since they
+    ///     don't target a real app.
+    ///   - runningBundleIdentifiers: a workspace snapshot taken once at open
+    ///     time, not re-queried per keystroke.
+    static func build(
+        apps: [AppEntry],
+        shortcuts: [AppShortcut],
+        runningBundleIdentifiers: Set<String>
+    ) -> [SearchPaletteCandidate] {
+        var keycapByBundleIdentifier: [String: String] = [:]
+        for shortcut in shortcuts
+        where shortcut.isEnabled && !shortcut.isFrontmostAppTarget && !shortcut.isSearchPaletteTarget {
+            keycapByBundleIdentifier[shortcut.bundleIdentifier] = ModifierFormatting.displayText(
+                modifierFlags: shortcut.modifierFlags,
+                keyEquivalent: shortcut.keyEquivalent
+            )
+        }
+
+        return apps.map { entry in
+            SearchPaletteCandidate(
+                entry: entry,
+                normalizedName: entry.name.lowercased(),
+                keycap: keycapByBundleIdentifier[entry.bundleIdentifier],
+                isRunning: runningBundleIdentifiers.contains(entry.bundleIdentifier)
+            )
+        }
+    }
+}
+
+/// Tiered prefix/subsequence scoring — deliberately NOT a multi-layer
+/// edit-distance waterfall (#356 hard constraint: app names are a much
+/// cleaner corpus than the window titles AltTab's scorer handles). Four
+/// tiers, highest first: exact name match, prefix match, a later word's
+/// prefix match (e.g. "code" hitting "Visual Studio Code"), and general
+/// in-order subsequence match. A contiguous substring is a special case of
+/// "in order" — so `localizedName` containment (the IME note in the issue:
+/// v1 matches a fully-composed CJK app name via containment) falls out of
+/// the subsequence tier for free, with no separate containment check
+/// needed.
+enum SearchPaletteMatch {
+    private static let exactScore = 1_000
+    private static let prefixBaseScore = 900
+    private static let wordPrefixScore = 700
+    private static let subsequenceBaseScore = 500
+
+    /// - Parameters:
+    ///   - query: already trimmed; case folding happens here.
+    ///   - normalizedName: `SearchPaletteCandidate.normalizedName` (already
+    ///     lowercased, so this call does zero per-row lowercasing work).
+    /// - Returns: a score where higher ranks better, or `nil` for no match.
+    static func score(query: String, normalizedName: String) -> Int? {
+        guard !query.isEmpty else { return nil }
+        let normalizedQuery = query.lowercased()
+
+        if normalizedName == normalizedQuery {
+            return exactScore
+        }
+        if normalizedName.hasPrefix(normalizedQuery) {
+            // Shorter names score a touch higher for the same prefix (a more
+            // specific match), bounded so this tier can never cross into the
+            // exact-match score.
+            let extraLength = normalizedName.count - normalizedQuery.count
+            return prefixBaseScore - min(extraLength, 100)
+        }
+        if normalizedName.split(separator: " ").contains(where: { $0.hasPrefix(normalizedQuery) }) {
+            return wordPrefixScore
+        }
+        if let spread = subsequenceSpread(query: normalizedQuery, candidate: normalizedName) {
+            // Tighter, earlier matches score higher within the tier — a
+            // contiguous substring match (spread == matchedLength - 1) sits
+            // at the top of this tier.
+            return subsequenceBaseScore - min(spread, 400)
+        }
+        return nil
+    }
+
+    /// Whether every character of `query` appears in `candidate` in order
+    /// (not necessarily contiguous). Returns the index distance between the
+    /// first and last matched character — 0 means every matched character
+    /// was adjacent (a contiguous substring, the exact "localizedName
+    /// containment" case the issue's IME note calls out) — or `nil` when
+    /// `query` isn't a subsequence of `candidate` at all.
+    private static func subsequenceSpread(query: String, candidate: String) -> Int? {
+        guard !query.isEmpty else { return 0 }
+        var queryIndex = query.startIndex
+        var firstMatchedPosition: Int?
+        var lastMatchedPosition = 0
+
+        for (position, character) in candidate.enumerated() {
+            guard queryIndex < query.endIndex else { break }
+            if character == query[queryIndex] {
+                if firstMatchedPosition == nil {
+                    firstMatchedPosition = position
+                }
+                lastMatchedPosition = position
+                queryIndex = query.index(after: queryIndex)
+            }
+        }
+
+        guard queryIndex == query.endIndex, let firstMatchedPosition else {
+            return nil
+        }
+        return lastMatchedPosition - firstMatchedPosition
+    }
+}
+
+enum SearchPaletteRanking {
+    /// Bounds the palette's result list (also bounds its panel height —
+    /// #352's "bounded height" pattern, structurally rather than via a
+    /// scroll view since this cap makes an unbounded list impossible).
+    static let defaultLimit = 8
+
+    /// Scores every candidate, drops non-matches, and returns the top
+    /// `limit` sorted by score (descending) then localized name (ascending)
+    /// for a deterministic tie-break. An empty query returns no results —
+    /// the palette shows a small recents list for that case instead (see
+    /// `SearchPaletteHUD.swift`), not a scored ranking.
+    static func rank(
+        query: String,
+        candidates: [SearchPaletteCandidate],
+        limit: Int = defaultLimit
+    ) -> [SearchPaletteCandidate] {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else { return [] }
+
+        let scored: [(candidate: SearchPaletteCandidate, score: Int)] = candidates.compactMap { candidate in
+            guard let score = SearchPaletteMatch.score(query: trimmedQuery, normalizedName: candidate.normalizedName) else {
+                return nil
+            }
+            return (candidate, score)
+        }
+
+        return scored
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score {
+                    return lhs.score > rhs.score
+                }
+                return lhs.candidate.entry.name.localizedCaseInsensitiveCompare(rhs.candidate.entry.name) == .orderedAscending
+            }
+            .prefix(limit)
+            .map(\.candidate)
+    }
+}

--- a/Sources/Wink/Services/SearchPaletteMatcher.swift
+++ b/Sources/Wink/Services/SearchPaletteMatcher.swift
@@ -57,18 +57,27 @@ enum SearchPaletteCandidateBuilder {
 
 /// Tiered prefix/subsequence scoring — deliberately NOT a multi-layer
 /// edit-distance waterfall (#356 hard constraint: app names are a much
-/// cleaner corpus than the window titles AltTab's scorer handles). Four
+/// cleaner corpus than the window titles AltTab's scorer handles). Five
 /// tiers, highest first: exact name match, prefix match, a later word's
-/// prefix match (e.g. "code" hitting "Visual Studio Code"), and general
-/// in-order subsequence match. A contiguous substring is a special case of
-/// "in order" — so `localizedName` containment (the IME note in the issue:
-/// v1 matches a fully-composed CJK app name via containment) falls out of
-/// the subsequence tier for free, with no separate containment check
-/// needed.
+/// prefix match (e.g. "code" hitting "Visual Studio Code"), any contiguous
+/// substring match anywhere in the name (the IME note in the issue: v1
+/// matches a fully-composed CJK app name via `localizedName` containment),
+/// and general in-order subsequence match as the fallback tier. The
+/// contiguous-substring tier is explicit and separate from the subsequence
+/// one on purpose: the subsequence scan below is a cheap greedy
+/// leftmost-anchor match (not a tightest-window search — that would start
+/// creeping toward the edit-distance waterfall the issue rules out), so it
+/// can anchor an early, spread-out match instead of recognizing a genuine
+/// contiguous substring elsewhere in the name (e.g. query "ab" against "a
+/// fab" — greedily anchoring the standalone "a" produces a wider spread
+/// than the actual contiguous "ab" at the end). Checking `contains` first
+/// guarantees a real substring always outranks a non-contiguous subsequence
+/// match, regardless of what the greedy scan below would have produced.
 enum SearchPaletteMatch {
     private static let exactScore = 1_000
     private static let prefixBaseScore = 900
     private static let wordPrefixScore = 700
+    private static let containsScore = 600
     private static let subsequenceBaseScore = 500
 
     /// - Parameters:
@@ -93,21 +102,22 @@ enum SearchPaletteMatch {
         if normalizedName.split(separator: " ").contains(where: { $0.hasPrefix(normalizedQuery) }) {
             return wordPrefixScore
         }
+        if normalizedName.contains(normalizedQuery) {
+            return containsScore
+        }
         if let spread = subsequenceSpread(query: normalizedQuery, candidate: normalizedName) {
-            // Tighter, earlier matches score higher within the tier — a
-            // contiguous substring match (spread == matchedLength - 1) sits
-            // at the top of this tier.
+            // Tighter, earlier matches score higher within the tier.
             return subsequenceBaseScore - min(spread, 400)
         }
         return nil
     }
 
     /// Whether every character of `query` appears in `candidate` in order
-    /// (not necessarily contiguous). Returns the index distance between the
-    /// first and last matched character — 0 means every matched character
-    /// was adjacent (a contiguous substring, the exact "localizedName
-    /// containment" case the issue's IME note calls out) — or `nil` when
-    /// `query` isn't a subsequence of `candidate` at all.
+    /// (not necessarily contiguous) — the fallback tier once a contiguous
+    /// substring match (checked above, and always preferred) doesn't apply.
+    /// Returns the index distance between the first and last matched
+    /// character, or `nil` when `query` isn't a subsequence of `candidate`
+    /// at all.
     private static func subsequenceSpread(query: String, candidate: String) -> Int? {
         guard !query.isEmpty else { return 0 }
         var queryIndex = query.startIndex
@@ -167,5 +177,42 @@ enum SearchPaletteRanking {
             }
             .prefix(limit)
             .map(\.candidate)
+    }
+
+    /// Empty-query default (Spotlight/Alfred convention: "what can I switch
+    /// to right now"). Most recently activated running apps first, using
+    /// `AppListProvider.recentBundleIDs`; running apps with no recency
+    /// signal at all (never activated through Wink) fall back to
+    /// alphabetical order at the tail. Never includes non-running apps —
+    /// an empty query with nothing typed yet shouldn't suggest launching
+    /// something.
+    static func recentRunning(
+        candidates: [SearchPaletteCandidate],
+        recentBundleIdentifiers: [String],
+        limit: Int = defaultLimit
+    ) -> [SearchPaletteCandidate] {
+        let running = candidates.filter(\.isRunning)
+        guard !running.isEmpty else { return [] }
+
+        let runningByBundleIdentifier = Dictionary(
+            running.map { ($0.entry.bundleIdentifier, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        var ordered: [SearchPaletteCandidate] = []
+        var seenBundleIdentifiers = Set<String>()
+        for bundleIdentifier in recentBundleIdentifiers {
+            guard let candidate = runningByBundleIdentifier[bundleIdentifier],
+                  !seenBundleIdentifiers.contains(bundleIdentifier) else { continue }
+            ordered.append(candidate)
+            seenBundleIdentifiers.insert(bundleIdentifier)
+        }
+
+        let remaining = running
+            .filter { !seenBundleIdentifiers.contains($0.entry.bundleIdentifier) }
+            .sorted { $0.entry.name.localizedCaseInsensitiveCompare($1.entry.name) == .orderedAscending }
+        ordered.append(contentsOf: remaining)
+
+        return Array(ordered.prefix(limit))
     }
 }

--- a/Sources/Wink/Services/ShortcutEditorState.swift
+++ b/Sources/Wink/Services/ShortcutEditorState.swift
@@ -83,6 +83,11 @@ final class ShortcutEditorState {
     var recordedSearchPaletteShortcut: RecordedShortcut?
     var isRecordingSearchPaletteShortcut: Bool = false
     var searchPaletteConflictMessage: String?
+    /// Palette-scoped mirror of `saveErrorMessage` — the General tab's card
+    /// shows this instead of the shared property so a persistence failure
+    /// there is never confused with (or masked by) one that happened on the
+    /// Shortcuts tab, and vice versa.
+    var searchPaletteSaveErrorMessage: String?
     var recipeFeedback: RecipeFeedback?
     var pendingRecipeImport: WinkRecipeImportPlanner.ImportPlan?
     var usageCounts: [UUID: Int] = [:]
@@ -188,9 +193,18 @@ final class ShortcutEditorState {
         } else {
             updated.append(candidate)
         }
-        guard persist(updated) else { return }
+        // persist() sets the shared saveErrorMessage either way; mirror it
+        // into the palette-scoped copy so the General tab's card shows its
+        // own failure instead of a stale/unrelated message that happened to
+        // land on the Shortcuts tab.
+        guard persist(updated) else {
+            searchPaletteSaveErrorMessage = saveErrorMessage
+            recordedSearchPaletteShortcut = nil
+            return
+        }
         onShortcutConfigurationChange()
         searchPaletteConflictMessage = nil
+        searchPaletteSaveErrorMessage = nil
         recordedSearchPaletteShortcut = nil
     }
 
@@ -199,19 +213,20 @@ final class ShortcutEditorState {
               shortcuts[index].isEnabled != enabled else { return }
         var updated = shortcuts
         updated[index].isEnabled = enabled
-        guard persist(updated) else { return }
+        guard persist(updated) else {
+            searchPaletteSaveErrorMessage = saveErrorMessage
+            return
+        }
         onShortcutConfigurationChange()
+        searchPaletteSaveErrorMessage = nil
     }
 
     func removeSearchPaletteShortcut() {
         guard let id = searchPaletteShortcut?.id else { return }
         removeShortcut(id: id)
-    }
-
-    func clearRecordedSearchPaletteShortcut() {
-        recordedSearchPaletteShortcut = nil
-        isRecordingSearchPaletteShortcut = false
-        searchPaletteConflictMessage = nil
+        // removeShortcut(id:) is shared with the per-app list and calls
+        // persist() itself; mirror its outcome the same way as above.
+        searchPaletteSaveErrorMessage = saveErrorMessage
     }
 
     func removeShortcut(id: UUID) {

--- a/Sources/Wink/Services/ShortcutEditorState.swift
+++ b/Sources/Wink/Services/ShortcutEditorState.swift
@@ -76,6 +76,13 @@ final class ShortcutEditorState {
     var isRecordingShortcut: Bool = false
     var conflictMessage: String?
     var saveErrorMessage: String?
+    /// Recording state for the #356 search-palette trigger's dedicated
+    /// recorder (General tab) — kept separate from `recordedShortcut` /
+    /// `isRecordingShortcut` above so recording one control never clobbers
+    /// an in-progress draft in the other.
+    var recordedSearchPaletteShortcut: RecordedShortcut?
+    var isRecordingSearchPaletteShortcut: Bool = false
+    var searchPaletteConflictMessage: String?
     var recipeFeedback: RecipeFeedback?
     var pendingRecipeImport: WinkRecipeImportPlanner.ImportPlan?
     var usageCounts: [UUID: Int] = [:]
@@ -133,10 +140,7 @@ final class ShortcutEditorState {
         )
 
         if let conflict = shortcutValidator.conflict(for: candidate, in: shortcuts) {
-            conflictMessage = String(
-                localized: "Conflict: \(conflict.existingShortcut.displayAppName) already uses \(conflict.existingShortcut.modifierFlags.joined(separator: "+"))+\(conflict.existingShortcut.keyEquivalent.uppercased())",
-                bundle: WinkResourceBundle.bundle
-            )
+            conflictMessage = conflictMessageText(for: conflict)
             return
         }
 
@@ -147,6 +151,67 @@ final class ShortcutEditorState {
         conflictMessage = nil
         resetDraft()
         Task { await refreshUsageCounts() }
+    }
+
+    /// The #356 search-palette trigger, if one is currently recorded. Not
+    /// rendered in the per-app "Your Shortcuts" list (it targets no app) —
+    /// see `ShortcutsTabView`'s `visibleShortcuts` filter — but it lives in
+    /// the same `shortcuts` array so `ShortcutValidator` and the trigger
+    /// index treat it exactly like any other binding for conflict detection
+    /// and dispatch.
+    var searchPaletteShortcut: AppShortcut? {
+        shortcuts.first(where: \.isSearchPaletteTarget)
+    }
+
+    /// Records (or re-records) the search-palette trigger. Reuses the
+    /// candidate's existing id on a re-record so this replaces the binding
+    /// in place instead of accumulating duplicate rows.
+    func commitSearchPaletteShortcut(_ recorded: RecordedShortcut) {
+        let candidate = AppShortcut(
+            id: searchPaletteShortcut?.id ?? UUID(),
+            appName: AppShortcut.searchPaletteTargetStableName,
+            bundleIdentifier: AppShortcut.searchPaletteTargetSentinelBundleIdentifier,
+            keyEquivalent: recorded.keyEquivalent,
+            modifierFlags: recorded.modifierFlags,
+            target: .searchPalette
+        )
+
+        if let conflict = shortcutValidator.conflict(for: candidate, in: shortcuts) {
+            searchPaletteConflictMessage = conflictMessageText(for: conflict)
+            recordedSearchPaletteShortcut = nil
+            return
+        }
+
+        var updated = shortcuts
+        if let index = updated.firstIndex(where: { $0.id == candidate.id }) {
+            updated[index] = candidate
+        } else {
+            updated.append(candidate)
+        }
+        guard persist(updated) else { return }
+        onShortcutConfigurationChange()
+        searchPaletteConflictMessage = nil
+        recordedSearchPaletteShortcut = nil
+    }
+
+    func setSearchPaletteEnabled(_ enabled: Bool) {
+        guard let index = shortcuts.firstIndex(where: \.isSearchPaletteTarget),
+              shortcuts[index].isEnabled != enabled else { return }
+        var updated = shortcuts
+        updated[index].isEnabled = enabled
+        guard persist(updated) else { return }
+        onShortcutConfigurationChange()
+    }
+
+    func removeSearchPaletteShortcut() {
+        guard let id = searchPaletteShortcut?.id else { return }
+        removeShortcut(id: id)
+    }
+
+    func clearRecordedSearchPaletteShortcut() {
+        recordedSearchPaletteShortcut = nil
+        isRecordingSearchPaletteShortcut = false
+        searchPaletteConflictMessage = nil
     }
 
     func removeShortcut(id: UUID) {
@@ -262,8 +327,16 @@ final class ShortcutEditorState {
         isRecordingShortcut = false
     }
 
+    /// Recipes are a portable set of app bindings to share with others — the
+    /// search-palette trigger is a local device preference (like Hyper Key
+    /// enablement or the frontmost-exceptions list), not an app binding, so
+    /// it never travels in an exported `.winkrecipe`.
+    private var exportableShortcuts: [AppShortcut] {
+        shortcuts.filter { !$0.isSearchPaletteTarget }
+    }
+
     func exportRecipeData() throws -> Data {
-        try recipeCodec.encode(shortcuts: shortcuts)
+        try recipeCodec.encode(shortcuts: exportableShortcuts)
     }
 
     func exportRecipes() {
@@ -278,7 +351,7 @@ final class ShortcutEditorState {
 
             recipeFeedback = .success(
                 String(
-                    localized: "Exported \(shortcuts.count) shortcuts to \(url.lastPathComponent)",
+                    localized: "Exported \(exportableShortcuts.count) shortcuts to \(url.lastPathComponent)",
                     bundle: WinkResourceBundle.bundle
                 )
             )
@@ -373,6 +446,17 @@ final class ShortcutEditorState {
         guard generation == usageRefreshGeneration else { return }
         usageCounts = fetchedCounts
         lastUsed = fetchedLastUsed
+    }
+
+    /// Shared by the per-app composer and the search-palette recorder —
+    /// same wording either way, and `displayAppName` already resolves a
+    /// pseudo-target's sentinel bundle (e.g. a colliding search-palette
+    /// trigger) to its localized label.
+    private func conflictMessageText(for conflict: ShortcutConflict) -> String {
+        String(
+            localized: "Conflict: \(conflict.existingShortcut.displayAppName) already uses \(conflict.existingShortcut.modifierFlags.joined(separator: "+"))+\(conflict.existingShortcut.keyEquivalent.uppercased())",
+            bundle: WinkResourceBundle.bundle
+        )
     }
 
     /// Saves through the manager (disk first, then in-memory store). On

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -75,6 +75,12 @@ final class ShortcutManager {
     /// threshold. The consumer (AppController) owns what a hold action does;
     /// the manager only resolves the gesture and the matched shortcut.
     var onHoldActionTriggered: (@MainActor (AppShortcut) -> Void)?
+    /// Fires when the #356 search-palette trigger shortcut matches a plain
+    /// (non-hold) key-down — its sentinel bundle names no real app, so
+    /// `handleKeyPress` routes it here instead of `trigger(_:)`/
+    /// `AppSwitcher.toggleApplication`. The consumer (AppController) owns
+    /// presenting the palette.
+    var onSearchPaletteTriggered: (@MainActor () -> Void)?
     private var holdGestureArbiter: HoldGestureArbiter?
     /// True while an interactive Wink panel (the hold-to-show window picker)
     /// is key. Matched shortcut dispatch is gated on it instead of the full
@@ -594,11 +600,13 @@ final class ShortcutManager {
         var availableBundleIdentifiers = Set<String>()
 
         for shortcut in shortcutStore.shortcuts where shortcut.isEnabled {
-            // Frontmost-app pseudo-targets have no app URL by design (their
-            // sentinel bundle names no installed app) and are always
-            // available: skipping the locator check here is what makes
-            // them register with Carbon and enter the trigger index.
+            // Frontmost-app pseudo-targets and the search-palette trigger
+            // have no app URL by design (their sentinel bundles name no
+            // installed app) and are always available: skipping the locator
+            // check here is what makes them register with Carbon and enter
+            // the trigger index.
             guard shortcut.isFrontmostAppTarget
+                    || shortcut.isSearchPaletteTarget
                     || appBundleLocator.applicationURL(for: shortcut.bundleIdentifier) != nil else {
                 continue
             }
@@ -639,7 +647,14 @@ final class ShortcutManager {
         logger.info("MATCHED: \(match.appName) - \(match.bundleIdentifier)")
         diagnosticClient.log("MATCHED: \(match.appName) - \(match.bundleIdentifier)")
         diagnosticClient.log(matchedShortcutTraceMessage(for: match))
-        _ = trigger(match)
+        if match.isSearchPaletteTarget {
+            // No real app to toggle — and no usage row to record, since this
+            // shortcut's id is never a real per-app binding a user can see
+            // usage for. AppController owns presentation.
+            onSearchPaletteTriggered?()
+        } else {
+            _ = trigger(match)
+        }
         return true
     }
 

--- a/Sources/Wink/Services/WinkRecipeImportPlanner.swift
+++ b/Sources/Wink/Services/WinkRecipeImportPlanner.swift
@@ -122,6 +122,16 @@ struct WinkRecipeImportPlanner {
         var entries: [ImportEntry] = []
 
         for shortcut in recipe.shortcuts {
+            // The #356 search-palette trigger is a local device preference,
+            // never a portable app binding — ShortcutEditorState.exportRecipeData
+            // already excludes it on export, and it must never come back in
+            // on import either (hand-edited recipe, or a future schema): it
+            // targets no app, so every list in this app hides it, and a
+            // second hidden global chord would be undeletable through any
+            // UI. Skip it before planning so it never appears as ready,
+            // conflicting, or unresolved.
+            guard shortcut.shortcutTarget != .searchPalette else { continue }
+
             let planned = plannedShortcut(for: shortcut, installedApps: installedApps)
             let candidate = planned.makeAppShortcut()
             let conflict = shortcutValidator.conflict(

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -31,7 +31,7 @@ struct GeneralTabView: View {
 
                 keyboardCard(importPreviewActive: importPreviewActive)
 
-                searchPaletteCard
+                searchPaletteCard(importPreviewActive: importPreviewActive)
 
                 WinkCard(
                     title: {
@@ -300,8 +300,11 @@ struct GeneralTabView: View {
     /// than a row in the per-app Shortcuts list — it targets no app, so it
     /// doesn't belong in the app picker. The Permissions card immediately
     /// below already surfaces degraded-capture state for every shortcut,
-    /// this one included, so no separate banner is needed here.
-    private var searchPaletteCard: some View {
+    /// this one included, so no separate banner is needed here. Disabled
+    /// during an active import preview, same as `keyboardCard`'s controls —
+    /// recording a chord mid-preview would silently invalidate an already
+    /// "ready" plan entry by the time the user applies it.
+    private func searchPaletteCard(importPreviewActive: Bool) -> some View {
         WinkCard(
             title: {
                 Text("Search Palette", bundle: WinkResourceBundle.bundle)
@@ -316,9 +319,16 @@ struct GeneralTabView: View {
 
                     searchPaletteAccessory
                         .frame(width: 200, alignment: .trailing)
+                        .disabled(importPreviewActive)
                 }
 
                 if let message = editor.searchPaletteConflictMessage {
+                    Text(message)
+                        .font(WinkType.labelSmall)
+                        .foregroundStyle(palette.red)
+                }
+
+                if let message = editor.searchPaletteSaveErrorMessage {
                     Text(message)
                         .font(WinkType.labelSmall)
                         .foregroundStyle(palette.red)

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -31,6 +31,8 @@ struct GeneralTabView: View {
 
                 keyboardCard(importPreviewActive: importPreviewActive)
 
+                searchPaletteCard
+
                 WinkCard(
                     title: {
                         Text("Permissions", bundle: WinkResourceBundle.bundle)
@@ -289,6 +291,95 @@ struct GeneralTabView: View {
                     }
                     .padding(.leading, 2)
                 }
+            }
+        }
+    }
+
+    /// The #356 search-to-switch palette's own settings surface: off by
+    /// default (no shortcut recorded), one dedicated recorder here rather
+    /// than a row in the per-app Shortcuts list — it targets no app, so it
+    /// doesn't belong in the app picker. The Permissions card immediately
+    /// below already surfaces degraded-capture state for every shortcut,
+    /// this one included, so no separate banner is needed here.
+    private var searchPaletteCard: some View {
+        WinkCard(
+            title: {
+                Text("Search Palette", bundle: WinkResourceBundle.bundle)
+            }
+        ) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 12) {
+                    Text("Type an app name and press Return to switch to it.", bundle: WinkResourceBundle.bundle)
+                        .font(WinkType.labelSmall)
+                        .foregroundStyle(palette.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    searchPaletteAccessory
+                        .frame(width: 200, alignment: .trailing)
+                }
+
+                if let message = editor.searchPaletteConflictMessage {
+                    Text(message)
+                        .font(WinkType.labelSmall)
+                        .foregroundStyle(palette.red)
+                }
+            }
+            .padding(14)
+        }
+    }
+
+    @ViewBuilder
+    private var searchPaletteAccessory: some View {
+        if let shortcut = editor.searchPaletteShortcut {
+            HStack(spacing: 8) {
+                if shortcut.isHyper {
+                    WinkHyperBadge()
+                }
+
+                Text(shortcut.displayText)
+                    .font(WinkType.monoBadge)
+                    .tracking(0.5)
+                    .foregroundStyle(palette.textPrimary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(palette.controlBgRest)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .stroke(palette.controlBorder, lineWidth: 0.5)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
+
+                WinkSwitch(isOn: Binding(
+                    get: { shortcut.isEnabled },
+                    set: { editor.setSearchPaletteEnabled($0) }
+                ), size: .small)
+
+                Button {
+                    editor.removeSearchPaletteShortcut()
+                } label: {
+                    WinkIcon.close.image(size: 9)
+                        .foregroundStyle(palette.textTertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "Delete Shortcut", bundle: WinkResourceBundle.bundle))
+            }
+        } else if editor.isRecordingSearchPaletteShortcut {
+            ShortcutRecorderView(
+                recordedShortcut: Binding(
+                    get: { editor.recordedSearchPaletteShortcut },
+                    set: { newValue in
+                        editor.recordedSearchPaletteShortcut = newValue
+                        if let newValue {
+                            editor.commitSearchPaletteShortcut(newValue)
+                        }
+                    }
+                ),
+                isRecording: $editor.isRecordingSearchPaletteShortcut
+            )
+            .frame(height: 28)
+        } else {
+            ShortcutRecorderIdleField(recordedShortcut: nil) {
+                editor.isRecordingSearchPaletteShortcut = true
             }
         }
     }

--- a/Sources/Wink/UI/InsightsViewModel.swift
+++ b/Sources/Wink/UI/InsightsViewModel.swift
@@ -194,6 +194,12 @@ final class InsightsViewModel {
         self.heatmapBuckets = snapshot.heatmapBuckets
         self.unusedShortcutNames = shortcuts
             .filter(\.isEnabled)
+            // The #356 search-palette trigger never records per-shortcut
+            // usage (see ShortcutManager.handleKeyPress — it dispatches
+            // through onSearchPaletteTriggered, not trigger(_:)), so it
+            // would otherwise always read as zero-count and get nudged for
+            // removal even when the user opens the palette constantly.
+            .filter { !$0.isSearchPaletteTarget }
             .filter { (snapshot.unusedCounts[$0.id] ?? 0) == 0 }
             .map(\.displayAppName)
 

--- a/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
+++ b/Sources/Wink/UI/MenuBar/MenuBarPopoverView.swift
@@ -157,7 +157,12 @@ final class MenuBarPopoverModel {
     }
 
     func refresh() {
-        let shortcuts = shortcutStore.shortcuts
+        // The #356 search-palette trigger targets no app — like
+        // `ShortcutsTabView`'s per-app list, this quick-launch status list
+        // excludes it rather than showing it permanently flagged "App
+        // unavailable" (its sentinel bundle never resolves to an installed
+        // app or a running process).
+        let shortcuts = shortcutStore.shortcuts.filter { !$0.isSearchPaletteTarget }
         shortcutStatusProvider.track(shortcuts)
         shortcutRows = shortcuts.map { shortcut in
             let status = shortcutStatusProvider.status(for: shortcut)

--- a/Sources/Wink/UI/SearchPaletteHUD.swift
+++ b/Sources/Wink/UI/SearchPaletteHUD.swift
@@ -1,0 +1,256 @@
+import AppKit
+import SwiftUI
+
+/// Search-palette-specific panel (#356): same key-capable base as the
+/// window picker, but with no `keyDown` override of its own — unlike the
+/// picker, this panel hosts a real `TextField`. Keyboard routing goes
+/// through SwiftUI's `.onKeyPress`/`.onSubmit` + `@FocusState` (the same
+/// pattern `AppPickerPopover` already uses) once the focused field editor
+/// has key status, rather than a window-level event intercept.
+final class SearchPalettePanel: KeyCapableHUDPanel {}
+
+/// Global "type an app name, press Enter, that app activates" palette
+/// (#356). Reuses the #352 panel scaffolding (`KeyCapableHUDPanel`,
+/// `HUDPanelPlacement`) and the exact "activate, never hide" seam
+/// `AppController` wires through `activate` — see that closure's call site
+/// for why a plain `toggleApplication` call would be wrong here.
+@MainActor
+final class SearchPaletteHUDController {
+    private let onSessionStateChange: @MainActor (Bool) -> Void
+    /// Snapshot-at-open candidate builder — never called per keystroke. See
+    /// `SearchPaletteMatcher.swift` for the latency rationale.
+    private let candidatesProvider: @MainActor () -> [SearchPaletteCandidate]
+    private let activate: @MainActor (AppEntry) -> Bool
+
+    private var panel: SearchPalettePanel?
+    private var hosting: NSHostingView<SearchPaletteView>?
+    private var resignKeyObserver: NSObjectProtocol?
+    private var isActive = false
+
+    init(
+        onSessionStateChange: @escaping @MainActor (Bool) -> Void,
+        candidatesProvider: @escaping @MainActor () -> [SearchPaletteCandidate],
+        activate: @escaping @MainActor (AppEntry) -> Bool
+    ) {
+        self.onSessionStateChange = onSessionStateChange
+        self.candidatesProvider = candidatesProvider
+        self.activate = activate
+    }
+
+    var isPresented: Bool { isActive }
+
+    func present() {
+        guard !isActive else { return }
+        isActive = true
+        onSessionStateChange(true)
+
+        let candidates = candidatesProvider()
+        let panel = ensurePanel()
+        render(candidates: candidates)
+        HUDPanelPlacement.centerOnPointerScreen(panel)
+        panel.makeKeyAndOrderFront(nil)
+
+        resignKeyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: panel,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.dismiss()
+            }
+        }
+    }
+
+    func dismiss() {
+        guard isActive else { return }
+        if let resignKeyObserver {
+            NotificationCenter.default.removeObserver(resignKeyObserver)
+            self.resignKeyObserver = nil
+        }
+        isActive = false
+        panel?.orderOut(nil)
+        onSessionStateChange(false)
+    }
+
+    private func commit(_ entry: AppEntry) {
+        // Dismiss FIRST — activation makes another app key, which fires the
+        // resign-key observer; running the dismissal ourselves keeps the
+        // session-state transition ordered before the activation side
+        // effect (same ordering rule as WindowPickerHUDController).
+        dismiss()
+        _ = activate(entry)
+    }
+
+    private func ensurePanel() -> SearchPalettePanel {
+        if let panel {
+            return panel
+        }
+        let panel = SearchPalettePanel()
+        self.panel = panel
+        return panel
+    }
+
+    private func render(candidates: [SearchPaletteCandidate]) {
+        guard let panel else { return }
+        let view = SearchPaletteView(
+            candidates: candidates,
+            onCommit: { [weak self] entry in
+                self?.commit(entry)
+            },
+            onCancel: { [weak self] in
+                self?.dismiss()
+            }
+        )
+        if let hosting {
+            hosting.rootView = view
+        } else {
+            let hosting = NSHostingView(rootView: view)
+            self.hosting = hosting
+            panel.contentView = hosting
+        }
+        hosting?.layoutSubtreeIfNeeded()
+        let size = hosting?.fittingSize ?? .zero
+        panel.setContentSize(size)
+    }
+}
+
+private enum SearchPaletteMetrics {
+    static let width: CGFloat = 420
+    static let maxResultsHeight: CGFloat = 320
+    static let rowIconSize: CGFloat = 22
+}
+
+private struct SearchPaletteView: View {
+    let candidates: [SearchPaletteCandidate]
+    let onCommit: (AppEntry) -> Void
+    let onCancel: () -> Void
+
+    @State private var query = ""
+    @State private var highlight = AppPickerHighlightState()
+    @FocusState private var isFieldFocused: Bool
+
+    /// Empty query shows the most recent apps up front (Spotlight/Alfred
+    /// convention) — cheap since `AppListProvider` already tracks recency;
+    /// a non-empty query runs the tiered scorer. Either way this recomputes
+    /// per keystroke against the already-built `candidates` array, never
+    /// re-scanning the app list itself (see `SearchPaletteMatcher.swift`).
+    private var results: [SearchPaletteCandidate] {
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return Array(candidates.filter(\.isRunning).prefix(SearchPaletteRanking.defaultLimit))
+        }
+        return SearchPaletteRanking.rank(query: query, candidates: candidates)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                WinkIcon.search.image(size: 13)
+                    .foregroundStyle(.secondary)
+                TextField(Self.placeholder, text: $query)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 16))
+                    .focused($isFieldFocused)
+                    .onSubmit { commitHighlighted() }
+                    .onChange(of: query) { _, _ in
+                        highlight.searchTextChanged()
+                    }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+
+            if !results.isEmpty {
+                Divider()
+                ScrollViewReader { proxy in
+                    ScrollView(.vertical, showsIndicators: false) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            ForEach(Array(results.enumerated()), id: \.element.id) { index, candidate in
+                                SearchPaletteRow(
+                                    candidate: candidate,
+                                    isHighlighted: highlight.highlightedIndex == index
+                                )
+                                .contentShape(Rectangle())
+                                .onTapGesture { onCommit(candidate.entry) }
+                                .id(index)
+                            }
+                        }
+                        .padding(8)
+                    }
+                    .frame(maxHeight: SearchPaletteMetrics.maxResultsHeight)
+                    .onChange(of: highlight.highlightedIndex) { _, newIndex in
+                        guard let newIndex else { return }
+                        proxy.scrollTo(newIndex)
+                    }
+                }
+            } else if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Divider()
+                Text(Self.noResultsText)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .padding(14)
+            }
+        }
+        .frame(width: SearchPaletteMetrics.width)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .onAppear {
+            highlight.reset()
+            isFieldFocused = true
+        }
+        .onKeyPress(.upArrow) { move(-1); return .handled }
+        .onKeyPress(.downArrow) { move(1); return .handled }
+        .onKeyPress(.escape) { onCancel(); return .handled }
+    }
+
+    private func move(_ delta: Int) {
+        _ = highlight.move(delta, count: results.count)
+    }
+
+    private func commitHighlighted() {
+        guard let entry = highlight.selection(in: results)?.entry else { return }
+        onCommit(entry)
+    }
+
+    private static var placeholder: String {
+        String(localized: "Search apps…", bundle: WinkResourceBundle.bundle)
+    }
+
+    private static var noResultsText: String {
+        String(localized: "No matching apps", bundle: WinkResourceBundle.bundle)
+    }
+}
+
+private struct SearchPaletteRow: View {
+    @Environment(\.winkPalette) private var palette
+
+    let candidate: SearchPaletteCandidate
+    let isHighlighted: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            AppIconView(bundleIdentifier: candidate.entry.bundleIdentifier, size: SearchPaletteMetrics.rowIconSize)
+
+            Text(candidate.entry.name)
+                .font(.system(size: 13))
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            if candidate.isRunning {
+                WinkStatusDot(color: palette.green)
+            }
+
+            Spacer(minLength: 8)
+
+            if let keycap = candidate.keycap {
+                Text(keycap)
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(isHighlighted ? Color.accentColor.opacity(0.25) : .clear)
+        )
+    }
+}

--- a/Sources/Wink/UI/SearchPaletteHUD.swift
+++ b/Sources/Wink/UI/SearchPaletteHUD.swift
@@ -14,26 +14,58 @@ final class SearchPalettePanel: KeyCapableHUDPanel {}
 /// `HUDPanelPlacement`) and the exact "activate, never hide" seam
 /// `AppController` wires through `activate` — see that closure's call site
 /// for why a plain `toggleApplication` call would be wrong here.
+///
+/// State (query, highlight) lives HERE, on the controller — not as `@State`
+/// inside `SearchPaletteView` — mirroring `WindowPickerHUDController`
+/// exactly: every mutation goes through `renderContent()`, which rebuilds
+/// the view, reassigns `hosting.rootView`, and re-measures/resizes the
+/// panel via `layoutSubtreeIfNeeded()` + `fittingSize`. That's what keeps
+/// the panel's height in sync as the result count changes per keystroke —
+/// sizing once at `present()` and never again would clip a query that grows
+/// from one row to eight. View-driven mutations (typing, arrow keys) are
+/// funneled back through this controller via closures and dispatched with
+/// `DispatchQueue.main.async` before touching `hosting.rootView`, since
+/// reassigning it synchronously from inside a SwiftUI-owned callback (a
+/// `Binding` setter, `.onKeyPress`) would mutate the same hosting view
+/// while SwiftUI is still mid-update for that same view.
 @MainActor
 final class SearchPaletteHUDController {
     private let onSessionStateChange: @MainActor (Bool) -> Void
     /// Snapshot-at-open candidate builder — never called per keystroke. See
     /// `SearchPaletteMatcher.swift` for the latency rationale.
     private let candidatesProvider: @MainActor () -> [SearchPaletteCandidate]
+    /// Most-recently-activated bundle identifiers, most recent first —
+    /// orders the empty-query list; recency only, never re-scored. `nil`
+    /// resolves to `[]` in the body (not a closure-literal default
+    /// argument): the CI toolchain (Xcode 16.4, Swift 6.1.2) has twice
+    /// crashed SILGen on non-trivial init default-argument expressions —
+    /// same mitigation as `WindowCycleClient.live`/`ShortcutManager`'s
+    /// `secureInputProbe`.
+    private let recentBundleIdentifiersProvider: (@MainActor () -> [String])?
     private let activate: @MainActor (AppEntry) -> Bool
 
-    private var panel: SearchPalettePanel?
+    /// Internal (not private) read access only — `private(set)` — so tests
+    /// can assert on the panel's structural size (e.g. "grew as results
+    /// grew") without opening up write access from outside the controller.
+    private(set) var panel: SearchPalettePanel?
     private var hosting: NSHostingView<SearchPaletteView>?
     private var resignKeyObserver: NSObjectProtocol?
     private var isActive = false
 
+    private var candidates: [SearchPaletteCandidate] = []
+    private var recentBundleIdentifiers: [String] = []
+    private var query = ""
+    private var highlight = AppPickerHighlightState()
+
     init(
         onSessionStateChange: @escaping @MainActor (Bool) -> Void,
         candidatesProvider: @escaping @MainActor () -> [SearchPaletteCandidate],
+        recentBundleIdentifiersProvider: (@MainActor () -> [String])? = nil,
         activate: @escaping @MainActor (AppEntry) -> Bool
     ) {
         self.onSessionStateChange = onSessionStateChange
         self.candidatesProvider = candidatesProvider
+        self.recentBundleIdentifiersProvider = recentBundleIdentifiersProvider
         self.activate = activate
     }
 
@@ -44,9 +76,13 @@ final class SearchPaletteHUDController {
         isActive = true
         onSessionStateChange(true)
 
-        let candidates = candidatesProvider()
+        candidates = candidatesProvider()
+        recentBundleIdentifiers = resolveRecentBundleIdentifiers()
+        query = ""
+        highlight.reset()
+
         let panel = ensurePanel()
-        render(candidates: candidates)
+        renderContent()
         HUDPanelPlacement.centerOnPointerScreen(panel)
         panel.makeKeyAndOrderFront(nil)
 
@@ -61,6 +97,21 @@ final class SearchPaletteHUDController {
         }
     }
 
+    /// A trigger fired before `AppListProvider`'s first scan lands would
+    /// otherwise open onto an empty (or installed-apps-only) snapshot that
+    /// stays empty until dismiss/reopen. `AppController` calls this once the
+    /// scan completes; a no-op while the palette isn't presented.
+    func refreshCandidatesIfPresented() {
+        guard isActive else { return }
+        candidates = candidatesProvider()
+        recentBundleIdentifiers = resolveRecentBundleIdentifiers()
+        renderContent()
+    }
+
+    private func resolveRecentBundleIdentifiers() -> [String] {
+        recentBundleIdentifiersProvider?() ?? []
+    }
+
     func dismiss() {
         guard isActive else { return }
         if let resignKeyObserver {
@@ -70,6 +121,36 @@ final class SearchPaletteHUDController {
         isActive = false
         panel?.orderOut(nil)
         onSessionStateChange(false)
+    }
+
+    /// Empty query shows the most recently activated running apps first
+    /// (Spotlight/Alfred convention), alphabetical as the tail/fallback for
+    /// running apps with no recency signal; a non-empty query runs the
+    /// tiered scorer. Either way this recomputes against the already-built
+    /// `candidates` array, never re-scanning the app list itself (see
+    /// `SearchPaletteMatcher.swift`, which owns both ranking functions).
+    private var results: [SearchPaletteCandidate] {
+        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return SearchPaletteRanking.recentRunning(candidates: candidates, recentBundleIdentifiers: recentBundleIdentifiers)
+        }
+        return SearchPaletteRanking.rank(query: query, candidates: candidates)
+    }
+
+    private func handleQueryChange(_ newQuery: String) {
+        guard query != newQuery else { return }
+        query = newQuery
+        highlight.searchTextChanged()
+        scheduleRender()
+    }
+
+    private func moveHighlight(_ delta: Int) {
+        _ = highlight.move(delta, count: results.count)
+        scheduleRender()
+    }
+
+    private func commitHighlighted() {
+        guard let entry = highlight.selection(in: results)?.entry else { return }
+        commit(entry)
     }
 
     private func commit(_ entry: AppEntry) {
@@ -90,11 +171,36 @@ final class SearchPaletteHUDController {
         return panel
     }
 
-    private func render(candidates: [SearchPaletteCandidate]) {
-        guard let panel else { return }
+    /// Defers the actual re-render/resize to the next run-loop turn: this
+    /// is called from closures SwiftUI itself invokes (a `TextField`
+    /// binding's setter, `.onKeyPress`), and reassigning `hosting.rootView`
+    /// synchronously from inside one of those would mutate the same hosting
+    /// view while SwiftUI is still mid-update for it. One tick is
+    /// imperceptible; `present()`/`refreshCandidatesIfPresented()` call
+    /// `renderContent()` directly since they run from plain AppKit call
+    /// sites, outside any SwiftUI update.
+    private func scheduleRender() {
+        DispatchQueue.main.async { [weak self] in
+            self?.renderContent()
+        }
+    }
+
+    private func renderContent() {
+        guard isActive, let panel else { return }
         let view = SearchPaletteView(
-            candidates: candidates,
-            onCommit: { [weak self] entry in
+            query: query,
+            results: results,
+            highlightedIndex: highlight.highlightedIndex,
+            onQueryChange: { [weak self] newQuery in
+                self?.handleQueryChange(newQuery)
+            },
+            onMoveHighlight: { [weak self] delta in
+                self?.moveHighlight(delta)
+            },
+            onCommitHighlighted: { [weak self] in
+                self?.commitHighlighted()
+            },
+            onCommitEntry: { [weak self] entry in
                 self?.commit(entry)
             },
             onCancel: { [weak self] in
@@ -121,24 +227,19 @@ private enum SearchPaletteMetrics {
 }
 
 private struct SearchPaletteView: View {
-    let candidates: [SearchPaletteCandidate]
-    let onCommit: (AppEntry) -> Void
+    let query: String
+    let results: [SearchPaletteCandidate]
+    let highlightedIndex: Int?
+    let onQueryChange: (String) -> Void
+    let onMoveHighlight: (Int) -> Void
+    let onCommitHighlighted: () -> Void
+    let onCommitEntry: (AppEntry) -> Void
     let onCancel: () -> Void
 
-    @State private var query = ""
-    @State private var highlight = AppPickerHighlightState()
     @FocusState private var isFieldFocused: Bool
 
-    /// Empty query shows the most recent apps up front (Spotlight/Alfred
-    /// convention) — cheap since `AppListProvider` already tracks recency;
-    /// a non-empty query runs the tiered scorer. Either way this recomputes
-    /// per keystroke against the already-built `candidates` array, never
-    /// re-scanning the app list itself (see `SearchPaletteMatcher.swift`).
-    private var results: [SearchPaletteCandidate] {
-        guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return Array(candidates.filter(\.isRunning).prefix(SearchPaletteRanking.defaultLimit))
-        }
-        return SearchPaletteRanking.rank(query: query, candidates: candidates)
+    private var queryBinding: Binding<String> {
+        Binding(get: { query }, set: { newQuery in onQueryChange(newQuery) })
     }
 
     var body: some View {
@@ -146,14 +247,11 @@ private struct SearchPaletteView: View {
             HStack(spacing: 8) {
                 WinkIcon.search.image(size: 13)
                     .foregroundStyle(.secondary)
-                TextField(Self.placeholder, text: $query)
+                TextField(Self.placeholder, text: queryBinding)
                     .textFieldStyle(.plain)
                     .font(.system(size: 16))
                     .focused($isFieldFocused)
-                    .onSubmit { commitHighlighted() }
-                    .onChange(of: query) { _, _ in
-                        highlight.searchTextChanged()
-                    }
+                    .onSubmit { onCommitHighlighted() }
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
@@ -166,17 +264,17 @@ private struct SearchPaletteView: View {
                             ForEach(Array(results.enumerated()), id: \.element.id) { index, candidate in
                                 SearchPaletteRow(
                                     candidate: candidate,
-                                    isHighlighted: highlight.highlightedIndex == index
+                                    isHighlighted: highlightedIndex == index
                                 )
                                 .contentShape(Rectangle())
-                                .onTapGesture { onCommit(candidate.entry) }
+                                .onTapGesture { onCommitEntry(candidate.entry) }
                                 .id(index)
                             }
                         }
                         .padding(8)
                     }
                     .frame(maxHeight: SearchPaletteMetrics.maxResultsHeight)
-                    .onChange(of: highlight.highlightedIndex) { _, newIndex in
+                    .onChange(of: highlightedIndex) { _, newIndex in
                         guard let newIndex else { return }
                         proxy.scrollTo(newIndex)
                     }
@@ -192,21 +290,11 @@ private struct SearchPaletteView: View {
         .frame(width: SearchPaletteMetrics.width)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         .onAppear {
-            highlight.reset()
             isFieldFocused = true
         }
-        .onKeyPress(.upArrow) { move(-1); return .handled }
-        .onKeyPress(.downArrow) { move(1); return .handled }
+        .onKeyPress(.upArrow) { onMoveHighlight(-1); return .handled }
+        .onKeyPress(.downArrow) { onMoveHighlight(1); return .handled }
         .onKeyPress(.escape) { onCancel(); return .handled }
-    }
-
-    private func move(_ delta: Int) {
-        _ = highlight.move(delta, count: results.count)
-    }
-
-    private func commitHighlighted() {
-        guard let entry = highlight.selection(in: results)?.entry else { return }
-        onCommit(entry)
     }
 
     private static var placeholder: String {

--- a/Sources/Wink/UI/SharedComponents.swift
+++ b/Sources/Wink/UI/SharedComponents.swift
@@ -75,6 +75,10 @@ struct AppIconView: View {
             icon = Self.frontmostTargetIcon
             return
         }
+        if bundleIdentifier == AppShortcut.searchPaletteTargetSentinelBundleIdentifier {
+            icon = Self.searchPaletteTargetIcon
+            return
+        }
         icon = AppIconCache.icon(for: bundleIdentifier) ?? Self.fallbackIcon
     }
 
@@ -84,6 +88,16 @@ struct AppIconView: View {
         return NSImage(
             systemSymbolName: "macwindow.on.rectangle",
             accessibilityDescription: AppShortcut.frontmostTargetDisplayName
+        )?.withSymbolConfiguration(configuration) ?? fallbackIcon
+    }()
+    // Same sentinel-icon treatment as `frontmostTargetIcon`, wherever the
+    // #356 trigger shortcut's own row renders (the General tab card, and the
+    // Hyper cheat sheet if the trigger is bound to a Hyper combo).
+    private static let searchPaletteTargetIcon: NSImage = {
+        let configuration = NSImage.SymbolConfiguration(pointSize: 22, weight: .medium)
+        return NSImage(
+            systemSymbolName: "magnifyingglass",
+            accessibilityDescription: AppShortcut.searchPaletteTargetDisplayName
         )?.withSymbolConfiguration(configuration) ?? fallbackIcon
     }()
 }

--- a/Sources/Wink/UI/ShortcutsTabView.swift
+++ b/Sources/Wink/UI/ShortcutsTabView.swift
@@ -304,13 +304,21 @@ struct ShortcutsTabView: View {
     @State private var dragStartSourceFrame: CGRect?
     @State private var dragTranslationY: CGFloat = 0
 
+    /// The #356 search-palette trigger targets no app — it lives in
+    /// `editor.shortcuts` for conflict validation and dispatch, but has its
+    /// own recorder in the General tab and never appears in this per-app
+    /// list (its sentinel bundle would otherwise render a broken icon row).
+    private var visibleShortcuts: [AppShortcut] {
+        editor.shortcuts.filter { !$0.isSearchPaletteTarget }
+    }
+
     private var filteredShortcuts: [AppShortcut] {
         let query = filterText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !query.isEmpty else {
-            return editor.shortcuts
+            return visibleShortcuts
         }
 
-        return editor.shortcuts.filter { shortcut in
+        return visibleShortcuts.filter { shortcut in
             shortcut.displayAppName.localizedCaseInsensitiveContains(query)
                 || shortcut.displayText.localizedCaseInsensitiveContains(query)
         }
@@ -482,10 +490,10 @@ struct ShortcutsTabView: View {
         .background(palette.windowBg)
         .onAppear {
             accessibilityOptions = .current
-            shortcutStatusProvider.track(editor.shortcuts)
+            shortcutStatusProvider.track(visibleShortcuts)
         }
-        .onChange(of: editor.shortcuts) { _, newShortcuts in
-            shortcutStatusProvider.track(newShortcuts)
+        .onChange(of: editor.shortcuts) { _, _ in
+            shortcutStatusProvider.track(visibleShortcuts)
         }
         .onReceive(
             NSWorkspace.shared.notificationCenter.publisher(
@@ -535,7 +543,7 @@ struct ShortcutsTabView: View {
 
         WinkCard(
             title: {
-                Text("Your Shortcuts · \(editor.shortcuts.count)", bundle: WinkResourceBundle.bundle)
+                Text("Your Shortcuts · \(visibleShortcuts.count)", bundle: WinkResourceBundle.bundle)
             },
             accessory: {
                 HStack(spacing: 6) {
@@ -558,7 +566,7 @@ struct ShortcutsTabView: View {
                         Button(String(localized: "Export…", bundle: WinkResourceBundle.bundle)) {
                             editor.exportRecipes()
                         }
-                        .disabled(editor.shortcuts.isEmpty)
+                        .disabled(visibleShortcuts.isEmpty)
                     } label: {
                         WinkIcon.more.image(size: 12)
                             .foregroundStyle(palette.textSecondary)

--- a/Sources/Wink/UI/WindowPickerHUD.swift
+++ b/Sources/Wink/UI/WindowPickerHUD.swift
@@ -1,16 +1,61 @@
 import AppKit
 import SwiftUI
 
-/// Key-capable, non-activating panel (#352): `.nonactivatingPanel` keeps
-/// Wink from activating when the panel fronts, while the explicit
-/// `canBecomeKey` override (borderless panels are never key by default)
-/// lets it receive arrow/Enter/Escape directly. This is the TilesPanel
-/// pattern — deliberately NOT WhatsNewPanel, whose `.titled` mask only
-/// avoids stealing focus at order-front time.
-final class WindowPickerPanel: NSPanel {
-    var onKeyDown: ((NSEvent) -> Bool)?
-
+/// Shared base for Wink's key-capable, non-activating HUD panels (#352's
+/// window picker, #356's search palette): `.nonactivatingPanel` keeps Wink
+/// from activating when the panel fronts, while the explicit `canBecomeKey`
+/// override (borderless panels are never key by default) lets the panel
+/// receive keyboard input directly — discrete arrow/Enter/Escape routing for
+/// the window picker, real text input via the field editor for the search
+/// palette (a focused `TextField` needs key status to get the field editor
+/// at all). This is the TilesPanel pattern — deliberately NOT WhatsNewPanel,
+/// whose `.titled` mask only avoids stealing focus at order-front time.
+class KeyCapableHUDPanel: NSPanel {
     override var canBecomeKey: Bool { true }
+
+    init() {
+        super.init(
+            contentRect: .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        isFloatingPanel = true
+        level = .popUpMenu
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = true
+        ignoresMouseEvents = false
+        hidesOnDeactivate = false
+        collectionBehavior = [.canJoinAllSpaces, .transient, .fullScreenAuxiliary]
+    }
+}
+
+/// Anchors a HUD panel centered on the screen holding the pointer — these
+/// panels follow the user's attention, not a target window. Shared by the
+/// window picker (#352) and the search palette (#356); the panel must
+/// already be sized (`setContentSize`/`setFrame`) before calling this.
+@MainActor
+enum HUDPanelPlacement {
+    static func centerOnPointerScreen(_ panel: NSPanel) {
+        let mouse = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(mouse) }
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        guard let screenFrame = screen?.visibleFrame else { return }
+        let size = panel.frame.size
+        panel.setFrameOrigin(NSPoint(
+            x: screenFrame.midX - size.width / 2,
+            y: screenFrame.midY - size.height / 2
+        ))
+    }
+}
+
+/// Window-picker-specific panel: same key-capable base as above, plus the
+/// discrete `keyDown` routing the picker's arrow/Enter/Escape handling
+/// needs (there's no focused text field here to dispatch through).
+final class WindowPickerPanel: KeyCapableHUDPanel {
+    var onKeyDown: ((NSEvent) -> Bool)?
 
     override func keyDown(with event: NSEvent) {
         if onKeyDown?(event) != true {
@@ -53,7 +98,7 @@ final class WindowPickerHUDController {
 
         let panel = ensurePanel()
         renderContent()
-        anchorToPointerScreen(panel)
+        HUDPanelPlacement.centerOnPointerScreen(panel)
         panel.makeKeyAndOrderFront(nil)
 
         resignKeyObserver = NotificationCenter.default.addObserver(
@@ -125,20 +170,7 @@ final class WindowPickerHUDController {
         if let panel {
             return panel
         }
-        let panel = WindowPickerPanel(
-            contentRect: .zero,
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: true
-        )
-        panel.isFloatingPanel = true
-        panel.level = .popUpMenu
-        panel.backgroundColor = .clear
-        panel.isOpaque = false
-        panel.hasShadow = true
-        panel.ignoresMouseEvents = false
-        panel.hidesOnDeactivate = false
-        panel.collectionBehavior = [.canJoinAllSpaces, .transient, .fullScreenAuxiliary]
+        let panel = WindowPickerPanel()
         panel.onKeyDown = { [weak self] event in
             MainActor.assumeIsolated {
                 self?.handleKeyDown(event) ?? false
@@ -167,21 +199,6 @@ final class WindowPickerHUDController {
         hosting?.layoutSubtreeIfNeeded()
         let size = hosting?.fittingSize ?? .zero
         panel.setContentSize(size)
-    }
-
-    /// Same anchoring rule as the cheat sheet: the pointer's screen, since
-    /// the picker follows the user's attention, not the target window.
-    private func anchorToPointerScreen(_ panel: NSPanel) {
-        let mouse = NSEvent.mouseLocation
-        let screen = NSScreen.screens.first { $0.frame.contains(mouse) }
-            ?? NSScreen.main
-            ?? NSScreen.screens.first
-        guard let screenFrame = screen?.visibleFrame else { return }
-        let size = panel.frame.size
-        panel.setFrameOrigin(NSPoint(
-            x: screenFrame.midX - size.width / 2,
-            y: screenFrame.midY - size.height / 2
-        ))
     }
 }
 

--- a/Tests/WinkTests/AppPreferencesTests.swift
+++ b/Tests/WinkTests/AppPreferencesTests.swift
@@ -726,7 +726,7 @@ private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
 @MainActor
 private struct FakeAppSwitcher: AppSwitching {
     @discardableResult
-    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
         true
     }
 }
@@ -736,7 +736,7 @@ private final class RecordingAppSwitcher: AppSwitching {
     private(set) var lastBehavior: FrontmostTargetBehavior?
 
     @discardableResult
-    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
         true
     }
 

--- a/Tests/WinkTests/AppSwitcherTests.swift
+++ b/Tests/WinkTests/AppSwitcherTests.swift
@@ -2335,6 +2335,66 @@ func cooldownBlocksBeforeNewGenerationIsAllocated() {
     #expect(switcher.pendingActivationState?.generation == generationAfterFirst)
 }
 
+/// #356 regression: hide an app via its real shortcut, then commit the same
+/// app from the search palette within the 400ms cooldown window — a very
+/// feasible sequence (open the palette, type, Enter). A plain call would be
+/// silently dropped after the palette already dismissed, leaving the app
+/// hidden with no feedback. `bypassCooldown: true` must get past the gate
+/// that blocks it, while a same-window REAL press still gets blocked (the
+/// existing guarantee for real shortcut presses is untouched), and the
+/// bypassed call still stamps the cooldown so it protects the very next
+/// real press.
+@Test @MainActor
+func bypassCooldownLetsAPaletteCommitThroughWhileARealPressInTheSameWindowStaysBlocked() {
+    let clock = MutableClock(time: 1000.0)
+    let coordinator = ToggleSessionCoordinator(now: { clock.time })
+    let launchCompletions = LockedValue<[@Sendable (NSRunningApplication?, Error?) -> Void]>([])
+    let switcher = AppSwitcher(
+        frontmostTracker: makeTrackerForAppSwitcherTests(),
+        fallbackActivationClient: .init(openApplication: { _, _, completion in
+            launchCompletions.value.append(completion)
+        }),
+        appLookupClient: .init(
+            runningApplications: { _ in [] },
+            applicationURL: { _ in URL(fileURLWithPath: "/Applications/PaletteCooldown.app") }
+        ),
+        confirmationClient: .init(now: { clock.time }, schedule: { _, _ in }),
+        sessionCoordinator: coordinator
+    )
+    let shortcut = AppShortcut(
+        appName: "PaletteCooldown",
+        bundleIdentifier: "com.test.PaletteCooldown",
+        keyEquivalent: "p",
+        modifierFlags: ["command"]
+    )
+
+    // A real shortcut press hides/toggles the app and stamps the cooldown.
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    let firstGeneration = coordinator.session(for: shortcut.bundleIdentifier)?.generation
+    #expect(launchCompletions.value.count == 1)
+
+    // Well within the 400ms window: a plain second press is still dropped —
+    // this guarantee for real shortcut presses is unchanged by the bypass.
+    clock.time += 0.2
+    #expect(switcher.toggleApplication(for: shortcut) == false)
+    #expect(coordinator.session(for: shortcut.bundleIdentifier)?.generation == firstGeneration)
+    #expect(launchCompletions.value.count == 1)
+
+    // The search palette's commit, in the exact same window, must not be
+    // dropped.
+    #expect(switcher.toggleApplication(for: shortcut, bypassCooldown: true) == true)
+    let bypassGeneration = coordinator.session(for: shortcut.bundleIdentifier)?.generation
+    #expect(bypassGeneration != firstGeneration)
+    #expect(launchCompletions.value.count == 2)
+
+    // The bypassed call still stamped the cooldown: an immediately-following
+    // real press is blocked, protecting the app from a stray repeat right
+    // after the palette commit.
+    #expect(switcher.toggleApplication(for: shortcut) == false)
+    #expect(coordinator.session(for: shortcut.bundleIdentifier)?.generation == bypassGeneration)
+    #expect(launchCompletions.value.count == 2)
+}
+
 @Test @MainActor
 func hideToggleLogsStructuredMetricFields() {
     let switcher = AppSwitcher(

--- a/Tests/WinkTests/InsightsViewModelTests.swift
+++ b/Tests/WinkTests/InsightsViewModelTests.swift
@@ -135,6 +135,66 @@ actor TimeZoneAlignedUsageTracker: UsageTracking {
     }
 }
 
+/// Reports nonzero usage for exactly one shortcut id, zero (absent) for
+/// every other — enough to distinguish "genuinely unused" from "excluded
+/// from the nudge entirely" in `unusedShortcutNudgeExcludesTheSearchPaletteTrigger`.
+private actor SingleShortcutUsageTracker: UsageTracking {
+    let usedShortcutId: UUID
+
+    init(usedShortcutId: UUID) {
+        self.usedShortcutId = usedShortcutId
+    }
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] { [] }
+    func deleteUsage(shortcutId: UUID) {}
+    func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] { [usedShortcutId: 5] }
+    func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] { [:] }
+    func totalSwitches(days: Int, relativeTo now: Date) async -> Int { 5 }
+    func hourlyCounts(days: Int, relativeTo now: Date) async -> [HourlyUsageBucket] { [] }
+    func previousPeriodTotal(days: Int, relativeTo now: Date) async -> Int { 0 }
+    func streakDays(relativeTo now: Date) async -> Int { 0 }
+    func usageTimeZone() async -> TimeZone { .current }
+}
+
+/// #356: the search-palette trigger never records per-shortcut usage (its
+/// key match dispatches through `onSearchPaletteTriggered`, not
+/// `ShortcutManager.trigger(_:)`), so without an explicit exclusion it would
+/// always read as zero-count and get nudged for removal — even a trigger the
+/// user presses constantly. A genuinely unused real app shortcut (IINA)
+/// stays in the nudge; the trigger never appears in it at all.
+@Test @MainActor
+func unusedShortcutNudgeExcludesTheSearchPaletteTrigger() async {
+    let safari = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "s",
+        modifierFlags: ["command"]
+    )
+    let iina = AppShortcut(
+        appName: "IINA",
+        bundleIdentifier: "com.colliderli.iina",
+        keyEquivalent: "i",
+        modifierFlags: ["command", "option"]
+    )
+    let paletteTrigger = AppShortcut(
+        appName: AppShortcut.searchPaletteTargetStableName,
+        bundleIdentifier: AppShortcut.searchPaletteTargetSentinelBundleIdentifier,
+        keyEquivalent: "space",
+        modifierFlags: ["command", "option"],
+        target: .searchPalette
+    )
+    let store = ShortcutStore()
+    store.replaceAll(with: [safari, iina, paletteTrigger])
+
+    let viewModel = InsightsViewModel(
+        usageTracker: SingleShortcutUsageTracker(usedShortcutId: safari.id),
+        shortcutStore: store
+    )
+    await viewModel.refresh(for: .week)
+
+    #expect(viewModel.unusedShortcutNames == ["IINA"])
+}
+
 @Test @MainActor
 func latestPeriodWinsWhenRefreshesOverlap() async {
     let shortcutId = UUID()

--- a/Tests/WinkTests/LaunchAtLoginPresentationTests.swift
+++ b/Tests/WinkTests/LaunchAtLoginPresentationTests.swift
@@ -179,7 +179,7 @@ private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
 @MainActor
 private struct FakeAppSwitcher: AppSwitching {
     @discardableResult
-    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
         true
     }
 }

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -1157,7 +1157,7 @@ private final class SettingsViewLayoutContext {
 @MainActor
 private struct LayoutFakeAppSwitcher: AppSwitching {
     @discardableResult
-    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
         true
     }
 }

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -200,9 +200,18 @@ struct LayoutRegressionTests {
         let context = SettingsViewLayoutContext()
         defer { context.harness.cleanup() }
 
+        // Height raised from the original 620 to fit the #356 search-palette
+        // card added below keyboardCard: LazyVStack only fully, individually
+        // lays out rows within (or very near) the fixed test viewport when
+        // there is no live scroll gesture driving it, so a viewport shorter
+        // than the (now taller) General tab's total content collapses
+        // keyboardCard's own subviews into unresolved placeholder frames
+        // instead of its real ~138pt height. The row-density assertion below
+        // is unchanged and still targets keyboardCard specifically —
+        // widening the viewport doesn't relax it.
         let hostingView = makeHostingView(
             GeneralTabView(preferences: context.preferences, editor: context.editor),
-            size: NSSize(width: 700, height: 620)
+            size: NSSize(width: 700, height: 900)
         )
 
         let candidateCardHeights = hostingView.subviews

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverSearchTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverSearchTests.swift
@@ -231,7 +231,7 @@ private final class SearchFakeHyperCaptureProvider: HyperShortcutCaptureProvider
 
 private struct SearchFakeAppSwitcher: AppSwitching {
     @MainActor
-    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
         true
     }
 }

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
@@ -496,7 +496,7 @@ private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
 @MainActor
 private struct FakeAppSwitcher: AppSwitching {
     @discardableResult
-    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
         true
     }
 }

--- a/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
+++ b/Tests/WinkTests/MenuBar/MenuBarPopoverViewTests.swift
@@ -6,6 +6,36 @@ import Testing
 
 @Suite("Menu bar popover")
 struct MenuBarPopoverViewTests {
+    /// #356: the search-palette trigger's sentinel bundle never resolves to
+    /// an installed app or a running process, so an unfiltered status list
+    /// would permanently flag it "App unavailable" even though it's working
+    /// exactly as configured — this quick-launch list excludes it entirely,
+    /// same as `ShortcutsTabView`'s per-app list.
+    @Test @MainActor
+    func shortcutRowsExcludeTheSearchPaletteTrigger() {
+        let context = makePopoverContext(
+            shortcuts: [
+                AppShortcut(
+                    appName: "Safari",
+                    bundleIdentifier: "com.apple.Safari",
+                    keyEquivalent: "s",
+                    modifierFlags: ["command"]
+                ),
+                AppShortcut(
+                    appName: AppShortcut.searchPaletteTargetStableName,
+                    bundleIdentifier: AppShortcut.searchPaletteTargetSentinelBundleIdentifier,
+                    keyEquivalent: "space",
+                    modifierFlags: ["command", "option"],
+                    target: .searchPalette
+                ),
+            ],
+            usageTotal: 0
+        )
+
+        #expect(context.model.shortcutRows.count == 1)
+        #expect(context.model.shortcutRows.first?.shortcut.bundleIdentifier == "com.apple.Safari")
+    }
+
     @Test @MainActor
     func viewRendersSearchSectionsRowsAndActions() async {
         let context = makePopoverContext(

--- a/Tests/WinkTests/PauseAllShortcutsTests.swift
+++ b/Tests/WinkTests/PauseAllShortcutsTests.swift
@@ -176,7 +176,7 @@ private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
 @MainActor
 private struct FakeAppSwitcher: AppSwitching {
     @discardableResult
-    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
         true
     }
 }

--- a/Tests/WinkTests/PerShortcutBehaviorOverrideTests.swift
+++ b/Tests/WinkTests/PerShortcutBehaviorOverrideTests.swift
@@ -137,6 +137,36 @@ import Testing
     #expect(lenient.target == nil)
 }
 
+// MARK: - Search-palette trigger target (#356)
+
+@Test func searchPaletteTargetRoundTripsAndDecodesLeniently() throws {
+    let shortcut = AppShortcut(
+        appName: AppShortcut.searchPaletteTargetStableName,
+        bundleIdentifier: AppShortcut.searchPaletteTargetSentinelBundleIdentifier,
+        keyEquivalent: "space",
+        modifierFlags: ["command", "option"],
+        target: .searchPalette
+    )
+    let decoded = try JSONDecoder().decode(AppShortcut.self, from: JSONEncoder().encode(shortcut))
+    #expect(decoded.target == .searchPalette)
+    #expect(decoded.isSearchPaletteTarget)
+    #expect(!decoded.isFrontmostAppTarget)
+
+    // A build that predates `.searchPalette` (or any hand-edited/future
+    // rawValue) decodes leniently to nil — same guarantee the frontmost
+    // pseudo-target already relies on, exercised here against this specific
+    // sentinel bundle so a regression in either target's leniency shows up
+    // independently.
+    let json = """
+    {"id":"22222222-2222-2222-2222-222222222222","appName":"Search Palette",
+     "bundleIdentifier":"wink.target.search-palette","keyEquivalent":"space",
+     "modifierFlags":["command","option"],"isEnabled":true,"target":"someFutureTarget"}
+    """
+    let lenient = try JSONDecoder().decode(AppShortcut.self, from: Data(json.utf8))
+    #expect(lenient.target == nil)
+    #expect(!lenient.isSearchPaletteTarget)
+}
+
 @Test func recipeWithFrontmostTargetExportsAsV2AndPlansAvailable() throws {
     let codec = WinkRecipeCodec()
     let pseudo = AppShortcut(

--- a/Tests/WinkTests/SearchPaletteDispatchTests.swift
+++ b/Tests/WinkTests/SearchPaletteDispatchTests.swift
@@ -1,0 +1,222 @@
+import Carbon.HIToolbox
+import Foundation
+import Testing
+@testable import Wink
+
+// MARK: - Local fakes (mirrors the ShortcutManagerStatusTests harness shape,
+// kept file-local per this suite's established per-file-fakes convention)
+
+@MainActor
+private final class FakeCaptureProvider: ShortcutCaptureProvider {
+    var isRunning = false
+    var inputMonitoringRequired = false
+    private(set) var registeredShortcuts: Set<KeyPress> = []
+    private var onKeyPress: (@MainActor @Sendable (KeyPress) -> Void)?
+
+    var registrationState: ShortcutCaptureRegistrationState {
+        ShortcutCaptureRegistrationState(
+            desiredShortcutCount: registeredShortcuts.count,
+            registeredShortcutCount: registeredShortcuts.count,
+            failures: []
+        )
+    }
+
+    func start(onKeyPress: @escaping @MainActor @Sendable (KeyPress) -> Void) {
+        self.onKeyPress = onKeyPress
+        isRunning = true
+    }
+
+    func stop() {
+        isRunning = false
+        onKeyPress = nil
+    }
+
+    func updateRegisteredShortcuts(_ keyPresses: Set<KeyPress>) {
+        registeredShortcuts = keyPresses
+    }
+
+    func emit(_ keyPress: KeyPress) {
+        onKeyPress?(keyPress)
+    }
+}
+
+@MainActor
+private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
+    var isRunning = false
+    private var onKeyPress: (@MainActor @Sendable (KeyPress) -> Void)?
+
+    var registrationState: ShortcutCaptureRegistrationState {
+        ShortcutCaptureRegistrationState(desiredShortcutCount: 0, registeredShortcutCount: 0, failures: [])
+    }
+
+    func start(onKeyPress: @escaping @MainActor @Sendable (KeyPress) -> Void) {
+        self.onKeyPress = onKeyPress
+    }
+
+    func stop() {
+        onKeyPress = nil
+    }
+
+    func updateRegisteredShortcuts(_ keyPresses: Set<KeyPress>) {}
+    func setHyperKeyEnabled(_ enabled: Bool) {}
+}
+
+private struct FakePermissionService: PermissionServicing {
+    func isTrusted() -> Bool { true }
+    func isAccessibilityTrusted() -> Bool { true }
+    func isInputMonitoringTrusted() -> Bool { true }
+    @discardableResult
+    func requestIfNeeded(prompt: Bool, inputMonitoringRequired: Bool) -> Bool { true }
+}
+
+/// Records every `toggleApplication` call so dispatch tests can assert the
+/// search-palette match never reaches `AppSwitcher` (it has no real app to
+/// toggle — see `ShortcutManager.handleKeyPress`).
+@MainActor
+private final class RecordingAppSwitcher: AppSwitching {
+    private(set) var toggledBundleIdentifiers: [String] = []
+
+    @discardableResult
+    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+        toggledBundleIdentifiers.append(shortcut.bundleIdentifier)
+        return true
+    }
+}
+
+private func searchPaletteTriggerShortcut() -> AppShortcut {
+    AppShortcut(
+        appName: AppShortcut.searchPaletteTargetStableName,
+        bundleIdentifier: AppShortcut.searchPaletteTargetSentinelBundleIdentifier,
+        keyEquivalent: "space",
+        modifierFlags: ["command", "option"],
+        target: .searchPalette
+    )
+}
+
+private func searchPaletteTriggerKeyPress() -> KeyPress {
+    KeyPress(keyCode: UInt16(kVK_Space), modifiers: [.command, .option])
+}
+
+private func realAppShortcut() -> AppShortcut {
+    AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "s",
+        modifierFlags: ["command", "shift"]
+    )
+}
+
+private func realAppShortcutKeyPress() -> KeyPress {
+    KeyPress(keyCode: UInt16(kVK_ANSI_S), modifiers: [.command, .shift])
+}
+
+@MainActor
+private func makeContext(
+    shortcuts: [AppShortcut]
+) -> (manager: ShortcutManager, appSwitcher: RecordingAppSwitcher, standardProvider: FakeCaptureProvider) {
+    let shortcutStore = ShortcutStore()
+    shortcutStore.replaceAll(with: shortcuts)
+    let standardProvider = FakeCaptureProvider()
+    let appSwitcher = RecordingAppSwitcher()
+    let manager = ShortcutManager(
+        shortcutStore: shortcutStore,
+        persistenceService: TestPersistenceHarness().makePersistenceService(),
+        appSwitcher: appSwitcher,
+        captureCoordinator: ShortcutCaptureCoordinator(
+            standardProvider: standardProvider,
+            hyperProvider: FakeHyperCaptureProvider()
+        ),
+        permissionService: FakePermissionService(),
+        appBundleLocator: TestAppBundleLocator(entries: [
+            "com.apple.Safari": URL(fileURLWithPath: "/Applications/Safari.app"),
+        ]).locator,
+        diagnosticClient: .init(log: { _ in })
+    )
+    manager.start()
+    return (manager, appSwitcher, standardProvider)
+}
+
+// MARK: - Dispatch branch
+
+@Test @MainActor
+func searchPaletteTriggerFiresTheDedicatedCallbackInsteadOfTogglingAnApp() throws {
+    let context = makeContext(shortcuts: [searchPaletteTriggerShortcut()])
+    var firedCount = 0
+    context.manager.onSearchPaletteTriggered = {
+        firedCount += 1
+    }
+
+    context.standardProvider.emit(searchPaletteTriggerKeyPress())
+
+    #expect(firedCount == 1)
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+}
+
+@Test @MainActor
+func realAppShortcutsStillDispatchThroughAppSwitcherAndNeverFireThePaletteCallback() throws {
+    let context = makeContext(shortcuts: [realAppShortcut()])
+    var firedCount = 0
+    context.manager.onSearchPaletteTriggered = {
+        firedCount += 1
+    }
+
+    context.standardProvider.emit(realAppShortcutKeyPress())
+
+    #expect(firedCount == 0)
+    #expect(context.appSwitcher.toggledBundleIdentifiers == ["com.apple.Safari"])
+}
+
+@Test @MainActor
+func searchPaletteTriggerRegistersWithoutAnInstalledAppLikeTheFrontmostPseudoTarget() throws {
+    let context = makeContext(shortcuts: [searchPaletteTriggerShortcut()])
+    #expect(context.standardProvider.registeredShortcuts == [searchPaletteTriggerKeyPress()])
+}
+
+// MARK: - Session-gate interplay (#352's shared interactivePanelSessionActive)
+
+@Test @MainActor
+func searchPaletteTriggerIsSwallowedWhileAnInteractivePanelSessionIsActive() throws {
+    let context = makeContext(shortcuts: [searchPaletteTriggerShortcut()])
+    var firedCount = 0
+    context.manager.onSearchPaletteTriggered = {
+        firedCount += 1
+    }
+
+    // Simulates the window picker being open (#352's gate — AppController
+    // wires WindowPickerHUDController's onSessionStateChange the same way).
+    context.manager.setInteractivePanelSessionActive(true)
+    context.standardProvider.emit(searchPaletteTriggerKeyPress())
+
+    #expect(firedCount == 0)
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+}
+
+@Test @MainActor
+func regularShortcutDispatchIsSwallowedWhileTheSearchPaletteItselfIsTheActiveSession() throws {
+    let context = makeContext(shortcuts: [realAppShortcut()])
+
+    // Simulates AppController's searchPaletteHUD.onSessionStateChange firing
+    // true while the palette is key — proves the mutual exclusion holds in
+    // both directions through the one shared flag.
+    context.manager.setInteractivePanelSessionActive(true)
+    context.standardProvider.emit(realAppShortcutKeyPress())
+
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+}
+
+@Test @MainActor
+func dispatchResumesOnceTheInteractivePanelSessionEnds() throws {
+    let context = makeContext(shortcuts: [searchPaletteTriggerShortcut()])
+    var firedCount = 0
+    context.manager.onSearchPaletteTriggered = {
+        firedCount += 1
+    }
+
+    context.manager.setInteractivePanelSessionActive(true)
+    context.standardProvider.emit(searchPaletteTriggerKeyPress())
+    #expect(firedCount == 0)
+
+    context.manager.setInteractivePanelSessionActive(false)
+    context.standardProvider.emit(searchPaletteTriggerKeyPress())
+    #expect(firedCount == 1)
+}

--- a/Tests/WinkTests/SearchPaletteDispatchTests.swift
+++ b/Tests/WinkTests/SearchPaletteDispatchTests.swift
@@ -75,10 +75,12 @@ private struct FakePermissionService: PermissionServicing {
 @MainActor
 private final class RecordingAppSwitcher: AppSwitching {
     private(set) var toggledBundleIdentifiers: [String] = []
+    private(set) var bypassCooldownFlags: [Bool] = []
 
     @discardableResult
-    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
         toggledBundleIdentifiers.append(shortcut.bundleIdentifier)
+        bypassCooldownFlags.append(bypassCooldown)
         return true
     }
 }

--- a/Tests/WinkTests/SearchPaletteHUDTests.swift
+++ b/Tests/WinkTests/SearchPaletteHUDTests.swift
@@ -1,0 +1,123 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Wink
+
+@MainActor
+private func ensureAppKitApplication() {
+    _ = NSApplication.shared
+}
+
+@MainActor
+private func drainMainRunLoop(_ seconds: TimeInterval = 0.05) {
+    RunLoop.current.run(until: Date().addingTimeInterval(seconds))
+}
+
+private func makeCandidate(
+    _ name: String,
+    _ bundleIdentifier: String,
+    isRunning: Bool
+) -> SearchPaletteCandidate {
+    SearchPaletteCandidate(
+        entry: AppEntry(id: bundleIdentifier, name: name, url: URL(fileURLWithPath: "/Applications/\(name).app")),
+        normalizedName: name.lowercased(),
+        keycap: nil,
+        isRunning: isRunning
+    )
+}
+
+@MainActor
+private final class SearchPaletteHUDHarness {
+    var candidates: [SearchPaletteCandidate]
+    var activatedEntries: [AppEntry] = []
+    var sessionActiveCalls: [Bool] = []
+
+    lazy var controller = SearchPaletteHUDController(
+        onSessionStateChange: { [unowned self] active in self.sessionActiveCalls.append(active) },
+        candidatesProvider: { [unowned self] in self.candidates },
+        activate: { [unowned self] entry in
+            self.activatedEntries.append(entry)
+            return true
+        }
+    )
+
+    init(candidates: [SearchPaletteCandidate]) {
+        self.candidates = candidates
+    }
+}
+
+// MARK: - P2-1: panel resizes as content changes (structural, not pixel)
+
+/// #356 P2-1 regression: sizing only ever happened once, at `present()`.
+/// Typing a query that grows the result set (or, as exercised here,
+/// `refreshCandidatesIfPresented()` picking up a larger candidate set) left
+/// a stale, clipped viewport. This asserts the panel's content actually
+/// grows — not an exact pixel height, which would be a brittle assertion
+/// against SwiftUI/AppKit layout internals.
+@Test @MainActor
+func presentedPanelGrowsAsTheCandidateSetGrows() throws {
+    ensureAppKitApplication()
+    let harness = SearchPaletteHUDHarness(candidates: [
+        makeCandidate("Safari", "com.apple.Safari", isRunning: true),
+    ])
+
+    harness.controller.present()
+    drainMainRunLoop()
+    let panel = try #require(harness.controller.panel)
+    let heightWithOneResult = panel.frame.height
+
+    harness.candidates = (0..<8).map { index in
+        makeCandidate("App \(index)", "com.example.app\(index)", isRunning: true)
+    }
+    harness.controller.refreshCandidatesIfPresented()
+    drainMainRunLoop()
+    let heightWithEightResults = panel.frame.height
+
+    #expect(heightWithEightResults > heightWithOneResult)
+
+    harness.controller.dismiss()
+}
+
+// MARK: - P2-7: resilience to a trigger fired before the app list is warm
+
+/// #356 P2-7 regression: a trigger fired before `AppListProvider`'s first
+/// scan lands would otherwise open onto an empty snapshot that stayed empty
+/// until dismiss/reopen. `AppController` wires `AppListProvider.onRefreshCompleted`
+/// to this method; this proves the presented palette actually picks up a
+/// later-arriving candidate set instead of requiring the user to
+/// dismiss/reopen.
+@Test @MainActor
+func refreshCandidatesIfPresentedPicksUpALaterArrivingCandidateSet() throws {
+    ensureAppKitApplication()
+    let harness = SearchPaletteHUDHarness(candidates: [])
+
+    harness.controller.present()
+    drainMainRunLoop()
+    let panel = try #require(harness.controller.panel)
+    let heightWhileEmpty = panel.frame.height
+
+    harness.candidates = [
+        makeCandidate("Safari", "com.apple.Safari", isRunning: true),
+        makeCandidate("Terminal", "com.apple.Terminal", isRunning: true),
+    ]
+    harness.controller.refreshCandidatesIfPresented()
+    drainMainRunLoop()
+
+    #expect(panel.frame.height > heightWhileEmpty)
+
+    harness.controller.dismiss()
+}
+
+@Test @MainActor
+func refreshCandidatesIfPresentedIsANoOpWhenNotPresented() {
+    ensureAppKitApplication()
+    let harness = SearchPaletteHUDHarness(candidates: [
+        makeCandidate("Safari", "com.apple.Safari", isRunning: true),
+    ])
+
+    // Never presented — must not create a panel or crash.
+    harness.controller.refreshCandidatesIfPresented()
+
+    #expect(harness.controller.panel == nil)
+    #expect(!harness.controller.isPresented)
+}

--- a/Tests/WinkTests/SearchPaletteMatchingTests.swift
+++ b/Tests/WinkTests/SearchPaletteMatchingTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import Testing
+@testable import Wink
+
+private func entry(_ name: String, _ bundleIdentifier: String? = nil) -> AppEntry {
+    AppEntry(
+        id: bundleIdentifier ?? "com.example.\(name.lowercased())",
+        name: name,
+        url: URL(fileURLWithPath: "/Applications/\(name).app")
+    )
+}
+
+private func candidate(
+    _ name: String,
+    bundleIdentifier: String? = nil,
+    keycap: String? = nil,
+    isRunning: Bool = false
+) -> SearchPaletteCandidate {
+    let appEntry = entry(name, bundleIdentifier)
+    return SearchPaletteCandidate(
+        entry: appEntry,
+        normalizedName: appEntry.name.lowercased(),
+        keycap: keycap,
+        isRunning: isRunning
+    )
+}
+
+// MARK: - Tiered scoring
+
+@Test func exactMatchOutranksEveryOtherTier() throws {
+    let exact = try #require(SearchPaletteMatch.score(query: "Safari", normalizedName: "safari"))
+    let prefix = try #require(SearchPaletteMatch.score(query: "Saf", normalizedName: "safari"))
+    #expect(exact > prefix)
+}
+
+@Test func prefixMatchOutranksWordPrefixMatch() throws {
+    let prefix = try #require(SearchPaletteMatch.score(query: "vis", normalizedName: "visual studio code"))
+    let wordPrefix = try #require(SearchPaletteMatch.score(query: "code", normalizedName: "visual studio code"))
+    #expect(prefix > wordPrefix)
+}
+
+@Test func wordPrefixMatchOutranksGeneralSubsequenceMatch() throws {
+    let wordPrefix = try #require(SearchPaletteMatch.score(query: "code", normalizedName: "visual studio code"))
+    // "vsc" is a subsequence of "visual studio code" but matches no whole
+    // word's start, so it can only land in the lowest tier.
+    let subsequence = try #require(SearchPaletteMatch.score(query: "vsc", normalizedName: "visual studio code"))
+    #expect(wordPrefix > subsequence)
+}
+
+@Test func nonMatchingQueryReturnsNil() {
+    #expect(SearchPaletteMatch.score(query: "xyz123", normalizedName: "safari") == nil)
+}
+
+@Test func outOfOrderCharactersDoNotMatchAsASubsequence() {
+    // "fri" reversed against "safari" ("i","r","f") is not in-order.
+    #expect(SearchPaletteMatch.score(query: "irf", normalizedName: "safari") == nil)
+}
+
+@Test func scoringIsCaseInsensitive() throws {
+    let lower = try #require(SearchPaletteMatch.score(query: "saf", normalizedName: "safari"))
+    let upper = try #require(SearchPaletteMatch.score(query: "SAF", normalizedName: "safari"))
+    #expect(lower == upper)
+}
+
+@Test func emptyQueryNeverMatches() {
+    #expect(SearchPaletteMatch.score(query: "", normalizedName: "safari") == nil)
+}
+
+/// #356's IME note: v1 matches a fully-composed CJK app name via
+/// `localizedName` containment. A contiguous substring is a special case of
+/// "in order", so this needs no separate containment branch in the scorer.
+@Test func containedSubstringMatchesIncludingCJKNames() throws {
+    #expect(SearchPaletteMatch.score(query: "信", normalizedName: "微信") != nil)
+    #expect(SearchPaletteMatch.score(query: "微信", normalizedName: "微信") == 1_000)
+}
+
+@Test func tighterSubsequenceMatchScoresHigherThanASpreadOutOne() throws {
+    // Both are non-prefix, non-word-prefix subsequence matches of "ff", but
+    // "office" has the two f's adjacent while "far far away" spreads them
+    // across the whole string.
+    let tight = try #require(SearchPaletteMatch.score(query: "ff", normalizedName: "office"))
+    let spread = try #require(SearchPaletteMatch.score(query: "ff", normalizedName: "far far away"))
+    #expect(tight > spread)
+}
+
+// MARK: - Ranking
+
+@Test func rankingExcludesNonMatchesAndOrdersByScoreDescending() {
+    let candidates = [
+        candidate("Terminal"),
+        candidate("Safari"),
+        candidate("Xcode"),
+    ]
+    let results = SearchPaletteRanking.rank(query: "Safari", candidates: candidates)
+    #expect(results.map(\.entry.name) == ["Safari"])
+}
+
+@Test func rankingBreaksScoreTiesAlphabetically() {
+    // Both are pure prefix matches of "s" at the same extra-length tier
+    // boundary handling — use two names of equal length so the score
+    // formula ties exactly, then confirm the alphabetical tie-break.
+    let candidates = [
+        candidate("Sun"),
+        candidate("Sky"),
+    ]
+    let results = SearchPaletteRanking.rank(query: "s", candidates: candidates)
+    #expect(results.map(\.entry.name) == ["Sky", "Sun"])
+}
+
+@Test func rankingRespectsTheResultLimit() {
+    let candidates = (0..<20).map { candidate("App\($0)") }
+    let results = SearchPaletteRanking.rank(query: "App", candidates: candidates, limit: 5)
+    #expect(results.count == 5)
+}
+
+@Test func emptyQueryRanksToNoResults() {
+    let candidates = [candidate("Safari")]
+    #expect(SearchPaletteRanking.rank(query: "   ", candidates: candidates).isEmpty)
+}
+
+// MARK: - Candidate building
+
+@Test func candidateBuilderAttachesKeycapOnlyForEnabledRealAppShortcuts() {
+    let apps = [entry("Safari", "com.apple.Safari"), entry("Terminal", "com.apple.Terminal")]
+    let shortcuts = [
+        AppShortcut(
+            appName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            keyEquivalent: "s",
+            modifierFlags: ["command", "shift"]
+        ),
+        AppShortcut(
+            appName: "Terminal",
+            bundleIdentifier: "com.apple.Terminal",
+            keyEquivalent: "t",
+            modifierFlags: ["command"],
+            isEnabled: false
+        ),
+    ]
+
+    let candidates = SearchPaletteCandidateBuilder.build(
+        apps: apps,
+        shortcuts: shortcuts,
+        runningBundleIdentifiers: []
+    )
+
+    let safari = candidates.first { $0.entry.bundleIdentifier == "com.apple.Safari" }
+    let terminal = candidates.first { $0.entry.bundleIdentifier == "com.apple.Terminal" }
+    #expect(safari?.keycap == "⌘⇧S")
+    // Disabled shortcuts never surface a keycap — they aren't live bindings.
+    #expect(terminal?.keycap == nil)
+}
+
+@Test func candidateBuilderNeverAttachesAKeycapFromAPseudoTargetShortcut() {
+    let apps = [entry("Safari", "com.apple.Safari")]
+    // A pseudo-target shortcut is excluded by its `target`, not by which
+    // bundle it happens to carry — bind it to Safari's real bundle id to
+    // prove that.
+    let shortcuts = [
+        AppShortcut(
+            appName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            keyEquivalent: "s",
+            modifierFlags: ["command"],
+            target: .frontmostApp
+        ),
+    ]
+
+    let candidates = SearchPaletteCandidateBuilder.build(
+        apps: apps,
+        shortcuts: shortcuts,
+        runningBundleIdentifiers: []
+    )
+
+    #expect(candidates.first?.keycap == nil)
+}
+
+@Test func candidateBuilderPropagatesRunningState() {
+    let apps = [entry("Safari", "com.apple.Safari"), entry("Terminal", "com.apple.Terminal")]
+    let candidates = SearchPaletteCandidateBuilder.build(
+        apps: apps,
+        shortcuts: [],
+        runningBundleIdentifiers: ["com.apple.Safari"]
+    )
+
+    #expect(candidates.first { $0.entry.bundleIdentifier == "com.apple.Safari" }?.isRunning == true)
+    #expect(candidates.first { $0.entry.bundleIdentifier == "com.apple.Terminal" }?.isRunning == false)
+}
+
+// MARK: - Structural latency guard
+
+/// Not a strict SLA (wall-clock assertions in CI are inherently noisy) —
+/// this is a coarse regression canary confirming the per-keystroke ranking
+/// cost stays a cheap in-memory scan even against a candidate list far
+/// larger than any real Mac's installed-app count, with a bound generous
+/// enough to absorb slow CI hosts without flaking.
+@Test func rankingStaysCheapAgainstALargeCandidateList() {
+    let candidates = (0..<2_000).map { candidate("Application Number \($0)") }
+    let start = Date()
+    _ = SearchPaletteRanking.rank(query: "Application Number 1234", candidates: candidates)
+    let elapsed = Date().timeIntervalSince(start)
+    #expect(elapsed < 0.5)
+}

--- a/Tests/WinkTests/SearchPaletteMatchingTests.swift
+++ b/Tests/WinkTests/SearchPaletteMatchingTests.swift
@@ -75,12 +75,36 @@ private func candidate(
 }
 
 @Test func tighterSubsequenceMatchScoresHigherThanASpreadOutOne() throws {
-    // Both are non-prefix, non-word-prefix subsequence matches of "ff", but
-    // "office" has the two f's adjacent while "far far away" spreads them
-    // across the whole string.
-    let tight = try #require(SearchPaletteMatch.score(query: "ff", normalizedName: "office"))
-    let spread = try #require(SearchPaletteMatch.score(query: "ff", normalizedName: "far far away"))
+    // Both are non-prefix, non-word-prefix, non-contiguous-substring
+    // matches of "acd" — "abcd" has the matched characters close together
+    // (one letter between them) while "a b c d" spreads them across the
+    // whole string. Neither candidate contains "acd" as a literal
+    // substring, so both land in the subsequence tier and this isolates its
+    // tightness-based sub-ordering from the contains tier.
+    let tight = try #require(SearchPaletteMatch.score(query: "acd", normalizedName: "abcd"))
+    let spread = try #require(SearchPaletteMatch.score(query: "acd", normalizedName: "a b c d"))
     #expect(tight > spread)
+}
+
+/// #356 regression: a greedy leftmost subsequence scan can anchor an early,
+/// spread-out match instead of recognizing a genuine contiguous substring
+/// elsewhere in the name — query "ab" against "a fab" would otherwise
+/// anchor the standalone "a" (position 0) and miss the tighter "ab" at the
+/// end, scoring below a candidate where "ab" is merely a spread-out
+/// subsequence. The explicit contains tier must outrank that regardless.
+@Test func containsTierAlwaysOutranksANonContiguousSubsequenceMatch() throws {
+    let containsMatch = try #require(SearchPaletteMatch.score(query: "ab", normalizedName: "a fab"))
+    let subsequenceOnlyMatch = try #require(SearchPaletteMatch.score(query: "ab", normalizedName: "axb"))
+    #expect(containsMatch > subsequenceOnlyMatch)
+}
+
+@Test func containsTierOutranksSubsequenceButNotWordPrefix() throws {
+    let wordPrefix = try #require(SearchPaletteMatch.score(query: "code", normalizedName: "visual studio code"))
+    // "tudio" is a substring of "studio" but not a prefix of any word (the
+    // word itself starts with "s"), so it isolates the contains tier from
+    // the word-prefix tier above it.
+    let contains = try #require(SearchPaletteMatch.score(query: "tudio", normalizedName: "visual studio code"))
+    #expect(wordPrefix > contains)
 }
 
 // MARK: - Ranking
@@ -185,6 +209,80 @@ private func candidate(
 
     #expect(candidates.first { $0.entry.bundleIdentifier == "com.apple.Safari" }?.isRunning == true)
     #expect(candidates.first { $0.entry.bundleIdentifier == "com.apple.Terminal" }?.isRunning == false)
+}
+
+// MARK: - Empty-query recency ordering (#356 P3-11)
+
+@Test func recentRunningOrdersByRecencyMostRecentFirst() {
+    let candidates = [
+        candidate("Safari", bundleIdentifier: "com.apple.Safari", isRunning: true),
+        candidate("Terminal", bundleIdentifier: "com.apple.Terminal", isRunning: true),
+        candidate("Xcode", bundleIdentifier: "com.apple.Xcode", isRunning: true),
+    ]
+
+    let results = SearchPaletteRanking.recentRunning(
+        candidates: candidates,
+        recentBundleIdentifiers: ["com.apple.Xcode", "com.apple.Safari", "com.apple.Terminal"]
+    )
+
+    #expect(results.map(\.entry.bundleIdentifier) == ["com.apple.Xcode", "com.apple.Safari", "com.apple.Terminal"])
+}
+
+@Test func recentRunningFallsBackToAlphabeticalForRunningAppsWithNoRecencySignal() {
+    let candidates = [
+        candidate("Zephyr", bundleIdentifier: "com.example.Zephyr", isRunning: true),
+        candidate("Anchor", bundleIdentifier: "com.example.Anchor", isRunning: true),
+        candidate("Safari", bundleIdentifier: "com.apple.Safari", isRunning: true),
+    ]
+
+    // Only Safari has a recency signal; the other two running apps (never
+    // activated through Wink) fall back to alphabetical order at the tail.
+    let results = SearchPaletteRanking.recentRunning(
+        candidates: candidates,
+        recentBundleIdentifiers: ["com.apple.Safari"]
+    )
+
+    #expect(results.map(\.entry.name) == ["Safari", "Anchor", "Zephyr"])
+}
+
+@Test func recentRunningExcludesNonRunningApps() {
+    let candidates = [
+        candidate("Safari", bundleIdentifier: "com.apple.Safari", isRunning: true),
+        candidate("Terminal", bundleIdentifier: "com.apple.Terminal", isRunning: false),
+    ]
+
+    let results = SearchPaletteRanking.recentRunning(
+        candidates: candidates,
+        recentBundleIdentifiers: ["com.apple.Terminal", "com.apple.Safari"]
+    )
+
+    #expect(results.map(\.entry.bundleIdentifier) == ["com.apple.Safari"])
+}
+
+@Test func recentRunningIgnoresStaleRecentEntriesNotCurrentlyRunning() {
+    // A bundle can be "recent" (previously activated) without being running
+    // right now — a stale recent id that isn't in the running set must not
+    // produce a missing/duplicate row.
+    let candidates = [
+        candidate("Safari", bundleIdentifier: "com.apple.Safari", isRunning: true),
+    ]
+
+    let results = SearchPaletteRanking.recentRunning(
+        candidates: candidates,
+        recentBundleIdentifiers: ["com.apple.QuitApp", "com.apple.Safari"]
+    )
+
+    #expect(results.map(\.entry.bundleIdentifier) == ["com.apple.Safari"])
+}
+
+@Test func recentRunningRespectsTheLimit() {
+    let candidates = (0..<20).map { candidate("App\($0)", bundleIdentifier: "com.example.app\($0)", isRunning: true) }
+    let results = SearchPaletteRanking.recentRunning(
+        candidates: candidates,
+        recentBundleIdentifiers: [],
+        limit: 5
+    )
+    #expect(results.count == 5)
 }
 
 // MARK: - Structural latency guard

--- a/Tests/WinkTests/SettingsViewTests.swift
+++ b/Tests/WinkTests/SettingsViewTests.swift
@@ -377,7 +377,7 @@ private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
 @MainActor
 private struct FakeAppSwitcher: AppSwitching {
     @discardableResult
-    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
         true
     }
 }

--- a/Tests/WinkTests/ShortcutEditorStateTests.swift
+++ b/Tests/WinkTests/ShortcutEditorStateTests.swift
@@ -103,6 +103,72 @@ func failedToggleLeavesEnabledStateUnchanged() {
     #expect(context.editor.saveErrorMessage != nil)
 }
 
+/// #356 P2-5 regression: a persistence failure while committing the
+/// search-palette trigger must surface on the General tab's own card
+/// (`searchPaletteSaveErrorMessage`), not only the shared `saveErrorMessage`
+/// that only `ShortcutsTabView` renders.
+@Test @MainActor
+func commitSearchPaletteShortcutSurfacesAPaletteScopedSaveError() {
+    let context = makeFailingSaveEditorContext(existingShortcuts: [])
+
+    context.editor.commitSearchPaletteShortcut(
+        RecordedShortcut(keyEquivalent: "space", modifierFlags: ["command", "option"])
+    )
+
+    #expect(context.editor.searchPaletteShortcut == nil)
+    #expect(context.editor.searchPaletteSaveErrorMessage != nil)
+    #expect(context.editor.searchPaletteSaveErrorMessage == context.editor.saveErrorMessage)
+    #expect(context.editor.recordedSearchPaletteShortcut == nil)
+}
+
+@Test @MainActor
+func setSearchPaletteEnabledSurfacesAPaletteScopedSaveError() {
+    let trigger = AppShortcut(
+        appName: AppShortcut.searchPaletteTargetStableName,
+        bundleIdentifier: AppShortcut.searchPaletteTargetSentinelBundleIdentifier,
+        keyEquivalent: "space",
+        modifierFlags: ["command", "option"],
+        target: .searchPalette
+    )
+    let context = makeFailingSaveEditorContext(existingShortcuts: [trigger])
+
+    context.editor.setSearchPaletteEnabled(false)
+
+    #expect(context.editor.searchPaletteShortcut?.isEnabled == true)
+    #expect(context.editor.searchPaletteSaveErrorMessage != nil)
+}
+
+@Test @MainActor
+func removeSearchPaletteShortcutSurfacesAPaletteScopedSaveError() {
+    let trigger = AppShortcut(
+        appName: AppShortcut.searchPaletteTargetStableName,
+        bundleIdentifier: AppShortcut.searchPaletteTargetSentinelBundleIdentifier,
+        keyEquivalent: "space",
+        modifierFlags: ["command", "option"],
+        target: .searchPalette
+    )
+    let context = makeFailingSaveEditorContext(existingShortcuts: [trigger])
+
+    context.editor.removeSearchPaletteShortcut()
+
+    #expect(context.editor.searchPaletteShortcut != nil)
+    #expect(context.editor.searchPaletteSaveErrorMessage != nil)
+}
+
+/// #356 P2-5: a successful commit clears any prior palette-scoped error.
+@Test @MainActor
+func commitSearchPaletteShortcutClearsAPriorPaletteScopedSaveError() {
+    let context = makeEditorContext()
+    defer { context.harness.cleanup() }
+
+    context.editor.searchPaletteSaveErrorMessage = "stale error"
+    context.editor.commitSearchPaletteShortcut(
+        RecordedShortcut(keyEquivalent: "space", modifierFlags: ["command", "option"])
+    )
+
+    #expect(context.editor.searchPaletteSaveErrorMessage == nil)
+}
+
 @Test @MainActor
 func successfulSaveClearsPreviousSaveError() {
     let context = makeEditorContext()
@@ -939,7 +1005,7 @@ private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
 @MainActor
 private struct FakeAppSwitcher: AppSwitching {
     @discardableResult
-    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
         true
     }
 }

--- a/Tests/WinkTests/ShortcutEditorStateTests.swift
+++ b/Tests/WinkTests/ShortcutEditorStateTests.swift
@@ -705,6 +705,167 @@ func exportRecipeDataUsesShareableSchema() throws {
     ])
 }
 
+// MARK: - Search-palette trigger recorder (#356)
+
+@Test @MainActor
+func commitSearchPaletteShortcutPersistsAnEnabledTrigger() throws {
+    let context = makeEditorContext()
+    defer { context.harness.cleanup() }
+
+    context.editor.commitSearchPaletteShortcut(
+        RecordedShortcut(keyEquivalent: "space", modifierFlags: ["command", "option"])
+    )
+
+    let persisted = try #require(context.editor.searchPaletteShortcut)
+    #expect(persisted.isSearchPaletteTarget)
+    #expect(persisted.isEnabled)
+    #expect(persisted.keyEquivalent == "space")
+    #expect(persisted.modifierFlags == ["command", "option"])
+    #expect(context.editor.searchPaletteConflictMessage == nil)
+    #expect(context.editor.recordedSearchPaletteShortcut == nil)
+    #expect(context.callbackCount.value == 1)
+    #expect(context.shortcutStore.shortcuts.count == 1)
+}
+
+@Test @MainActor
+func commitSearchPaletteShortcutReplacesThePriorBindingInPlace() throws {
+    let context = makeEditorContext()
+    defer { context.harness.cleanup() }
+
+    context.editor.commitSearchPaletteShortcut(
+        RecordedShortcut(keyEquivalent: "space", modifierFlags: ["command", "option"])
+    )
+    let firstID = try #require(context.editor.searchPaletteShortcut?.id)
+
+    context.editor.commitSearchPaletteShortcut(
+        RecordedShortcut(keyEquivalent: "j", modifierFlags: ["command", "option"])
+    )
+
+    // Re-recording replaces the one binding rather than accumulating a
+    // second search-palette row.
+    #expect(context.shortcutStore.shortcuts.count == 1)
+    #expect(context.editor.searchPaletteShortcut?.id == firstID)
+    #expect(context.editor.searchPaletteShortcut?.keyEquivalent == "j")
+}
+
+@Test @MainActor
+func commitSearchPaletteShortcutRejectsAConflictWithAnExistingAppShortcut() throws {
+    let safari = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "s",
+        modifierFlags: ["command", "shift"]
+    )
+    let context = makeEditorContext(existingShortcuts: [safari])
+    defer { context.harness.cleanup() }
+
+    context.editor.commitSearchPaletteShortcut(
+        RecordedShortcut(keyEquivalent: "s", modifierFlags: ["command", "shift"])
+    )
+
+    #expect(context.editor.searchPaletteShortcut == nil)
+    #expect(context.editor.recordedSearchPaletteShortcut == nil)
+    #expect(context.editor.searchPaletteConflictMessage?.contains("Safari") == true)
+    #expect(context.shortcutStore.shortcuts == [safari])
+}
+
+@Test @MainActor
+func addingAnAppShortcutRejectsAConflictWithAnExistingSearchPaletteTrigger() throws {
+    let context = makeEditorContext()
+    defer { context.harness.cleanup() }
+
+    context.editor.commitSearchPaletteShortcut(
+        RecordedShortcut(keyEquivalent: "space", modifierFlags: ["command", "option"])
+    )
+
+    context.editor.selectedAppName = "Safari"
+    context.editor.selectedBundleIdentifier = "com.apple.Safari"
+    context.editor.recordedShortcut = RecordedShortcut(keyEquivalent: "space", modifierFlags: ["command", "option"])
+    context.editor.addShortcut()
+
+    // The conflict message resolves through `displayAppName`, so the
+    // colliding search-palette trigger reads as "Search Palette", not its
+    // sentinel bundle identifier.
+    #expect(context.editor.conflictMessage?.contains("Search Palette") == true)
+    #expect(context.shortcutStore.shortcuts.count == 1)
+    #expect(context.shortcutStore.shortcuts.first?.isSearchPaletteTarget == true)
+}
+
+@Test @MainActor
+func setSearchPaletteEnabledTogglesWithoutRemovingTheBinding() throws {
+    let context = makeEditorContext()
+    defer { context.harness.cleanup() }
+
+    context.editor.commitSearchPaletteShortcut(
+        RecordedShortcut(keyEquivalent: "space", modifierFlags: ["command", "option"])
+    )
+    let callbackCountAfterCommit = context.callbackCount.value
+
+    context.editor.setSearchPaletteEnabled(false)
+    #expect(context.editor.searchPaletteShortcut?.isEnabled == false)
+    #expect(context.callbackCount.value == callbackCountAfterCommit + 1)
+
+    // Same value again is a no-op, matching setFrontmostBehaviorOverride's
+    // established no-op-on-unchanged-value contract.
+    context.editor.setSearchPaletteEnabled(false)
+    #expect(context.callbackCount.value == callbackCountAfterCommit + 1)
+
+    context.editor.setSearchPaletteEnabled(true)
+    #expect(context.editor.searchPaletteShortcut?.isEnabled == true)
+    #expect(context.callbackCount.value == callbackCountAfterCommit + 2)
+}
+
+@Test @MainActor
+func removeSearchPaletteShortcutClearsTheBinding() throws {
+    let context = makeEditorContext()
+    defer { context.harness.cleanup() }
+
+    context.editor.commitSearchPaletteShortcut(
+        RecordedShortcut(keyEquivalent: "space", modifierFlags: ["command", "option"])
+    )
+    #expect(context.editor.searchPaletteShortcut != nil)
+
+    context.editor.removeSearchPaletteShortcut()
+
+    #expect(context.editor.searchPaletteShortcut == nil)
+    #expect(context.shortcutStore.shortcuts.isEmpty)
+}
+
+@Test @MainActor
+func removeSearchPaletteShortcutWithNoBindingIsANoOp() throws {
+    let context = makeEditorContext()
+    defer { context.harness.cleanup() }
+
+    context.editor.removeSearchPaletteShortcut()
+
+    #expect(context.callbackCount.value == 0)
+    #expect(context.shortcutStore.shortcuts.isEmpty)
+}
+
+@Test @MainActor
+func exportRecipeDataExcludesTheSearchPaletteTrigger() throws {
+    let safari = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "s",
+        modifierFlags: ["command", "shift"]
+    )
+    let context = makeEditorContext(existingShortcuts: [safari])
+    defer { context.harness.cleanup() }
+
+    context.editor.commitSearchPaletteShortcut(
+        RecordedShortcut(keyEquivalent: "space", modifierFlags: ["command", "option"])
+    )
+    // Both a real binding and the trigger now live in the store...
+    #expect(context.shortcutStore.shortcuts.count == 2)
+
+    // ...but only the real binding travels in an exported recipe — the
+    // trigger is a local device preference, not a portable app binding.
+    let data = try context.editor.exportRecipeData()
+    let decoded = try WinkRecipeCodec().decode(data)
+    #expect(decoded.shortcuts.map(\.bundleIdentifier) == ["com.apple.Safari"])
+}
+
 private struct FakePermissionService: PermissionServicing {
     let ax: Bool
     let input: Bool

--- a/Tests/WinkTests/ShortcutManagerStatusTests.swift
+++ b/Tests/WinkTests/ShortcutManagerStatusTests.swift
@@ -178,7 +178,7 @@ private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
 @MainActor
 private struct FakeAppSwitcher: AppSwitching {
     @discardableResult
-    func toggleApplication(for shortcut: AppShortcut) -> Bool {
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
         true
     }
 }

--- a/Tests/WinkTests/WinkRecipeImportPlannerTests.swift
+++ b/Tests/WinkTests/WinkRecipeImportPlannerTests.swift
@@ -67,6 +67,48 @@ struct WinkRecipeImportPlannerTests {
         #expect(plan.entries[2].imported.resolution == .unresolved)
     }
 
+    /// #356: the search-palette trigger is a local device preference, never
+    /// a portable app binding — an inbound recipe carrying one (hand-edited,
+    /// or a future schema) must import none of it. Without this exclusion,
+    /// GeneralTabView.searchPaletteShortcut (which reads only `.first`) and
+    /// every other list (which hides the target entirely) would leave a
+    /// second live global chord invisible and undeletable.
+    @Test
+    func planImportDropsSearchPaletteSentinelRowsEntirely() {
+        let planner = WinkRecipeImportPlanner()
+        let recipe = WinkRecipe(
+            shortcuts: [
+                WinkRecipeShortcut(
+                    appName: AppShortcut.searchPaletteTargetStableName,
+                    bundleIdentifier: AppShortcut.searchPaletteTargetSentinelBundleIdentifier,
+                    keyEquivalent: "space",
+                    modifierFlags: ["command", "option"],
+                    isEnabled: true,
+                    target: "searchPalette"
+                ),
+                WinkRecipeShortcut(
+                    appName: AppShortcut.searchPaletteTargetStableName,
+                    bundleIdentifier: AppShortcut.searchPaletteTargetSentinelBundleIdentifier,
+                    keyEquivalent: "j",
+                    modifierFlags: ["command", "option"],
+                    isEnabled: true,
+                    target: "searchPalette"
+                ),
+            ]
+        )
+
+        let plan = planner.planImport(
+            recipe: recipe,
+            existingShortcuts: [],
+            installedApps: []
+        )
+
+        #expect(plan.entries.isEmpty)
+
+        let applied = planner.applying(plan: plan, to: [], strategy: .replaceExisting)
+        #expect(applied.isEmpty)
+    }
+
     @Test
     func ambiguousNameMatchesStayUnresolved() {
         let planner = WinkRecipeImportPlanner()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -354,7 +354,17 @@ Global shortcut event
   -> ShortcutManager.handleKeyPress()
   -> KeyMatcher normalizes KeyPress into ShortcutTrigger and triggerIndex finds the matching AppShortcut
   -> ShortcutManager emits `SHORTCUT_TRACE_DECISION event=matched`
-  -> AppSwitcher.toggleApplication()
+  -> match.isSearchPaletteTarget? (the #356 search-palette trigger's sentinel bundle names no app)
+       yes -> ShortcutManager.onSearchPaletteTriggered() -> AppController presents SearchPaletteHUDController
+              -> palette open gates matched dispatch via ShortcutManager.setInteractivePanelSessionActive(true),
+                 the same shared gate #352's window picker uses (mutual exclusion falls out of that one flag)
+              -> Enter commits: AppController's `activate` closure calls
+                 AppSwitcher.toggleApplication(for: adHocShortcut, bypassCooldown: true) with
+                 frontmostBehaviorOverride: .focus forced — activate/re-focus only, never a real
+                 toggle-off, and never routed through ShortcutManager.trigger (no usage recorded
+                 against an unpersisted ad hoc shortcut)
+              -> Escape or losing key status dismisses with zero side effects
+       no  -> AppSwitcher.toggleApplication() (the standard path below)
   -> ToggleSessionCoordinator creates/updates the pid-aware attempt session
   -> ApplicationObservation captures frontmost/window evidence
   -> activate / confirm / recover stage-by-stage

--- a/scripts/e2e-lib.bats
+++ b/scripts/e2e-lib.bats
@@ -507,6 +507,77 @@ JSON
   [[ "$output" == *'"keyCode":122'* ]]
 }
 
+@test "shortcut_inventory_json excludes frontmost-app and search-palette pseudo-target sentinels" {
+  local shortcuts="$BATS_TEST_TMPDIR/shortcuts.json"
+  cat >"$shortcuts" <<'JSON'
+[
+  {
+    "appName": "Safari",
+    "bundleIdentifier": "com.apple.Safari",
+    "id": "11111111-1111-1111-1111-111111111111",
+    "isEnabled": true,
+    "keyEquivalent": "s",
+    "modifierFlags": ["command", "shift"]
+  },
+  {
+    "appName": "Current App",
+    "bundleIdentifier": "wink.target.frontmost-app",
+    "id": "22222222-2222-2222-2222-222222222222",
+    "isEnabled": true,
+    "keyEquivalent": "j",
+    "modifierFlags": ["command"],
+    "target": "frontmostApp"
+  },
+  {
+    "appName": "Search Palette",
+    "bundleIdentifier": "wink.target.search-palette",
+    "id": "33333333-3333-3333-3333-333333333333",
+    "isEnabled": true,
+    "keyEquivalent": "space",
+    "modifierFlags": ["command", "option"],
+    "target": "searchPalette"
+  }
+]
+JSON
+
+  run bash -lc "source '$BATS_TEST_DIRNAME/e2e-lib.sh'; shortcut_inventory_json '$shortcuts' 1"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"bundleIdentifier":"com.apple.Safari"'* ]]
+  [[ "$output" != *"wink.target.frontmost-app"* ]]
+  [[ "$output" != *"wink.target.search-palette"* ]]
+}
+
+@test "resolve_primary_test_shortcut never selects a pseudo-target sentinel" {
+  local shortcuts="$BATS_TEST_TMPDIR/shortcuts.json"
+  cat >"$shortcuts" <<'JSON'
+[
+  {
+    "appName": "Search Palette",
+    "bundleIdentifier": "wink.target.search-palette",
+    "id": "11111111-1111-1111-1111-111111111111",
+    "isEnabled": true,
+    "keyEquivalent": "space",
+    "modifierFlags": ["command", "option"],
+    "target": "searchPalette"
+  },
+  {
+    "appName": "IINA",
+    "bundleIdentifier": "com.colliderli.iina",
+    "id": "22222222-2222-2222-2222-222222222222",
+    "isEnabled": true,
+    "keyEquivalent": "m",
+    "modifierFlags": ["command", "option", "control", "shift"]
+  }
+]
+JSON
+
+  run bash -lc "source '$BATS_TEST_DIRNAME/e2e-lib.sh'; resolve_primary_test_shortcut '$shortcuts' 1"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'"bundleIdentifier":"com.colliderli.iina"'* ]]
+}
+
 @test "resolve_isolation_shortcuts returns two distinct shortcuts for a hyper-only fixture" {
   local shortcuts="$BATS_TEST_TMPDIR/shortcuts.json"
   cat >"$shortcuts" <<'JSON'

--- a/scripts/e2e-lib.sh
+++ b/scripts/e2e-lib.sh
@@ -239,11 +239,20 @@ shortcut_inventory_json() {
           "down" => 125, "up" => 126, "return" => 36, "enter" => 36
         }
 
+        # Pseudo-target sentinels (#323 frontmost-app, #356 search-palette):
+        # neither names an installed app, so treating one as the toggle-test
+        # target would launch/poll a bundle id that can never exist and fail
+        # the gate on an otherwise-valid config. Exclude both by their known
+        # sentinel bundle identifiers rather than trying to infer "target"
+        # semantics from the raw JSON.
+        sentinel_bundle_ids = %w[wink.target.frontmost-app wink.target.search-palette]
+
         shortcuts = JSON.parse(File.read(ARGV[0])) rescue []
         hyper_enabled = ARGV[1] == "1"
 
         inventory = shortcuts.each_with_object([]) do |shortcut, entries|
           next if shortcut["isEnabled"] == false
+          next if sentinel_bundle_ids.include?(shortcut["bundleIdentifier"])
 
           key_equivalent = shortcut["keyEquivalent"].to_s.downcase
           key_code = key_codes[key_equivalent]


### PR DESCRIPTION
Fixes #356

## Summary
- Search-to-switch palette: one dedicated, user-assignable shortcut (off by default) opens a key-capable non-activating panel with a type-ahead field; typing a few characters of an app name and pressing Enter activates that app through Wink's standard activation path (launch-if-not-running included, forced `.focus` — never toggle-off). Escape closes with zero side effects. Bound apps show their keycap in the result rows. Installed/running apps only; four-tier deterministic scoring (exact → prefix → word-prefix → contains → in-order subsequence), explicitly no edit-distance waterfall. Empty query lists running apps, most-recent first. Zero new TCC.
- The trigger is modeled as an `AppShortcut` with a new `ShortcutTarget.searchPalette` case and sentinel bundle id, mirroring the `.frontmostApp` pseudo-target pattern — persistence, lenient decode (unknown target → nil on old builds, availability filter silently disables the row), bidirectional conflict validation, and Carbon/Hyper registration all ride existing machinery. `handleKeyPress` routes the sentinel to the palette instead of `toggleApplication`. Managed from a dedicated General-tab card (recorded through the existing recorder/validator); excluded from the Shortcuts list, menu-bar rows, Insights unused-nudge, recipe export AND import (local device preference, not portable), and the e2e toggle-test inventory.
- Panel scaffolding is shared with #352 (`KeyCapableHUDPanel` extraction, zero picker behavior change) and both panels share the interactive-panel dispatch gate — mutual exclusion needed no new code and is tested in both directions.
- Palette commits pass `bypassCooldown: true` to `toggleApplication`: a commit must not be droppable by the 400ms per-bundle cooldown (hide app → open palette → Enter is feasible inside the window), while the re-entry guard, confirmation/recovery pipeline, and the cooldown for real shortcut presses stay fully intact; the commit still stamps the cooldown to protect the next real press.
- Pre-push local Codex review (per `.claude/skills/pr-review-loop` Layer 1) found 7 P2 + 4 P3 before anything was pushed; all fixed in the five `fix:`/`docs:` commits (panel resize on result growth, warm-list resilience with scan-completion re-render, e2e sentinel exclusion, recipe-import drop, cooldown bypass, save-error surfacing on the General card, import-preview disable, localized app names at scan time, contains-tier ranking, recency-ordered empty state, architecture.md trigger-flow update).

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

684 tests in 54 suites pass: scoring tiers (incl. CJK containment and the contiguous-beats-loose regression), dispatch routing + panel-gate mutual exclusion both directions, cooldown-bypass repro (hide → commit inside 400ms), recorder/conflict/save-failure/import-preview lifecycles, recipe import drops sentinel rows, e2e-lib bats (27/28; the 1 failure reproduces identically on the pre-#356 baseline).

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Pending physical items:
- Palette opens from its shortcut over any app WITHOUT activating Wink or deactivating the frontmost app until commit; the text field accepts typing in the non-activating key panel (the highest-risk mechanism — TextField/field-editor in a `canBecomeKey` nonactivating panel was only exercised via unit-level fakes).
- Open-to-first-keystroke feels instant on a warm list (~50ms bound is structural; measure perceived latency live, including the one-tick deferred render under fast typing).
- Enter activates the top hit incl. launch-if-not-running; Escape zero side effects; panel resizes as results grow/shrink; hide app → palette → Enter within 400ms focuses it (cooldown bypass).
- Carbon AND Hyper registration of the trigger; conflict validation against an existing app shortcut in both directions; palette trigger while the #352 picker is open (and vice versa) is a silent no-op.
- zh-Hans: localized app names match (e.g. 微信), palette strings render translated.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

`docs/architecture.md`'s trigger-flow section now describes the sentinel dispatch branch and ad hoc commit path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
