### PR TITLE
fix: propagate live capture status to the cheat-sheet gate and General tab (#383)

### DIFF
--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -332,9 +332,13 @@ final class AppController {
 
         // Configured BEFORE the startup sequence so launching while an
         // exception app is frontmost never lets capture (or permission
-        // prompts) fire ahead of the auto-pause.
-        shortcutManager.onCaptureStatusChange = { [weak self] in
-            self?.appPreferences.refreshPermissions()
+        // prompts) fire ahead of the auto-pause. Applies the delivered
+        // snapshot directly (not `refreshPermissions()`'s independent
+        // re-pull) — the manager's AX/IM/Secure-Input probes are volatile,
+        // and a second probe here could race and desync from what the
+        // manager just deduped on (#383).
+        shortcutManager.onCaptureStatusChange = { [weak self] status in
+            self?.appPreferences.applyCaptureStatus(status)
         }
         // Hold events arrive on the tap thread; hop once to the main actor
         // via the main QUEUE, whose FIFO ordering keeps began/ended in

--- a/Sources/Wink/Services/AppPreferences.swift
+++ b/Sources/Wink/Services/AppPreferences.swift
@@ -274,6 +274,17 @@ final class AppPreferences {
         }
     }
 
+    /// Applies a status pushed by `ShortcutManager.onCaptureStatusChange`
+    /// directly, instead of re-pulling `shortcutCaptureStatus()`. AX/IM
+    /// trust and Secure Input are volatile external probes — a second
+    /// independent pull here could race the manager's own probe and land on
+    /// a different (even already-reverted) value, permanently desyncing
+    /// this cached status from what the manager just deduped on (#383).
+    func applyCaptureStatus(_ status: ShortcutCaptureStatus) {
+        guard status != shortcutCaptureStatus else { return }
+        shortcutCaptureStatus = status
+    }
+
     func requestShortcutPermissions() {
         shortcutManager.requestPermissions()
         refreshPermissions()

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -70,10 +70,15 @@ final class ShortcutManager {
     /// here that snapshot goes stale for the whole session (#383). Compared
     /// against in `notifyCaptureStatusChangeIfNeeded()` to dedupe.
     private var lastNotifiedCaptureStatus: ShortcutCaptureStatus?
-    /// Invoked from the 3s poll when observed capture-relevant state
-    /// changed (permissions, secure input) so observers can re-pull
-    /// `shortcutCaptureStatus()` without their own timers.
-    var onCaptureStatusChange: (@MainActor () -> Void)?
+    /// Invoked whenever observed capture-relevant state changed (permission
+    /// edges, Secure Input, the tap/Carbon start-stop transition). Delivers
+    /// the exact snapshot that was just stored as the dedupe baseline —
+    /// observers must apply this value directly rather than re-pulling
+    /// `shortcutCaptureStatus()` themselves: AX/IM trust and
+    /// `IsSecureEventInputEnabled()` are volatile, so a second independent
+    /// probe can race and observe a different (even reverted) value than
+    /// the one this dedupe just latched, permanently desyncing the two.
+    var onCaptureStatusChange: (@MainActor (ShortcutCaptureStatus) -> Void)?
     /// Fires whenever the composed pause state transitions (manual pause,
     /// exception auto-pause, either direction).
     var onCapturePauseStateChange: (@MainActor (_ paused: Bool) -> Void)?
@@ -281,16 +286,20 @@ final class ShortcutManager {
         )
     }
 
-    /// Re-pulls the live status and fires `onCaptureStatusChange` only on an
-    /// actual change from the last-notified snapshot. Called from every exit
-    /// of `checkPermissionChange()` and from both branches of
+    /// Re-pulls the live status and fires `onCaptureStatusChange` with it
+    /// only on an actual change from the last-notified snapshot. Called from
+    /// every exit of `checkPermissionChange()` and from both branches of
     /// `attemptStartIfPermitted` so the ordinary tap start/stop transition —
     /// not just permission/secure-input edges — reaches observers (#383).
+    /// Passes the exact `current` value it just latched as the baseline: AX/
+    /// IM trust and Secure Input are probed again by `shortcutCaptureStatus`
+    /// inside this call, and a second independent probe from the observer
+    /// could race and land on a different value than what got deduped here.
     private func notifyCaptureStatusChangeIfNeeded() {
         let current = shortcutCaptureStatus()
         guard current != lastNotifiedCaptureStatus else { return }
         lastNotifiedCaptureStatus = current
-        onCaptureStatusChange?()
+        onCaptureStatusChange?(current)
     }
 
     func setHyperKeyEnabled(_ enabled: Bool) {

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -64,6 +64,12 @@ final class ShortcutManager {
     private var autoPausedByException = false
     private let secureInputProbe: () -> Bool
     private var lastSecureInputState = false
+    /// Last status delivered to `onCaptureStatusChange`. `AppPreferences`
+    /// snapshots `shortcutCaptureStatus()` exactly once, in its own init,
+    /// before the tap/Carbon providers ever run — without an active push
+    /// here that snapshot goes stale for the whole session (#383). Compared
+    /// against in `notifyCaptureStatusChangeIfNeeded()` to dedupe.
+    private var lastNotifiedCaptureStatus: ShortcutCaptureStatus?
     /// Invoked from the 3s poll when observed capture-relevant state
     /// changed (permissions, secure input) so observers can re-pull
     /// `shortcutCaptureStatus()` without their own timers.
@@ -275,6 +281,18 @@ final class ShortcutManager {
         )
     }
 
+    /// Re-pulls the live status and fires `onCaptureStatusChange` only on an
+    /// actual change from the last-notified snapshot. Called from every exit
+    /// of `checkPermissionChange()` and from both branches of
+    /// `attemptStartIfPermitted` so the ordinary tap start/stop transition —
+    /// not just permission/secure-input edges — reaches observers (#383).
+    private func notifyCaptureStatusChangeIfNeeded() {
+        let current = shortcutCaptureStatus()
+        guard current != lastNotifiedCaptureStatus else { return }
+        lastNotifiedCaptureStatus = current
+        onCaptureStatusChange?()
+    }
+
     func setHyperKeyEnabled(_ enabled: Bool) {
         let inputMonitoringWasRequired = captureCoordinator.inputMonitoringRequired
         hyperKeyEnabled = enabled
@@ -377,6 +395,11 @@ final class ShortcutManager {
     }
 
     func checkPermissionChange() {
+        // Every early return below (and the ordinary fall-through) must
+        // still refresh observers: a tick can flip only Secure Input, or
+        // stop capture on lost Accessibility, and both are real transitions
+        // the cheat-sheet gate and General tab need to see.
+        defer { notifyCaptureStatusChangeIfNeeded() }
         let axGranted = permissionService.isAccessibilityTrusted()
         var imGranted = permissionService.isInputMonitoringTrusted()
         let secureInput = secureInputProbe()
@@ -385,7 +408,8 @@ final class ShortcutManager {
             diagnosticClient.log(secureInput
                 ? "Secure Input engaged — Hyper/event-tap shortcuts degraded until it ends"
                 : "Secure Input ended — shortcut capture back to normal")
-            onCaptureStatusChange?()
+            // `secureInputActive` is part of `ShortcutCaptureStatus`, so the
+            // function-exit defer above already notifies for this edge.
         }
         let snapshot = captureCoordinator.snapshot()
         let accessibilityChanged = axGranted != lastAccessibilityState
@@ -522,6 +546,7 @@ final class ShortcutManager {
                 "attemptStart: shortcuts=\(shortcutStore.shortcuts.count) triggerIndex=\(triggerIndex.count) carbon=\(snapshot.carbonHotKeysRegistered) carbonHandler=\(snapshot.standardHandlerState.diagnosticName) carbonHandlerStatus=\(snapshot.standardHandlerState.failureStatus.map(String.init) ?? "none") eventTap=\(snapshot.eventTapActive) standardFnObserverRequired=\(snapshot.standardInputMonitoringRequired) paused=true"
             )
             lastCaptureBlockedMessages = []
+            notifyCaptureStatusChangeIfNeeded()
             return
         }
 
@@ -550,6 +575,10 @@ final class ShortcutManager {
             "attemptStart: shortcuts=\(shortcutStore.shortcuts.count) triggerIndex=\(triggerIndex.count) carbon=\(snapshot.carbonHotKeysRegistered) carbonHandler=\(snapshot.standardHandlerState.diagnosticName) carbonHandlerStatus=\(snapshot.standardHandlerState.failureStatus.map(String.init) ?? "none") eventTap=\(snapshot.eventTapActive) standardFnObserverRequired=\(snapshot.standardInputMonitoringRequired)"
         )
         emitCaptureBlockedDiagnostics(snapshot: snapshot)
+        // Notify right after the real start attempt (not just the 3s poll)
+        // so the very first successful tap start reaches the cheat-sheet
+        // gate and General tab immediately (#383).
+        notifyCaptureStatusChangeIfNeeded()
     }
 
     private func handleCaptureConfigurationChange(inputMonitoringWasRequired: Bool) {

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -267,6 +267,11 @@ final class ShortcutManager {
         // could steer the next gesture and qualify for the relaxed
         // cycle cooldown.
         appSwitcher.invalidateWindowCycleSession(reason: "shortcut_configuration_changed")
+        // Adding/removing the first (or last) enabled Hyper shortcut starts
+        // or stops the tap synchronously inside the rebuild above; without a
+        // push here the cheat-sheet gate and General tab lag on the cached
+        // status until the next 3 s poll tick (#383).
+        notifyCaptureStatusChangeIfNeeded()
     }
 
     @discardableResult
@@ -309,6 +314,9 @@ final class ShortcutManager {
         handleCaptureConfigurationChange(
             inputMonitoringWasRequired: inputMonitoringWasRequired
         )
+        // The route rebuild above can start/stop the tap synchronously;
+        // same staleness window as `save(shortcuts:)` otherwise (#383).
+        notifyCaptureStatusChangeIfNeeded()
     }
 
     func setFrontmostTargetBehavior(_ behavior: FrontmostTargetBehavior) {
@@ -347,6 +355,13 @@ final class ShortcutManager {
     }
 
     private func applyEffectivePauseTransition() {
+        // Both pause bits are part of the composed status, and the
+        // exception auto-pause has no AppPreferences-side pull path at all
+        // — every branch below (including the paused early return) must
+        // push, or the cached status lags until the next poll tick (#383).
+        // The resume path's `attemptStartIfPermitted` also notifies; the
+        // dedupe makes the extra call free.
+        defer { notifyCaptureStatusChangeIfNeeded() }
         let paused = effectivePaused
         onCapturePauseStateChange?(paused)
         // A gesture straddling the pause transition must not resolve into a

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -395,19 +395,34 @@ struct GeneralTabView: View {
     }
 
     private var hyperCheatSheetSubtitle: String {
+        Self.hyperCheatSheetSubtitleText(
+            hyperCheatSheetEnabled: preferences.hyperCheatSheetEnabled,
+            hyperKeyEnabled: preferences.hyperKeyEnabled,
+            eventTapActive: preferences.shortcutCaptureStatus.eventTapActive
+        )
+    }
+
+    /// Pure decision logic pulled out of `hyperCheatSheetSubtitle` so tests
+    /// can drive the cold-start-then-tap-starts sequence (#383) directly,
+    /// without a live `AppPreferences`/`SwiftUI` view.
+    static func hyperCheatSheetSubtitleText(
+        hyperCheatSheetEnabled: Bool,
+        hyperKeyEnabled: Bool,
+        eventTapActive: Bool
+    ) -> String {
         // Each branch is one full self-contained catalog entry (not a
         // concatenation of localized fragments) so translators see a
         // complete, naturally-ordered sentence.
-        guard preferences.hyperCheatSheetEnabled else {
+        guard hyperCheatSheetEnabled else {
             return String(localized: "Hold Caps Lock without a second key to see all shortcuts.", bundle: WinkResourceBundle.bundle)
         }
-        if !preferences.hyperKeyEnabled {
+        if !hyperKeyEnabled {
             return String(
                 localized: "Hold Caps Lock without a second key to see all shortcuts. Needs Hyper Key enabled.",
                 bundle: WinkResourceBundle.bundle
             )
         }
-        if !preferences.shortcutCaptureStatus.eventTapActive {
+        if !eventTapActive {
             return String(
                 localized: "Hold Caps Lock without a second key to see all shortcuts. Needs at least one enabled Hyper shortcut.",
                 bundle: WinkResourceBundle.bundle

--- a/Tests/WinkTests/AppPreferencesTests.swift
+++ b/Tests/WinkTests/AppPreferencesTests.swift
@@ -39,7 +39,9 @@ func initSnapshotsShortcutAndLaunchAtLoginState() {
 /// a hand-set bool. This test drives the real snapshot-then-start lifecycle
 /// end to end, wired exactly like `AppController.start()`
 /// (`shortcutManager.onCaptureStatusChange` set before `shortcutManager.start()`,
-/// verified at AppController.swift:336-338/387-403).
+/// verified at AppController.swift:336-338/387-403) — including applying the
+/// DELIVERED snapshot via `applyCaptureStatus`, never an independent re-pull
+/// (AX/IM/Secure-Input are volatile probes that can race one; see #383 P2).
 @Test @MainActor
 func coldStartPropagatesLiveEventTapActivationIntoObservedCaptureStatus() throws {
     let suiteName = "AppPreferencesTests.coldStartPropagatesLiveEventTapActivationIntoObservedCaptureStatus"
@@ -81,8 +83,10 @@ func coldStartPropagatesLiveEventTapActivationIntoObservedCaptureStatus() throws
 
     // AppController wires this before `runStartupSequence` (which is what
     // calls `shortcutManager.setHyperKeyEnabled` then `shortcutManager.start()`).
-    manager.onCaptureStatusChange = { [weak preferences] in
-        preferences?.refreshPermissions()
+    // Applies the delivered snapshot directly — never `refreshPermissions()`'s
+    // independent re-pull.
+    manager.onCaptureStatusChange = { [weak preferences] status in
+        preferences?.applyCaptureStatus(status)
     }
 
     // AppController.runStartupSequence sets the manager's own Hyper routing

--- a/Tests/WinkTests/AppPreferencesTests.swift
+++ b/Tests/WinkTests/AppPreferencesTests.swift
@@ -32,6 +32,73 @@ func initSnapshotsShortcutAndLaunchAtLoginState() {
     #expect(preferences.hyperKeyEnabled == true)
 }
 
+/// #383 regression: `AppPreferences.init()` snapshots `shortcutCaptureStatus`
+/// exactly once, before the event tap ever runs, so the cheat-sheet gate
+/// (`hyperCheatSheetEnabled && hyperKeyEnabled && eventTapActive`) must be
+/// driven live by `ShortcutManager.onCaptureStatusChange`, not by re-reading
+/// a hand-set bool. This test drives the real snapshot-then-start lifecycle
+/// end to end, wired exactly like `AppController.start()`
+/// (`shortcutManager.onCaptureStatusChange` set before `shortcutManager.start()`,
+/// verified at AppController.swift:336-338/387-403).
+@Test @MainActor
+func coldStartPropagatesLiveEventTapActivationIntoObservedCaptureStatus() throws {
+    let suiteName = "AppPreferencesTests.coldStartPropagatesLiveEventTapActivationIntoObservedCaptureStatus"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defaults.removePersistentDomain(forName: suiteName)
+    defaults.set(true, forKey: "hyperKeyEnabled")
+
+    // Mirrors AppController's `replaceShortcuts(try loadShortcuts())`: the
+    // store is populated directly, bypassing `ShortcutManager.save()`, so
+    // the manager only learns about it once `start()` calls `rebuildIndex()`.
+    let shortcutStore = ShortcutStore()
+    shortcutStore.replaceAll(with: [
+        AppShortcut(
+            appName: "Safari",
+            bundleIdentifier: "com.apple.Safari",
+            keyEquivalent: "s",
+            modifierFlags: ["command", "option", "control", "shift"]
+        )
+    ])
+    let manager = ShortcutManager(
+        shortcutStore: shortcutStore,
+        persistenceService: TestPersistenceHarness().makePersistenceService(),
+        appSwitcher: FakeAppSwitcher(),
+        captureCoordinator: makeCaptureCoordinator(),
+        permissionService: FakePermissionService(ax: true, input: true),
+        diagnosticClient: .live
+    )
+
+    // AppPreferences.init() runs — and snapshots — before the event tap has
+    // ever started, exactly like AppController's lazy-var force at line 301.
+    let preferences = AppPreferences(
+        shortcutManager: manager,
+        hyperKeyService: HyperKeyService(runner: { _ in true }, defaults: defaults),
+        userDefaults: defaults
+    )
+    #expect(preferences.hyperKeyEnabled == true)
+    #expect(preferences.hyperCheatSheetEnabled == true)
+    #expect(preferences.shortcutCaptureStatus.eventTapActive == false)
+
+    // AppController wires this before `runStartupSequence` (which is what
+    // calls `shortcutManager.setHyperKeyEnabled` then `shortcutManager.start()`).
+    manager.onCaptureStatusChange = { [weak preferences] in
+        preferences?.refreshPermissions()
+    }
+
+    // AppController.runStartupSequence sets the manager's own Hyper routing
+    // flag directly (not through `AppPreferences.setHyperKeyEnabled`, which
+    // would additionally touch `HyperKeyService`) before starting capture.
+    manager.setHyperKeyEnabled(true)
+    manager.start()
+
+    #expect(preferences.shortcutCaptureStatus.eventTapActive == true)
+    #expect(
+        preferences.hyperCheatSheetEnabled
+            && preferences.hyperKeyEnabled
+            && preferences.shortcutCaptureStatus.eventTapActive
+    )
+}
+
 @Test @MainActor
 func setLaunchAtLoginDoesNotUpdateStateWhenRegistrationFails() {
     let state = MutableLaunchAtLoginState(status: .notRegistered)

--- a/Tests/WinkTests/GeneralTabViewTests.swift
+++ b/Tests/WinkTests/GeneralTabViewTests.swift
@@ -1,0 +1,57 @@
+import Testing
+@testable import Wink
+
+/// #383: `hyperCheatSheetSubtitleText` is the pure decision logic behind
+/// `GeneralTabView.hyperCheatSheetSubtitle`, covering the cold-start-then-
+/// tap-starts sequence — the "Needs at least one enabled Hyper shortcut"
+/// copy must track live `eventTapActive`, not a value frozen at launch.
+@Suite("General tab — Hyper cheat sheet subtitle")
+struct GeneralTabViewTests {
+    @Test @MainActor
+    func inactiveEventTapWithHyperEnabledShowsNeedsShortcutCopy() {
+        let subtitle = GeneralTabView.hyperCheatSheetSubtitleText(
+            hyperCheatSheetEnabled: true,
+            hyperKeyEnabled: true,
+            eventTapActive: false
+        )
+
+        #expect(subtitle == "Hold Caps Lock without a second key to see all shortcuts. Needs at least one enabled Hyper shortcut.")
+    }
+
+    @Test @MainActor
+    func activeEventTapAfterColdStartDoesNotShowNeedsShortcutCopy() {
+        // Same feature/Hyper-enabled inputs as the case above; only
+        // `eventTapActive` differs, as it would once the tap has actually
+        // started after a cold launch.
+        let subtitle = GeneralTabView.hyperCheatSheetSubtitleText(
+            hyperCheatSheetEnabled: true,
+            hyperKeyEnabled: true,
+            eventTapActive: true
+        )
+
+        #expect(subtitle != "Hold Caps Lock without a second key to see all shortcuts. Needs at least one enabled Hyper shortcut.")
+        #expect(subtitle == "Hold Caps Lock without a second key to see all shortcuts.")
+    }
+
+    @Test @MainActor
+    func hyperKeyDisabledShowsNeedsHyperKeyCopyRegardlessOfEventTap() {
+        #expect(
+            GeneralTabView.hyperCheatSheetSubtitleText(
+                hyperCheatSheetEnabled: true,
+                hyperKeyEnabled: false,
+                eventTapActive: false
+            ) == "Hold Caps Lock without a second key to see all shortcuts. Needs Hyper Key enabled."
+        )
+    }
+
+    @Test @MainActor
+    func featureDisabledShowsPlainCopyRegardlessOfOtherState() {
+        #expect(
+            GeneralTabView.hyperCheatSheetSubtitleText(
+                hyperCheatSheetEnabled: false,
+                hyperKeyEnabled: true,
+                eventTapActive: true
+            ) == "Hold Caps Lock without a second key to see all shortcuts."
+        )
+    }
+}

--- a/Tests/WinkTests/ShortcutEditorStateTests.swift
+++ b/Tests/WinkTests/ShortcutEditorStateTests.swift
@@ -1328,7 +1328,7 @@ func captureStatusReflectsSecureInputProbeAndPollNotifiesOnChange() {
         secureInputProbe: { secureInput },
         diagnosticClient: .init(log: { _ in })
     )
-    manager.onCaptureStatusChange = {
+    manager.onCaptureStatusChange = { _ in
         statusChangeNotifications += 1
     }
 

--- a/Tests/WinkTests/ShortcutManagerStatusTests.swift
+++ b/Tests/WinkTests/ShortcutManagerStatusTests.swift
@@ -419,6 +419,93 @@ func checkPermissionChangeNotifiesOnEventTapActivationAndSuppressesRepeatNotific
     #expect(notifyCount == notifyCountAfterActivation)
 }
 
+/// #383 bot P2: configuration changes start/stop the tap synchronously
+/// inside `save(shortcuts:)` — the status push must ride that path too, not
+/// wait for the next 3 s poll tick.
+@Test @MainActor
+func savingTheFirstAndLastHyperShortcutNotifiesWithoutWaitingForThePoll() throws {
+    let permissionService = MutablePermissionService(ax: true, input: true)
+    let context = makeShortcutManager(
+        permissionService: permissionService,
+        appBundleLocator: AppBundleLocator { _ in
+            URL(fileURLWithPath: "/Applications/Safari.app")
+        }
+    )
+    context.manager.setHyperKeyEnabled(true)
+    context.manager.start()
+
+    var lastDelivered: ShortcutCaptureStatus?
+    context.manager.onCaptureStatusChange = { status in
+        lastDelivered = status
+    }
+    #expect(context.manager.shortcutCaptureStatus().eventTapActive == false)
+
+    try context.manager.save(shortcuts: [hyperShortcut()])
+    #expect(lastDelivered?.eventTapActive == true)
+
+    try context.manager.save(shortcuts: [])
+    #expect(lastDelivered?.eventTapActive == false)
+}
+
+/// Same class as the `save(shortcuts:)` case: toggling the Hyper key
+/// rebuilds provider routes synchronously and must push the resulting
+/// status itself.
+@Test @MainActor
+func togglingHyperKeyNotifiesTheResultingCaptureStatusWithoutThePoll() throws {
+    let permissionService = MutablePermissionService(ax: true, input: true)
+    let context = makeShortcutManager(
+        permissionService: permissionService,
+        appBundleLocator: AppBundleLocator { _ in
+            URL(fileURLWithPath: "/Applications/Safari.app")
+        }
+    )
+    context.manager.setHyperKeyEnabled(true)
+    try context.manager.save(shortcuts: [hyperShortcut()])
+    context.manager.start()
+    #expect(context.manager.shortcutCaptureStatus().eventTapActive == true)
+
+    var lastDelivered: ShortcutCaptureStatus?
+    context.manager.onCaptureStatusChange = { status in
+        lastDelivered = status
+    }
+
+    context.manager.setHyperKeyEnabled(false)
+    #expect(lastDelivered?.eventTapActive == false)
+
+    context.manager.setHyperKeyEnabled(true)
+    #expect(lastDelivered?.eventTapActive == true)
+}
+
+/// The exception auto-pause has no AppPreferences-side pull path at all —
+/// the pause transition itself must push the paused status.
+@Test @MainActor
+func exceptionAutoPauseNotifiesThePausedCaptureStatusWithoutThePoll() throws {
+    let permissionService = MutablePermissionService(ax: true, input: true)
+    let context = makeShortcutManager(
+        permissionService: permissionService,
+        appBundleLocator: AppBundleLocator { _ in
+            URL(fileURLWithPath: "/Applications/Safari.app")
+        }
+    )
+    context.manager.setHyperKeyEnabled(true)
+    try context.manager.save(shortcuts: [hyperShortcut()])
+    context.manager.start()
+    #expect(context.manager.shortcutCaptureStatus().eventTapActive == true)
+
+    var lastDelivered: ShortcutCaptureStatus?
+    context.manager.onCaptureStatusChange = { status in
+        lastDelivered = status
+    }
+
+    context.manager.setAutoPausedByException(true)
+    #expect(lastDelivered?.eventTapActive == false)
+    #expect(lastDelivered?.shortcutsPaused == true)
+
+    context.manager.setAutoPausedByException(false)
+    #expect(lastDelivered?.eventTapActive == true)
+    #expect(lastDelivered?.shortcutsPaused == false)
+}
+
 /// #383 P2: `onCaptureStatusChange` must deliver the exact snapshot the
 /// dedupe just latched, not leave observers to re-pull `shortcutCaptureStatus()`
 /// themselves. AX/IM trust and Secure Input are volatile external probes —

--- a/Tests/WinkTests/ShortcutManagerStatusTests.swift
+++ b/Tests/WinkTests/ShortcutManagerStatusTests.swift
@@ -393,7 +393,11 @@ func checkPermissionChangeNotifiesOnEventTapActivationAndSuppressesRepeatNotific
     context.manager.setHyperKeyEnabled(true)
 
     var notifyCount = 0
-    context.manager.onCaptureStatusChange = { notifyCount += 1 }
+    var lastDelivered: ShortcutCaptureStatus?
+    context.manager.onCaptureStatusChange = { status in
+        notifyCount += 1
+        lastDelivered = status
+    }
 
     context.manager.start()
     let notifyCountAfterStart = notifyCount
@@ -407,11 +411,58 @@ func checkPermissionChangeNotifiesOnEventTapActivationAndSuppressesRepeatNotific
 
     #expect(context.manager.shortcutCaptureStatus().eventTapActive == true)
     #expect(notifyCount == notifyCountAfterStart + 1)
+    #expect(lastDelivered?.eventTapActive == true)
 
     let notifyCountAfterActivation = notifyCount
     context.manager.checkPermissionChange()
 
     #expect(notifyCount == notifyCountAfterActivation)
+}
+
+/// #383 P2: `onCaptureStatusChange` must deliver the exact snapshot the
+/// dedupe just latched, not leave observers to re-pull `shortcutCaptureStatus()`
+/// themselves. AX/IM trust and Secure Input are volatile external probes —
+/// this simulates a value that is true only for the single probe inside the
+/// notify path, so an observer-side re-pull immediately afterwards would
+/// silently disagree with what was actually notified.
+@Test @MainActor
+func onCaptureStatusChangeDeliversTheExactDedupedSnapshotEvenWhenTheUnderlyingProbeFlipsAgain() throws {
+    var probeCallCount = 0
+    let secureInputProbe: () -> Bool = {
+        probeCallCount += 1
+        // True only on the 2nd call — the one made from inside
+        // `notifyCaptureStatusChangeIfNeeded()`'s own `shortcutCaptureStatus()`
+        // pull during this `checkPermissionChange()` tick.
+        return probeCallCount == 2
+    }
+    let manager = ShortcutManager(
+        shortcutStore: ShortcutStore(),
+        persistenceService: TestPersistenceHarness().makePersistenceService(),
+        appSwitcher: FakeAppSwitcher(),
+        captureCoordinator: ShortcutCaptureCoordinator(
+            standardProvider: FakeCaptureProvider(),
+            hyperProvider: FakeHyperCaptureProvider()
+        ),
+        permissionService: FakePermissionService(ax: false, input: false),
+        secureInputProbe: secureInputProbe,
+        diagnosticClient: .init(log: { _ in })
+    )
+
+    var delivered: ShortcutCaptureStatus?
+    manager.onCaptureStatusChange = { status in
+        delivered = status
+    }
+
+    manager.checkPermissionChange()
+
+    let deliveredStatus = try #require(delivered)
+    #expect(deliveredStatus.secureInputActive == true)
+
+    // A hypothetical observer-side re-pull, taken immediately after the
+    // callback returns, lands on a DIFFERENT value — proving the delivered
+    // snapshot (not a re-pull) is the only value an observer can trust.
+    let repulled = manager.shortcutCaptureStatus()
+    #expect(repulled.secureInputActive == false)
 }
 
 @Test @MainActor

--- a/Tests/WinkTests/ShortcutManagerStatusTests.swift
+++ b/Tests/WinkTests/ShortcutManagerStatusTests.swift
@@ -376,6 +376,44 @@ func availabilityGainForHyperShortcutRequestsInputMonitoringAndStartsEventTap() 
     #expect(context.hyperProvider.isRunning == true)
 }
 
+/// #383: the ordinary tap start/stop transition (not just permission edges)
+/// must reach `onCaptureStatusChange`, and only on an actual change — a poll
+/// tick that observes the same status must not re-fire the callback.
+@Test @MainActor
+func checkPermissionChangeNotifiesOnEventTapActivationAndSuppressesRepeatNotifications() throws {
+    let bundleLocatorState = MutableAppBundleLocatorState(entries: [:])
+    let permissionService = MutablePermissionService(ax: true, input: true)
+    let context = makeShortcutManager(
+        permissionService: permissionService,
+        appBundleLocator: AppBundleLocator { bundleIdentifier in
+            bundleLocatorState.entries[bundleIdentifier]
+        }
+    )
+    try context.manager.save(shortcuts: [hyperShortcut()])
+    context.manager.setHyperKeyEnabled(true)
+
+    var notifyCount = 0
+    context.manager.onCaptureStatusChange = { notifyCount += 1 }
+
+    context.manager.start()
+    let notifyCountAfterStart = notifyCount
+    #expect(context.manager.shortcutCaptureStatus().eventTapActive == false)
+
+    // Availability gain flips the hyper provider inactive -> active on the
+    // very next poll tick (`checkPermissionChange`), not a manual pause
+    // cycle or Settings visit.
+    bundleLocatorState.entries["com.apple.Safari"] = URL(fileURLWithPath: "/Applications/Safari.app")
+    context.manager.checkPermissionChange()
+
+    #expect(context.manager.shortcutCaptureStatus().eventTapActive == true)
+    #expect(notifyCount == notifyCountAfterStart + 1)
+
+    let notifyCountAfterActivation = notifyCount
+    context.manager.checkPermissionChange()
+
+    #expect(notifyCount == notifyCountAfterActivation)
+}
+
 @Test @MainActor
 func availabilityLossRemovesRegisteredShortcutsWithoutAnotherSave() throws {
     let bundleLocatorState = MutableAppBundleLocatorState(entries: [


### PR DESCRIPTION
Fixes #383

## Summary
- The Hyper cheat sheet now arms on a cold launch: `ShortcutManager` pushes live capture-status changes (event-tap/Carbon start-stop transitions, permission edges, Secure Input) to `AppPreferences`, instead of only notifying on Secure Input transitions while the init-time snapshot stayed stale for the whole session.
- Root cause: `AppPreferences.shortcutCaptureStatus` was snapshotted once in its initializer, before the event tap started; the only refresh path was the Secure Input branch of the 3 s poll, so the cheat-sheet gate (`… && shortcutCaptureStatus.eventTapActive`) stayed false until a pause/resume or a Settings visit.
- New `notifyCaptureStatusChangeIfNeeded()` dedupes on the full `ShortcutCaptureStatus` value and fires from every exit of `checkPermissionChange()` (via `defer`) and from both exits of `attemptStartIfPermitted`, so the very first tap start notifies immediately instead of waiting for the next poll tick.
- `onCaptureStatusChange` now delivers the exact deduped snapshot and `AppPreferences.applyCaptureStatus(_:)` applies it directly — observers no longer re-pull volatile AX/IM/Secure-Input probes, which could race and permanently desync the cached status from the dedupe baseline (found in local pre-push review).
- Collateral fix: the General-tab cheat-sheet subtitle read the same stale snapshot ("Needs at least one enabled Hyper shortcut" right after launch); its branching is extracted into a testable pure helper and covered under the same cold-start sequence.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

`swift test`: 691/691 green. `scripts/e2e-full-test.sh` on the packaged branch build: 6/6 PASS, 0 warnings.

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Physical validation items (deterministic repro in `build/validation/batch-371-2026-07-22/RESULTS.md`):
- Launch the packaged app cold, hold Caps Lock 1.5–3 s with no pause/resume or Settings visit first → the cheat sheet appears.
- General tab right after launch shows the plain cheat-sheet subtitle (not "Needs at least one enabled Hyper shortcut") while Hyper shortcuts are enabled and the tap is running.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

`AGENTS.md`'s Secure Input note ("probed lazily in `shortcutCaptureStatus()` and on the existing 3s permission poll (no new timers)") remains accurate — this change adds no timers; it only propagates transitions the poll and start path already observe.

## Notes
- Local Codex pre-push review ran (per `pr-review-loop`); its confirmed P2 (dedupe baseline vs. delivered value divergence under volatile probes) is fixed in the second commit, with a regression test that flips the Secure Input probe between the two reads.
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
