### PR TITLE
fix: filter search-palette and recents candidates to regular-activation apps (#384)

### DIFF
--- a/Sources/Wink/Services/AppListProvider.swift
+++ b/Sources/Wink/Services/AppListProvider.swift
@@ -32,6 +32,7 @@ struct RunningApplicationSnapshot: Sendable {
     let bundleIdentifier: String?
     let localizedName: String?
     let bundleURL: URL?
+    let activationPolicy: NSApplication.ActivationPolicy
 }
 
 @MainActor
@@ -180,7 +181,12 @@ final class AppListProvider {
         var seen = Set(entries.map(\.id))
 
         for app in runningApplications {
-            guard let bid = app.bundleIdentifier,
+            // .accessory/.prohibited apps are background agents and embedded
+            // helpers (loginwindow, WindowManager, an app's own auxiliary
+            // process) — never user-facing switch targets, and some share a
+            // localizedName with their .regular parent (#384's WeChat case).
+            guard app.activationPolicy == .regular,
+                  let bid = app.bundleIdentifier,
                   !seen.contains(bid),
                   let url = app.bundleURL else { continue }
             let name = app.localizedName ?? url.deletingPathExtension().lastPathComponent
@@ -246,13 +252,25 @@ final class AppListProvider {
         guard let ids = client.loadRecents() else {
             // Seed from running apps if no recents file exists
             recentBundleIDs = runningApplications
+                .filter { $0.activationPolicy == .regular }
                 .compactMap(\.bundleIdentifier)
                 .filter { $0 != client.mainBundleIdentifier() }
                 .prefix(10)
                 .map { $0 }
             return
         }
-        recentBundleIDs = ids
+        // Conservative sanitation, not a general filter: only drop an id when
+        // the CURRENT running snapshot proves it's a non-.regular agent
+        // (loginwindow, WindowManager, ...). An id absent from the current
+        // snapshot is left alone — it may be a valid recent for an app that
+        // simply isn't running right now — so this can't wipe legitimate
+        // history, only evict the always-running agents #384 reported.
+        let nonRegularRunningIDs = Set(
+            runningApplications
+                .filter { $0.activationPolicy != .regular }
+                .compactMap(\.bundleIdentifier)
+        )
+        recentBundleIDs = ids.filter { !nonRegularRunningIDs.contains($0) }
     }
 
     private func saveRecents() {
@@ -275,7 +293,8 @@ extension AppListProvider.Client {
                 RunningApplicationSnapshot(
                     bundleIdentifier: app.bundleIdentifier,
                     localizedName: app.localizedName,
-                    bundleURL: app.bundleURL
+                    bundleURL: app.bundleURL,
+                    activationPolicy: app.activationPolicy
                 )
             }
         },

--- a/Sources/Wink/Services/AppListProvider.swift
+++ b/Sources/Wink/Services/AppListProvider.swift
@@ -185,6 +185,10 @@ final class AppListProvider {
             // helpers (loginwindow, WindowManager, an app's own auxiliary
             // process) — never user-facing switch targets, and some share a
             // localizedName with their .regular parent (#384's WeChat case).
+            // Trade-off: a legitimate .accessory app running from outside
+            // every scan root (e.g. launched from Downloads or an external
+            // volume) is knowingly excluded here too — the installed scan
+            // above already covers the legitimate standard-location case.
             guard app.activationPolicy == .regular,
                   let bid = app.bundleIdentifier,
                   !seen.contains(bid),
@@ -260,17 +264,30 @@ final class AppListProvider {
             return
         }
         // Conservative sanitation, not a general filter: only drop an id when
-        // the CURRENT running snapshot proves it's a non-.regular agent
-        // (loginwindow, WindowManager, ...). An id absent from the current
-        // snapshot is left alone — it may be a valid recent for an app that
-        // simply isn't running right now — so this can't wipe legitimate
-        // history, only evict the always-running agents #384 reported.
+        // BOTH (a) the CURRENT running snapshot proves it's a non-.regular
+        // process AND (b) it's absent from `allAppsByID` — i.e. it resolves
+        // to no installed app on any scan root. This targets exactly the
+        // #384 system agents (loginwindow, WindowManager, ...), which live
+        // under /System/Library/CoreServices outside every scan root and are
+        // no longer merged into `allApps`/`allAppsByID` by the filter above.
+        // A currently-.accessory id that DOES resolve in `allAppsByID` is a
+        // legitimate installed menu-bar-only app (Wink's toggle engine
+        // supports windowless .accessory targets, see
+        // docs/architecture.md:405) that a user could have picked from
+        // Settings — pruning it would wrongly evict a real recent. An id
+        // absent from the running snapshot entirely is left alone too — it
+        // may be a valid recent for an app that simply isn't running right
+        // now. `allAppsByID` is rebuilt just above (this method runs at the
+        // end of `applyRefresh`, after the `allApps`/`allAppsByID` assignment),
+        // so this check always sees the current-refresh installed set.
         let nonRegularRunningIDs = Set(
             runningApplications
                 .filter { $0.activationPolicy != .regular }
                 .compactMap(\.bundleIdentifier)
         )
-        recentBundleIDs = ids.filter { !nonRegularRunningIDs.contains($0) }
+        recentBundleIDs = ids.filter { id in
+            !nonRegularRunningIDs.contains(id) || allAppsByID[id] != nil
+        }
     }
 
     private func saveRecents() {

--- a/Tests/WinkTests/AppListProviderTests.swift
+++ b/Tests/WinkTests/AppListProviderTests.swift
@@ -272,13 +272,16 @@ func recentsSeedingExcludesNonRegularActivationPolicyApps() async {
 }
 
 @Test @MainActor
-func recentsSanitizationDropsCurrentlyRunningNonRegularIDsButKeepsNotRunningOnes() async {
+func recentsSanitizationDropsSystemAgentsButKeepsNotRunningOnes() async {
     let recorder = AppListProviderRecorder(now: Date(timeIntervalSinceReferenceDate: 650))
     let loginwindowURL = URL(fileURLWithPath: "/System/Library/CoreServices/loginwindow.app")
     let provider = AppListProvider(client: .init(
         now: { recorder.now },
         scanInstalledApps: {
             recorder.scanCallCount += 1
+            // loginwindow is outside every scan root, so it resolves in
+            // neither the scan nor allAppsByID — the second prong of the
+            // sanitization condition.
             return []
         },
         runningApplications: {
@@ -299,6 +302,43 @@ func recentsSanitizationDropsCurrentlyRunningNonRegularIDsButKeepsNotRunningOnes
     await provider.waitForRefreshForTesting()
 
     #expect(provider.recentBundleIDs == ["com.example.notRunning"])
+}
+
+@Test @MainActor
+func recentsSanitizationKeepsInstalledAccessoryAppEvenWhileCurrentlyRunning() async {
+    // Regression for a false positive found in review: a legitimate
+    // menu-bar-only app installed under a scan root (so it resolves in
+    // allAppsByID) must survive sanitization even though it currently runs
+    // as .accessory — Wink's toggle engine explicitly supports windowless
+    // .accessory targets (docs/architecture.md:405), and this is exactly
+    // the kind of app the Settings picker could have put into recents.
+    let recorder = AppListProviderRecorder(now: Date(timeIntervalSinceReferenceDate: 700))
+    let menuBarAppURL = URL(fileURLWithPath: "/Applications/MenuBarApp.app")
+    let provider = AppListProvider(client: .init(
+        now: { recorder.now },
+        scanInstalledApps: {
+            recorder.scanCallCount += 1
+            return [
+                AppEntry(id: "com.example.menubarapp", name: "MenuBarApp", url: menuBarAppURL),
+            ]
+        },
+        runningApplications: {
+            [
+                .init(bundleIdentifier: "com.example.menubarapp", localizedName: "MenuBarApp", bundleURL: menuBarAppURL, activationPolicy: .accessory),
+            ]
+        },
+        loadRecents: {
+            ["com.example.menubarapp"]
+        },
+        saveRecents: { _ in },
+        mainBundleIdentifier: { nil }
+    ))
+
+    provider.refreshIfNeeded()
+    await provider.waitForRefreshForTesting()
+
+    #expect(provider.recentBundleIDs == ["com.example.menubarapp"])
+    #expect(provider.recentApps.map(\.bundleIdentifier) == ["com.example.menubarapp"])
 }
 
 private final class AppListProviderRecorder: @unchecked Sendable {

--- a/Tests/WinkTests/AppListProviderTests.swift
+++ b/Tests/WinkTests/AppListProviderTests.swift
@@ -17,9 +17,9 @@ func refreshIfNeededMergesRunningAppsAndSeedsRecentsWhenStoredRecentsAreMissing(
         },
         runningApplications: {
             [
-                .init(bundleIdentifier: "com.apple.Safari", localizedName: "Safari", bundleURL: safariURL),
-                .init(bundleIdentifier: "com.apple.Terminal", localizedName: "Terminal", bundleURL: terminalURL),
-                .init(bundleIdentifier: nil, localizedName: "Broken", bundleURL: nil),
+                .init(bundleIdentifier: "com.apple.Safari", localizedName: "Safari", bundleURL: safariURL, activationPolicy: .regular),
+                .init(bundleIdentifier: "com.apple.Terminal", localizedName: "Terminal", bundleURL: terminalURL, activationPolicy: .regular),
+                .init(bundleIdentifier: nil, localizedName: "Broken", bundleURL: nil, activationPolicy: .regular),
             ]
         },
         loadRecents: { nil },
@@ -179,6 +179,126 @@ func appLookupHelpersSupportBundleIDAndExactNameMatching() async {
         "com.example.notes.one",
         "com.example.notes.two",
     ].sorted())
+}
+
+@Test @MainActor
+func refreshExcludesNonRegularActivationPolicyRunningApps() async {
+    let recorder = AppListProviderRecorder(now: Date(timeIntervalSinceReferenceDate: 500))
+    let safariURL = URL(fileURLWithPath: "/Applications/Safari.app")
+    let loginwindowURL = URL(fileURLWithPath: "/System/Library/CoreServices/loginwindow.app")
+    let viewBridgeURL = URL(fileURLWithPath: "/System/Library/ViewBridgeAuxiliary.app")
+    let provider = AppListProvider(client: .init(
+        now: { recorder.now },
+        scanInstalledApps: {
+            recorder.scanCallCount += 1
+            return []
+        },
+        runningApplications: {
+            [
+                .init(bundleIdentifier: "com.apple.Safari", localizedName: "Safari", bundleURL: safariURL, activationPolicy: .regular),
+                .init(bundleIdentifier: "com.apple.loginwindow", localizedName: "loginwindow", bundleURL: loginwindowURL, activationPolicy: .accessory),
+                .init(bundleIdentifier: "com.apple.ViewBridgeAuxiliary", localizedName: "ViewBridgeAuxiliary", bundleURL: viewBridgeURL, activationPolicy: .prohibited),
+            ]
+        },
+        loadRecents: { nil },
+        saveRecents: { _ in },
+        mainBundleIdentifier: { nil }
+    ))
+
+    provider.refreshIfNeeded()
+    await provider.waitForRefreshForTesting()
+
+    #expect(provider.allApps.map(\.bundleIdentifier) == ["com.apple.Safari"])
+}
+
+@Test @MainActor
+func refreshDedupesSharedLocalizedNameToTheRegularActivationPolicyApp() async {
+    // Mirrors #384's WeChat report: com.tencent.xinWeChat (.regular) and its
+    // embedded helper com.tencent.flue.WeChatAppEx (.accessory) both report
+    // localizedName "WeChat" — only the .regular one should surface.
+    let recorder = AppListProviderRecorder(now: Date(timeIntervalSinceReferenceDate: 550))
+    let weChatURL = URL(fileURLWithPath: "/Applications/WeChat.app")
+    let weChatHelperURL = URL(fileURLWithPath: "/Applications/WeChat.app/Contents/Helpers/WeChatAppEx.app")
+    let provider = AppListProvider(client: .init(
+        now: { recorder.now },
+        scanInstalledApps: {
+            recorder.scanCallCount += 1
+            return []
+        },
+        runningApplications: {
+            [
+                .init(bundleIdentifier: "com.tencent.xinWeChat", localizedName: "WeChat", bundleURL: weChatURL, activationPolicy: .regular),
+                .init(bundleIdentifier: "com.tencent.flue.WeChatAppEx", localizedName: "WeChat", bundleURL: weChatHelperURL, activationPolicy: .accessory),
+            ]
+        },
+        loadRecents: { nil },
+        saveRecents: { _ in },
+        mainBundleIdentifier: { nil }
+    ))
+
+    provider.refreshIfNeeded()
+    await provider.waitForRefreshForTesting()
+
+    #expect(provider.allApps.map(\.bundleIdentifier) == ["com.tencent.xinWeChat"])
+    #expect(provider.allApps.filter { $0.name == "WeChat" }.count == 1)
+}
+
+@Test @MainActor
+func recentsSeedingExcludesNonRegularActivationPolicyApps() async {
+    let recorder = AppListProviderRecorder(now: Date(timeIntervalSinceReferenceDate: 600))
+    let safariURL = URL(fileURLWithPath: "/Applications/Safari.app")
+    let windowManagerURL = URL(fileURLWithPath: "/System/Library/CoreServices/WindowManager.app")
+    let provider = AppListProvider(client: .init(
+        now: { recorder.now },
+        scanInstalledApps: {
+            recorder.scanCallCount += 1
+            return []
+        },
+        runningApplications: {
+            [
+                .init(bundleIdentifier: "com.apple.Safari", localizedName: "Safari", bundleURL: safariURL, activationPolicy: .regular),
+                .init(bundleIdentifier: "com.apple.WindowManager", localizedName: "WindowManager", bundleURL: windowManagerURL, activationPolicy: .accessory),
+            ]
+        },
+        loadRecents: { nil },
+        saveRecents: { _ in },
+        mainBundleIdentifier: { nil }
+    ))
+
+    provider.refreshIfNeeded()
+    await provider.waitForRefreshForTesting()
+
+    #expect(provider.recentBundleIDs == ["com.apple.Safari"])
+}
+
+@Test @MainActor
+func recentsSanitizationDropsCurrentlyRunningNonRegularIDsButKeepsNotRunningOnes() async {
+    let recorder = AppListProviderRecorder(now: Date(timeIntervalSinceReferenceDate: 650))
+    let loginwindowURL = URL(fileURLWithPath: "/System/Library/CoreServices/loginwindow.app")
+    let provider = AppListProvider(client: .init(
+        now: { recorder.now },
+        scanInstalledApps: {
+            recorder.scanCallCount += 1
+            return []
+        },
+        runningApplications: {
+            // loginwindow is currently running as an .accessory agent;
+            // com.example.notRunning isn't present at all in this snapshot.
+            [
+                .init(bundleIdentifier: "com.apple.loginwindow", localizedName: "loginwindow", bundleURL: loginwindowURL, activationPolicy: .accessory),
+            ]
+        },
+        loadRecents: {
+            ["com.apple.loginwindow", "com.example.notRunning"]
+        },
+        saveRecents: { _ in },
+        mainBundleIdentifier: { nil }
+    ))
+
+    provider.refreshIfNeeded()
+    await provider.waitForRefreshForTesting()
+
+    #expect(provider.recentBundleIDs == ["com.example.notRunning"])
 }
 
 private final class AppListProviderRecorder: @unchecked Sendable {


### PR DESCRIPTION
Fixes #384

## Summary
- The search palette (and the Settings app picker, which reads the same `AppListProvider`) no longer lists background agents and embedded helpers (`loginwindow`, `WindowManager`, `ViewBridgeAuxiliary`, `notificationcenterui`, WeChat's `WeChatAppEx` helper) as switch targets, and "WeChat" resolves to exactly one row.
- Root cause: `applyRefresh` merged every running app with no activation-policy filter, and `RunningApplicationSnapshot` didn't carry the policy, so nothing could filter on it. Recents seeding used the same unfiltered sequence.
- `RunningApplicationSnapshot` now carries `activationPolicy`; the running-app merge and the recents seeding are filtered to `.regular`.
- Persisted `recent-apps.json` is sanitized conservatively on load: an id is dropped only when the current running snapshot shows it as non-`.regular` AND it resolves to no installed app in `allAppsByID` — exactly the system agents from the issue, which live outside every scan root. Installed menu-bar-only (`.accessory`) apps a user legitimately picked stay in recents (Wink's toggle engine explicitly supports windowless non-regular targets, `docs/architecture.md:405`). The pruned list is only persisted by the next natural `saveRecents()`.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

`swift test`: 689/689 green (5 new provider tests incl. the two-WeChat dedupe and the installed-accessory-kept sanitization case). `scripts/e2e-full-test.sh` on the packaged branch build: 6/6 PASS, 0 warnings.

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Physical validation items (deterministic repro in `build/validation/batch-371-2026-07-22/RESULTS.md`):
- Empty-query palette shows only real apps (no `loginwindow`/`WindowManager`/`ViewBridgeAuxiliary` rows) and previously-persisted agent ids stop occupying recents slots.
- Query `we` returns exactly one WeChat row; `calcu` no longer returns `CoreSimulatorService`.
- Settings → app picker improves equally and still pins the frontmost-app sentinel entry.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Known trade-off (surfaced by local pre-push review, accepted deliberately): a `.accessory` app running from outside every scan root (e.g. launched from Downloads) is excluded from the running-app merge; the installed scan covers the legitimate standard-location case. Documented in the merge-filter comment.
- Agent ids that are in the persisted recents but NOT currently running are left alone by design (they can't be told apart from valid recents of not-running apps); they no longer display and age out naturally.
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
