### PR TITLE
fix: suppress deferred Hyper release during panel sessions (#385)

### DIFF
--- a/Sources/Wink/Protocols/EventTapManaging.swift
+++ b/Sources/Wink/Protocols/EventTapManaging.swift
@@ -19,6 +19,11 @@ protocol EventTapManaging {
     func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?)
     func updatePhasedChords(_ keyPresses: Set<KeyPress>)
     func setPhasedKeyObserver(_ observer: (@MainActor @Sendable (KeyPress, KeyEventPhase) -> Void)?)
+    /// See `EventTapBox.setHyperReleaseDeferralSuppressed(_:)` (#385).
+    /// Declared here (not just on the concrete manager) so it dispatches
+    /// through the protocol witness table like the other optional
+    /// capabilities below.
+    func setHyperReleaseDeferralSuppressed(_ suppressed: Bool)
 }
 
 extension EventTapManaging {
@@ -29,4 +34,7 @@ extension EventTapManaging {
     // defaults keep pre-phase fakes compiling with dynamic dispatch intact.
     func updatePhasedChords(_ keyPresses: Set<KeyPress>) {}
     func setPhasedKeyObserver(_ observer: (@MainActor @Sendable (KeyPress, KeyEventPhase) -> Void)?) {}
+    // Sync no-op default: only the live event-tap manager carries the
+    // toggle-quirk deferral state this suppresses.
+    func setHyperReleaseDeferralSuppressed(_ suppressed: Bool) {}
 }

--- a/Sources/Wink/Protocols/ShortcutCaptureProvider.swift
+++ b/Sources/Wink/Protocols/ShortcutCaptureProvider.swift
@@ -95,10 +95,18 @@ extension ShortcutCaptureProvider {
 protocol HyperShortcutCaptureProvider: ShortcutCaptureProvider {
     func setHyperKeyEnabled(_ enabled: Bool)
     func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?)
+    /// Suppresses (or restores) the F19 toggle-quirk release deferral for
+    /// the duration of an interactive panel session (#385). Declared here
+    /// so it dispatches dynamically like `setHyperHoldObserver`, not just on
+    /// the concrete event-tap provider.
+    func setHyperReleaseDeferralSuppressed(_ suppressed: Bool)
 }
 
 extension HyperShortcutCaptureProvider {
     // Sync no-op default; only the live event-tap provider surfaces
     // Hyper hold phases.
     func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?) {}
+    // Sync no-op default; only the live event-tap provider carries the
+    // toggle-quirk deferral state.
+    func setHyperReleaseDeferralSuppressed(_ suppressed: Bool) {}
 }

--- a/Sources/Wink/Services/EventTapCaptureProvider.swift
+++ b/Sources/Wink/Services/EventTapCaptureProvider.swift
@@ -4,6 +4,7 @@ import AppKit
 final class EventTapCaptureProvider: HyperShortcutCaptureProvider {
     private let manager: any EventTapManaging
     private var pendingHyperKeyEnabled = false
+    private var pendingHyperReleaseDeferralSuppressed = false
     private var registeredShortcuts: Set<KeyPress> = []
 
     init(manager: any EventTapManaging = EventTapManager()) {
@@ -31,6 +32,7 @@ final class EventTapCaptureProvider: HyperShortcutCaptureProvider {
         }
         if result == .started {
             manager.setHyperKeyEnabled(pendingHyperKeyEnabled)
+            manager.setHyperReleaseDeferralSuppressed(pendingHyperReleaseDeferralSuppressed)
         }
     }
 
@@ -50,6 +52,11 @@ final class EventTapCaptureProvider: HyperShortcutCaptureProvider {
 
     func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?) {
         manager.setHyperHoldObserver(observer)
+    }
+
+    func setHyperReleaseDeferralSuppressed(_ suppressed: Bool) {
+        pendingHyperReleaseDeferralSuppressed = suppressed
+        manager.setHyperReleaseDeferralSuppressed(suppressed)
     }
 
     func updatePhasedChords(_ keyPresses: Set<KeyPress>) {

--- a/Sources/Wink/Services/EventTapManager.swift
+++ b/Sources/Wink/Services/EventTapManager.swift
@@ -239,8 +239,12 @@ func handleEventTapEvent(
                 // physical press (toggle quirk). If keyUp arrives within 80ms of
                 // keyDown, keep _isHyperHeld true — it will be cleared when the next
                 // non-F19 keyDown is processed or by a later "real" keyUp.
+                // Suppressed (#385, e.g. an interactive panel session is open):
+                // never defer, regardless of elapsed — the deferral exists so a
+                // quick tap can act as Hyper for the NEXT keystroke, which is
+                // exactly what would eat a panel's first character.
                 let elapsed = event.timestamp - box._hyperKeyDownTimestamp
-                if elapsed > hyperKeyToggleQuirkThresholdNs {
+                if box._hyperReleaseDeferralSuppressed || elapsed > hyperKeyToggleQuirkThresholdNs {
                     box._isHyperHeld = false
                     box._hyperKeyUpDeferred = false
                 } else {
@@ -489,6 +493,7 @@ final class EventTapManager: EventTapManaging {
         box.phasedChords = phasedKeyPresses
         box.setPhasedKeyObserver(wrappedPhasedObserver(generation: generation))
         box.setHyperKey(enabled: hyperKeyEnabled)
+        box.setHyperReleaseDeferralSuppressed(hyperReleaseDeferralSuppressed)
         ownershipLedger.boxCreates += 1
         let session = EventTapOwnedSession(
             generation: generation,
@@ -604,6 +609,7 @@ final class EventTapManager: EventTapManaging {
     private var phasedKeyPresses: Set<KeyPress> = []
     private var phasedKeyObserver: (@MainActor @Sendable (KeyPress, KeyEventPhase) -> Void)?
     private var hyperKeyEnabled = false
+    private var hyperReleaseDeferralSuppressed = false
 
     func setHyperHoldObserver(_ observer: (@Sendable (HyperHoldEvent) -> Void)?) {
         hyperHoldObserver = observer
@@ -614,6 +620,19 @@ final class EventTapManager: EventTapManaging {
     func setHyperKeyEnabled(_ enabled: Bool) {
         hyperKeyEnabled = enabled
         owner?.box.setHyperKey(enabled: enabled)
+    }
+
+    /// See `EventTapBox.setHyperReleaseDeferralSuppressed(_:)`. Rare,
+    /// main-actor initiated — never called from the tap callback itself.
+    /// Persisted at the manager level (mirrors `hyperKeyEnabled` above) and
+    /// reseeded onto every freshly created box in `start()`: a full
+    /// stop/start cycle mid-session (a fresh `EventTapBox`, not the
+    /// in-place recreation `recreateEventTap` does on the SAME box) would
+    /// otherwise silently drop back to ordinary toggle-quirk behavior while
+    /// the panel session that requested suppression is still open.
+    func setHyperReleaseDeferralSuppressed(_ suppressed: Bool) {
+        hyperReleaseDeferralSuppressed = suppressed
+        owner?.box.setHyperReleaseDeferralSuppressed(suppressed)
     }
 
     /// Called on main thread from async dispatch. Applies debounce then calls handler.
@@ -1219,6 +1238,10 @@ final class EventTapBox: @unchecked Sendable {
     /// When true, an instant F19 keyUp was ignored; the next non-F19 keyDown
     /// should clear _isHyperHeld regardless of whether the combo is registered.
     fileprivate var _hyperKeyUpDeferred: Bool = false
+    /// When true (an interactive panel session is active, #385), the F19
+    /// toggle-quirk deferral never arms — every release resolves the held
+    /// state immediately. See `setHyperReleaseDeferralSuppressed(_:)`.
+    fileprivate var _hyperReleaseDeferralSuppressed: Bool = false
     /// True once F19 has been received via keyDown; prevents the flagsChanged
     /// handler from double-toggling _isHyperHeld.
     fileprivate var _f19ReceivedViaKeyDown: Bool = false
@@ -1254,6 +1277,34 @@ final class EventTapBox: @unchecked Sendable {
     var isHyperHeld: Bool {
         get { withLock { _isHyperHeld } }
         set { withLock { _isHyperHeld = newValue } }
+    }
+
+    /// Suppresses the F19 toggle-quirk release deferral for as long as an
+    /// interactive panel session is active (#385). This is session-scoped,
+    /// not a one-shot clear: the chord that opens a panel is swallowed on
+    /// its keyDown, but F19's own physical release routinely arrives AFTER
+    /// the panel is already open and the session has started — so a
+    /// point-in-time clear at "session opened" cannot resolve a deferral
+    /// that hasn't been armed yet. Suppressing the whole window means that
+    /// late release — and any bare Caps Lock tap landing mid-session —
+    /// resolves immediately instead of arming a deferral that would eat the
+    /// panel's next keystroke. Turning suppression on also resolves any
+    /// deferral already pending; turning it off restores ordinary
+    /// toggle-quirk behavior for the next physical tap. A genuine ongoing
+    /// hold (no deferral involved) is untouched either way.
+    func setHyperReleaseDeferralSuppressed(_ suppressed: Bool) {
+        withLock {
+            _hyperReleaseDeferralSuppressed = suppressed
+            if suppressed && _hyperKeyUpDeferred {
+                _isHyperHeld = false
+                _hyperKeyUpDeferred = false
+            }
+        }
+    }
+
+    /// Test/introspection seam mirroring `hyperKeyEnabled`'s getter shape.
+    var hyperReleaseDeferralSuppressed: Bool {
+        withLock { _hyperReleaseDeferralSuppressed }
     }
 
     /// Atomically update hyperKeyEnabled and clear isHyperHeld when disabling.

--- a/Sources/Wink/Services/ShortcutCaptureCoordinator.swift
+++ b/Sources/Wink/Services/ShortcutCaptureCoordinator.swift
@@ -129,6 +129,11 @@ final class ShortcutCaptureCoordinator {
         hyperProvider.setHyperHoldObserver(observer)
     }
 
+    /// See `HyperShortcutCaptureProvider.setHyperReleaseDeferralSuppressed(_:)` (#385).
+    func setHyperReleaseDeferralSuppressed(_ suppressed: Bool) {
+        hyperProvider.setHyperReleaseDeferralSuppressed(suppressed)
+    }
+
     /// Single consumer for both routes' phased (down/up) deliveries.
     /// Providers store the observer independently of their running state, so
     /// setting it once at wiring time survives provider stop/start cycles.

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -209,6 +209,15 @@ final class ShortcutManager {
         // gesture that slipped in around the session boundary so a stale
         // deadline cannot resurrect the picker the user just dismissed.
         holdGestureArbiter?.reset()
+        // #385: suppress (not merely clear) the F19 toggle-quirk release
+        // deferral for the whole session, on both transitions. A one-shot
+        // clear at open time cannot work — the chord that opens the panel is
+        // swallowed on its keyDown, but F19's own physical release routinely
+        // arrives AFTER the session has already started, so the deferral it
+        // would arm hasn't happened yet at open time. Session-scoped
+        // suppression catches that late release (and any bare Caps Lock tap
+        // landing mid-session) without touching a genuine ongoing hold.
+        captureCoordinator.setHyperReleaseDeferralSuppressed(active)
     }
 
     private func handleHoldGesture(_ keyPress: KeyPress) {

--- a/Tests/WinkTests/EventTapCaptureProviderTests.swift
+++ b/Tests/WinkTests/EventTapCaptureProviderTests.swift
@@ -8,6 +8,7 @@ private final class FakeEventTapManager: EventTapManaging {
     private(set) var isRunning = false
     private(set) var registeredShortcuts: Set<KeyPress> = []
     private(set) var setHyperEnabledCalls: [(enabled: Bool, whileRunning: Bool)] = []
+    private(set) var setHyperReleaseDeferralSuppressedCalls: [(suppressed: Bool, whileRunning: Bool)] = []
 
     func start(onKeyPress: @escaping @MainActor (KeyPress) -> Bool) -> EventTapStartResult {
         isRunning = true
@@ -24,6 +25,10 @@ private final class FakeEventTapManager: EventTapManaging {
 
     func setHyperKeyEnabled(_ enabled: Bool) {
         setHyperEnabledCalls.append((enabled: enabled, whileRunning: isRunning))
+    }
+
+    func setHyperReleaseDeferralSuppressed(_ suppressed: Bool) {
+        setHyperReleaseDeferralSuppressedCalls.append((suppressed: suppressed, whileRunning: isRunning))
     }
 }
 
@@ -49,5 +54,29 @@ func pendingHyperEnableIsReappliedAfterEventTapStarts() {
     #expect(
         manager.setHyperEnabledCalls.contains(where: { $0.enabled == true && $0.whileRunning }),
         "Hyper enable should be replayed after the event tap is running."
+    )
+}
+
+@Test @MainActor
+func pendingHyperReleaseDeferralSuppressionIsReappliedAfterEventTapStarts() {
+    // #385: a panel session can suppress the release deferral before the
+    // provider has an underlying running tap (e.g. immediately after a
+    // stop/start cycle); the suppression must survive to be replayed once
+    // the tap is actually running, same shape as pendingHyperKeyEnabled.
+    let manager = FakeEventTapManager()
+    let provider = EventTapCaptureProvider(manager: manager)
+
+    provider.setHyperReleaseDeferralSuppressed(true)
+
+    #expect(manager.setHyperReleaseDeferralSuppressedCalls.count == 1)
+    #expect(manager.setHyperReleaseDeferralSuppressedCalls[0].suppressed == true)
+    #expect(manager.setHyperReleaseDeferralSuppressedCalls[0].whileRunning == false)
+
+    provider.start { _ in }
+
+    #expect(manager.isRunning == true)
+    #expect(
+        manager.setHyperReleaseDeferralSuppressedCalls.contains(where: { $0.suppressed == true && $0.whileRunning }),
+        "Suppression should be replayed after the event tap is running."
     )
 }

--- a/Tests/WinkTests/EventTapManagerOwnershipTests.swift
+++ b/Tests/WinkTests/EventTapManagerOwnershipTests.swift
@@ -239,6 +239,14 @@ struct EventTapManagerOwnedSessionTests {
 
         #expect(manager.start { _ in true } == .started)
         manager.setHyperKeyEnabled(true)
+        // #385: a full stop/start cycle allocates a brand-new EventTapBox
+        // (unlike recreateEventTap's in-place tap/source swap on the SAME
+        // box — see the lifecycle note on
+        // EventTapManager.setHyperReleaseDeferralSuppressed). If a panel
+        // session is still active across such a restart, the fresh box must
+        // start pre-suppressed rather than silently reverting to ordinary
+        // toggle-quirk behavior mid-session.
+        manager.setHyperReleaseDeferralSuppressed(true)
         let firstThread = runtime.threads[0]
         let firstBox = runtime.boxes[0]
         firstThread.simulateUnexpectedExit()
@@ -259,6 +267,7 @@ struct EventTapManagerOwnedSessionTests {
         #expect(restarted.boxOwned == 1)
         #expect(restarted.threadOwned == 1)
         #expect(runtime.boxes[1].value?.hyperKeyEnabled == true)
+        #expect(runtime.boxes[1].value?.hyperReleaseDeferralSuppressed == true)
 
         manager.stop()
     }

--- a/Tests/WinkTests/SearchPaletteDispatchTests.swift
+++ b/Tests/WinkTests/SearchPaletteDispatchTests.swift
@@ -43,6 +43,9 @@ private final class FakeCaptureProvider: ShortcutCaptureProvider {
 @MainActor
 private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
     var isRunning = false
+    /// Records every `setHyperReleaseDeferralSuppressed` call in order, so
+    /// tests can assert both the values and the transition sequence.
+    private(set) var hyperReleaseDeferralSuppressionCalls: [Bool] = []
     private var onKeyPress: (@MainActor @Sendable (KeyPress) -> Void)?
 
     var registrationState: ShortcutCaptureRegistrationState {
@@ -59,6 +62,10 @@ private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
 
     func updateRegisteredShortcuts(_ keyPresses: Set<KeyPress>) {}
     func setHyperKeyEnabled(_ enabled: Bool) {}
+
+    func setHyperReleaseDeferralSuppressed(_ suppressed: Bool) {
+        hyperReleaseDeferralSuppressionCalls.append(suppressed)
+    }
 }
 
 private struct FakePermissionService: PermissionServicing {
@@ -115,10 +122,16 @@ private func realAppShortcutKeyPress() -> KeyPress {
 @MainActor
 private func makeContext(
     shortcuts: [AppShortcut]
-) -> (manager: ShortcutManager, appSwitcher: RecordingAppSwitcher, standardProvider: FakeCaptureProvider) {
+) -> (
+    manager: ShortcutManager,
+    appSwitcher: RecordingAppSwitcher,
+    standardProvider: FakeCaptureProvider,
+    hyperProvider: FakeHyperCaptureProvider
+) {
     let shortcutStore = ShortcutStore()
     shortcutStore.replaceAll(with: shortcuts)
     let standardProvider = FakeCaptureProvider()
+    let hyperProvider = FakeHyperCaptureProvider()
     let appSwitcher = RecordingAppSwitcher()
     let manager = ShortcutManager(
         shortcutStore: shortcutStore,
@@ -126,7 +139,7 @@ private func makeContext(
         appSwitcher: appSwitcher,
         captureCoordinator: ShortcutCaptureCoordinator(
             standardProvider: standardProvider,
-            hyperProvider: FakeHyperCaptureProvider()
+            hyperProvider: hyperProvider
         ),
         permissionService: FakePermissionService(),
         appBundleLocator: TestAppBundleLocator(entries: [
@@ -135,7 +148,7 @@ private func makeContext(
         diagnosticClient: .init(log: { _ in })
     )
     manager.start()
-    return (manager, appSwitcher, standardProvider)
+    return (manager, appSwitcher, standardProvider, hyperProvider)
 }
 
 // MARK: - Dispatch branch
@@ -221,4 +234,33 @@ func dispatchResumesOnceTheInteractivePanelSessionEnds() throws {
     context.manager.setInteractivePanelSessionActive(false)
     context.standardProvider.emit(searchPaletteTriggerKeyPress())
     #expect(firedCount == 1)
+}
+
+// MARK: - #385: session-scoped Hyper release-deferral suppression dispatch
+
+@Test @MainActor
+func openingTheInteractivePanelSessionSuppressesTheHyperProvidersReleaseDeferral() throws {
+    let context = makeContext(shortcuts: [searchPaletteTriggerShortcut()])
+
+    // Proves the dispatch path from ShortcutManager through
+    // ShortcutCaptureCoordinator reaches the hyper provider's
+    // setHyperReleaseDeferralSuppressed(true) through the protocol type
+    // (dynamic dispatch via `any HyperShortcutCaptureProvider`), not a
+    // concrete EventTapCaptureProvider/EventTapManager reference.
+    context.manager.setInteractivePanelSessionActive(true)
+
+    #expect(context.hyperProvider.hyperReleaseDeferralSuppressionCalls == [true])
+}
+
+@Test @MainActor
+func closingTheInteractivePanelSessionLiftsTheHyperProvidersReleaseDeferralSuppression() throws {
+    let context = makeContext(shortcuts: [searchPaletteTriggerShortcut()])
+
+    // Unlike a one-shot clear, suppression must be lifted on close too —
+    // otherwise every session after the first would permanently disable the
+    // toggle-quirk deferral. Both transitions reach the provider, in order.
+    context.manager.setInteractivePanelSessionActive(true)
+    context.manager.setInteractivePanelSessionActive(false)
+
+    #expect(context.hyperProvider.hyperReleaseDeferralSuppressionCalls == [true, false])
 }

--- a/Tests/WinkTests/WinkTests.swift
+++ b/Tests/WinkTests/WinkTests.swift
@@ -346,6 +346,140 @@ struct EventTapManagerDeliveryTests {
         #expect(result != nil, "A should pass through — no Hyper held after disable")
     }
 
+    // MARK: - #385: session-scoped suppression of the toggle-quirk deferral
+
+    @Test
+    func suppressingReleaseDeferralBeforeF19UpKeepsThePanelsFirstKeystrokePlain() {
+        // The realistic physical ordering (the P1 gap in a prior point-in-time
+        // "clear" fix): the panel opens on the chord's keyDown and suppression
+        // engages within a few ms — well BEFORE F19's own physical release,
+        // which can still land inside the 80ms toggle-quirk window. Session
+        // suppression must stop that later release from ever arming a
+        // deferral in the first place, not just resolve one already pending.
+        let f19Down = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: true)
+        let chordKeyPress = KeyPress(
+            keyCode: CGKeyCode(kVK_Space),
+            modifiers: [.command, .option, .control, .shift]
+        )
+        let chordDown = makeKeyEvent(CGKeyCode(kVK_Space), modifiers: [], keyDown: true)
+        let f19Up = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: false)
+        f19Up.timestamp = f19Down.timestamp + 1_000_000  // 1ms → inside the quirk window
+
+        let box = EventTapBox()
+        box.setHyperKey(enabled: true)
+        box.registeredShortcuts = [chordKeyPress]
+
+        #expect(handleEventTapEvent(type: .keyDown, event: f19Down, box: box) == nil)
+        #expect(
+            handleEventTapEvent(type: .keyDown, event: chordDown, box: box) == nil,
+            "Hyper+Space should be swallowed to open the panel"
+        )
+
+        // Simulates ShortcutManager.setInteractivePanelSessionActive(true):
+        // the panel opens on the chord's keyDown, before F19's physical
+        // release has even arrived.
+        box.setHyperReleaseDeferralSuppressed(true)
+
+        #expect(handleEventTapEvent(type: .keyUp, event: f19Up, box: box) == nil)
+        #expect(box.isHyperHeld == false, "a suppressed release must resolve immediately, never defer")
+
+        let charEvent = makeKeyEvent(CGKeyCode(kVK_ANSI_A), modifiers: [], keyDown: true)
+        let originalFlags = charEvent.flags
+        let result = handleEventTapEvent(type: .keyDown, event: charEvent, box: box)
+
+        #expect(result != nil, "the panel's first character must pass through unswallowed")
+        #expect(charEvent.flags == originalFlags, "flags must not get the Hyper union injected")
+    }
+
+    @Test
+    func suppressingReleaseDeferralAfterItIsAlreadyArmedResolvesItImmediately() {
+        // The synthetic-harness ordering (F19's release beats the panel's
+        // suppression call): the deferral is already pending when
+        // suppression turns on. Turning suppression on must resolve an
+        // already-armed deferral too, not only prevent future ones.
+        let f19Down = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: true)
+        let chordKeyPress = KeyPress(
+            keyCode: CGKeyCode(kVK_Space),
+            modifiers: [.command, .option, .control, .shift]
+        )
+        let chordDown = makeKeyEvent(CGKeyCode(kVK_Space), modifiers: [], keyDown: true)
+        let f19Up = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: false)
+        f19Up.timestamp = f19Down.timestamp + 1_000_000  // 1ms → inside the quirk window
+
+        let box = EventTapBox()
+        box.setHyperKey(enabled: true)
+        box.registeredShortcuts = [chordKeyPress]
+
+        #expect(handleEventTapEvent(type: .keyDown, event: f19Down, box: box) == nil)
+        #expect(
+            handleEventTapEvent(type: .keyDown, event: chordDown, box: box) == nil,
+            "Hyper+Space should be swallowed to open the panel"
+        )
+        #expect(handleEventTapEvent(type: .keyUp, event: f19Up, box: box) == nil)
+        #expect(box.isHyperHeld == true, "instant release should be deferred, not cleared")
+
+        box.setHyperReleaseDeferralSuppressed(true)
+        #expect(box.isHyperHeld == false, "an already-armed deferral must resolve when suppression engages")
+
+        let charEvent = makeKeyEvent(CGKeyCode(kVK_ANSI_A), modifiers: [], keyDown: true)
+        let originalFlags = charEvent.flags
+        let result = handleEventTapEvent(type: .keyDown, event: charEvent, box: box)
+
+        #expect(result != nil, "the panel's first character must pass through unswallowed")
+        #expect(charEvent.flags == originalFlags, "flags must not get the Hyper union injected")
+    }
+
+    @Test
+    func suppressingReleaseDeferralLeavesAGenuinePhysicalHoldUntouched() {
+        // Scoped strictly to the release deferral: a real, ongoing F19 hold
+        // (no keyUp at all) must survive suppression being engaged mid-hold.
+        let f19Down = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: true)
+        let box = EventTapBox()
+        box.setHyperKey(enabled: true)
+        box.setHyperReleaseDeferralSuppressed(true)
+
+        #expect(handleEventTapEvent(type: .keyDown, event: f19Down, box: box) == nil)
+        #expect(box.isHyperHeld == true, "F19 down must still set held state while suppressed")
+
+        let hyperShortcut = KeyPress(
+            keyCode: CGKeyCode(kVK_ANSI_A),
+            modifiers: [.command, .option, .control, .shift]
+        )
+        box.registeredShortcuts = [hyperShortcut]
+        let aEvent = makeKeyEvent(CGKeyCode(kVK_ANSI_A), modifiers: [], keyDown: true)
+        let result = handleEventTapEvent(type: .keyDown, event: aEvent, box: box)
+        #expect(result == nil, "Hyper+A should still be swallowed — the hold is still live")
+    }
+
+    @Test
+    func liftingSuppressionRestoresTheToggleQuirkDeferral() {
+        // Once the panel session ends, ordinary toggle-quirk behavior (a
+        // quick Caps Lock tap acts as Hyper for exactly the next keystroke)
+        // must return.
+        let box = EventTapBox()
+        box.setHyperKey(enabled: true)
+        box.setHyperReleaseDeferralSuppressed(true)
+        box.setHyperReleaseDeferralSuppressed(false)
+
+        let f19Down = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: true)
+        let f19Up = makeKeyEvent(HyperKeyService.f19KeyCode, modifiers: [], keyDown: false)
+        f19Up.timestamp = f19Down.timestamp + 1_000_000  // 1ms → inside the quirk window
+
+        #expect(handleEventTapEvent(type: .keyDown, event: f19Down, box: box) == nil)
+        #expect(handleEventTapEvent(type: .keyUp, event: f19Up, box: box) == nil)
+        #expect(box.isHyperHeld == true, "instant release should defer again once suppression is lifted")
+
+        let hyperA = KeyPress(
+            keyCode: CGKeyCode(kVK_ANSI_A),
+            modifiers: [.command, .option, .control, .shift]
+        )
+        box.registeredShortcuts = [hyperA]
+        let aEvent = makeKeyEvent(CGKeyCode(kVK_ANSI_A), modifiers: [], keyDown: true)
+        let result = handleEventTapEvent(type: .keyDown, event: aEvent, box: box)
+        #expect(result == nil, "Hyper+A should be swallowed — the deferred union still injects once")
+        #expect(box.isHyperHeld == false, "the deferred keyUp resolves after that one keyDown")
+    }
+
     @Test
     func flagsChangedSkippedWhenKeyDownPathActive() {
         // When F19 keyDown has been received (keyDown path active),


### PR DESCRIPTION
Fixes #385

## Summary
- The first character typed into the search palette no longer vanishes when the trigger chord's F19 release lands inside the 80 ms Caps-Lock toggle-quirk window (~12 % of real presses).
- Root cause: the tap defers a fast F19 release (`_isHyperHeld` stays true) so a single physical Caps-Lock tap can act as Hyper for the next keystroke — but when that next keystroke is the palette's first typed character, it gets the Hyper union injected, matches a registered shortcut, is swallowed, and is then dropped by the interactive-panel dispatch gate.
- Fix is session-scoped, not a point-in-time clear: `EventTapBox.setHyperReleaseDeferralSuppressed(_:)` suppresses the deferral for as long as an interactive panel session is active (`ShortcutManager.setInteractivePanelSessionActive` drives it on both transitions through the coordinator/provider plumbing). A point-in-time clear at panel-open cannot work — the physical F19 release routinely arrives after the panel is already open, so the deferral it would clear hasn't been armed yet (found in local pre-push review; the one-shot design was reworked before pushing).
- Turning suppression on also resolves an already-armed deferral; turning it off restores ordinary toggle-quirk behavior. A genuine ongoing F19 hold is untouched either way (the hold-to-show window picker keeps working mid-hold).
- The flag lives under the existing box lock (one extra flag read on the keyUp path, nothing added to keyDown), is reseeded onto fresh boxes on a full stop/start (mirroring the `hyperKeyEnabled` pattern at both the manager and provider layers), and survives in-place tap recreation, which reuses the same box.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

`swift test`: 691/691 green — includes the physical-ordering acceptance test (F19 down → chord down → suppress → F19 up at +1 ms → next character passes through with flags byte-for-byte unchanged), the reverse synthetic ordering, genuine-hold preservation, suppression-lift restoring the toggle quirk, both dispatch-level transitions through the protocol type, and reseed proofs at the provider and manager layers. `scripts/e2e-full-test.sh` on the packaged branch build: 6/6 PASS, 0 warnings.

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Physical validation items (deterministic repro in `build/validation/batch-371-2026-07-22/RESULTS.md`):
- Real Caps-Lock press releasing inside the 80 ms window → open palette → the first typed character reaches the field (previously `type "wech"` yielded `ech`).
- Ordinary quick Caps-Lock tap with no panel (toggle quirk) still acts as Hyper for the next keystroke — no regression.
- Hold-to-show window picker still works across an F19 held through panel-open.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

`AGENTS.md`'s hold-phase contract ("ended on every F19 keyUp swallow including the 80ms toggle-quirk tap") is unchanged by this PR — suppression only alters the internal deferral state, not which events are swallowed or which hold phases are emitted.

## Notes
- Residual (known, accepted): if the first character's keyDown reaches the tap before the main actor activates the panel session, that one keystroke can still be lost — same bound as pre-fix, deliberately out of scope.
- A second local Codex round over the reworked session-scoped semantics returned no findings (interleavings, lifecycle desync, reseed ordering, protocol conformers, hot-path cost all checked).
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
