### PR TITLE
fix: exclude untitled AXUnknown phantom windows from window cycling (#389)

### DIFF
--- a/Sources/Wink/Services/AppSwitcher.swift
+++ b/Sources/Wink/Services/AppSwitcher.swift
@@ -158,16 +158,25 @@ final class AppSwitcher: AppSwitching {
         let focusedWindowID: (pid_t) -> CGWindowID?
         /// Cycle eligibility: `kAXWindows` also surfaces auxiliary elements
         /// with valid window IDs — most visibly the native Split View
-        /// divider (role AXUnknown, ~13px wide, untitled, transient ID).
-        /// Raising one moves the divider and resizes both panes (#376), so
-        /// rotation must only ever contain real content windows.
+        /// divider. On-device (#389) Firefox exposes it as a genuine
+        /// `AXWindow` (role=AXWindow subrole=AXUnknown title="" size=13x1080),
+        /// so role alone does not distinguish it from a real window. Subrole
+        /// alone is not enough either: mpv run `--fs --no-native-fs` exposes
+        /// a genuinely titled fullscreen `AXWindow` that also reports
+        /// subrole AXUnknown, and that window must stay cyclable. The
+        /// divider's actual signature is two-factor — AXUnknown subrole AND
+        /// no title — so rotation must only ever contain real content
+        /// windows by that combined test.
         ///
-        /// Tri-state: `false` = the role read succeeded and the element is
-        /// definitively not a content window (excluded); `nil` = the role
-        /// read itself failed. The distinction matters mid-gesture: a
-        /// transient read failure must swallow the press like the
-        /// windows-read-failure path (never fall through to the hide lanes),
-        /// while a definitive auxiliary role is simply filtered out.
+        /// Tri-state: `false` = the role/subrole/title read succeeded and
+        /// the element is definitively not a content window (excluded);
+        /// `nil` = the role read itself failed. The distinction matters
+        /// mid-gesture: a transient read failure must swallow the press
+        /// like the windows-read-failure path (never fall through to the
+        /// hide lanes), while a definitive auxiliary shape is simply
+        /// filtered out. See
+        /// `AppSwitcher.contentWindowDecision(role:subrole:title:)` for the
+        /// pure classification behind the live closure.
         let isContentWindow: (AXUIElement) -> Bool?
         let raiseWindow: (AXUIElement) -> Void
         let unminimizeWindow: (AXUIElement) -> Void
@@ -177,6 +186,34 @@ final class AppSwitcher: AppSwitching {
         /// AX kAXTitle read for HUD feedback (Accessibility-covered; never
         /// CGWindowList titles, which would require Screen Recording).
         let windowTitle: (AXUIElement) -> String?
+    }
+
+    /// Pure decision behind `isContentWindow` (#389): a role-only check lets
+    /// the Split View divider through, because Firefox reports it as a
+    /// genuine `AXWindow` (role=AXWindow subrole=AXUnknown title="" size=
+    /// 13x1080) — #377's fixture (Finder's desktop `AXScrollArea`) never
+    /// exercised this because its role already fails the check. A blanket
+    /// reject-on-`AXUnknown`-subrole is *also* wrong: Apple permits genuine
+    /// windows with no matching predefined subrole to report `AXUnknown`
+    /// too — mpv run `--fs --no-native-fs` exposes a TITLED fullscreen
+    /// `AXWindow` with subrole AXUnknown, and rejecting on subrole alone
+    /// would drop it from both cycling and the window picker. The divider's
+    /// actual signature is two-factor: `AXUnknown` subrole AND no title. An
+    /// element with neither a meaningful subrole nor a title could never be
+    /// labeled in the HUD/picker anyway, so excluding that combination
+    /// costs nothing real. `title` follows the `windowTitle` client's own
+    /// convention — nil and empty both mean "no title" and are treated
+    /// identically here, regardless of which one a caller passes.
+    /// `nonisolated` because this is pure classification logic, not UI
+    /// state (see AGENTS.md actor-boundary guidance).
+    nonisolated static func contentWindowDecision(role: String?, subrole: String?, title: String?) -> Bool? {
+        guard let role else { return nil }
+        guard role == kAXWindowRole else { return false }
+        let isUntitled = title?.isEmpty ?? true
+        if subrole == kAXUnknownSubrole, isUntitled {
+            return false
+        }
+        return true
     }
 
     struct CycleHUDClient {
@@ -2437,9 +2474,21 @@ extension AppSwitcher.WindowCycleClient {
         },
         isContentWindow: { element in
             var roleRef: CFTypeRef?
-            let result = AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
-            guard result == .success, let role = roleRef as? String else { return nil }
-            return role == kAXWindowRole
+            let roleResult = AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
+            guard roleResult == .success, let role = roleRef as? String else { return nil }
+            var subroleRef: CFTypeRef?
+            let subroleResult = AXUIElementCopyAttributeValue(element, kAXSubroleAttribute as CFString, &subroleRef)
+            let subrole = subroleResult == .success ? subroleRef as? String : nil
+            // Third AX read, gated to the rare AXUnknown branch: every
+            // ordinary window (the common case) resolves off role+subrole
+            // alone, so it must not pay for a title read it doesn't need.
+            var title: String?
+            if subrole == kAXUnknownSubrole {
+                var titleRef: CFTypeRef?
+                let titleResult = AXUIElementCopyAttributeValue(element, kAXTitleAttribute as CFString, &titleRef)
+                title = titleResult == .success ? titleRef as? String : nil
+            }
+            return AppSwitcher.contentWindowDecision(role: role, subrole: subrole, title: title)
         },
         raiseWindow: { element in
             AXUIElementPerformAction(element, kAXRaiseAction as CFString)

--- a/Sources/Wink/Services/AppSwitcher.swift
+++ b/Sources/Wink/Services/AppSwitcher.swift
@@ -168,15 +168,22 @@ final class AppSwitcher: AppSwitching {
         /// no title — so rotation must only ever contain real content
         /// windows by that combined test.
         ///
-        /// Tri-state: `false` = the role/subrole/title read succeeded and
-        /// the element is definitively not a content window (excluded);
-        /// `nil` = the role read itself failed. The distinction matters
-        /// mid-gesture: a transient read failure must swallow the press
-        /// like the windows-read-failure path (never fall through to the
-        /// hide lanes), while a definitive auxiliary shape is simply
-        /// filtered out. See
-        /// `AppSwitcher.contentWindowDecision(role:subrole:title:)` for the
-        /// pure classification behind the live closure.
+        /// Tri-state: `false` = the role/subrole/title reads succeeded (or
+        /// definitively found nothing) and the element is definitively not
+        /// a content window (excluded); `nil` = a read that matters to the
+        /// decision failed TRANSIENTLY (busy/unresponsive target, or
+        /// Accessibility revoked mid-read) rather than telling us the
+        /// attribute genuinely has no value. The distinction applies to all
+        /// three reads, not just role: a transient failure on any of them
+        /// must swallow the press like the windows-read-failure path
+        /// (never fall through to the hide lanes and never silently drop a
+        /// real window from rotation/the picker), while a definitive
+        /// auxiliary shape — or a definitive absence, like an unreadable
+        /// subrole on a real window — is simply filtered out or included
+        /// per the existing rules. See
+        /// `AppSwitcher.contentWindowDecision(role:subrole:title:)` and
+        /// `AppSwitcher.AXStringReadOutcome` for the pure classification
+        /// behind the live closure.
         let isContentWindow: (AXUIElement) -> Bool?
         let raiseWindow: (AXUIElement) -> Void
         let unminimizeWindow: (AXUIElement) -> Void
@@ -186,6 +193,29 @@ final class AppSwitcher: AppSwitching {
         /// AX kAXTitle read for HUD feedback (Accessibility-covered; never
         /// CGWindowList titles, which would require Screen Recording).
         let windowTitle: (AXUIElement) -> String?
+    }
+
+    /// Read outcome for an AX string attribute where the failure mode
+    /// matters to classification (#389): `.transientFailure` means the read
+    /// itself failed for a reason unrelated to the attribute's actual value
+    /// — a busy/unresponsive target (`AXError.cannotComplete`) or
+    /// Accessibility revoked mid-read (`.apiDisabled`) — and must route
+    /// into the protective `nil` path, the same swallow-the-press contract
+    /// a role-read failure already gets (see the windows-read-failure
+    /// handling above `performFrontmostWindowCycle`). `.value(nil)` means
+    /// either the read succeeded and found nothing, or it failed for a
+    /// reason that IS a definitive "no value" (`.noValue`,
+    /// `.attributeUnsupported`, `.invalidUIElement`, …). Conflating the two
+    /// in either direction is a bug: mapping a transient failure to
+    /// `.value(nil)` silently drops a real window (a titled `AXUnknown`
+    /// window, e.g. mpv, whose title read is momentarily busy, gets
+    /// misread as the untitled divider); mapping a definitive absence to
+    /// `.transientFailure` would swallow every cycle press in a Split View,
+    /// because the divider's own title read commonly reports a definitive
+    /// non-success code, not `.cannotComplete`.
+    enum AXStringReadOutcome: Equatable {
+        case value(String?)
+        case transientFailure
     }
 
     /// Pure decision behind `isContentWindow` (#389): a role-only check lets
@@ -201,19 +231,36 @@ final class AppSwitcher: AppSwitching {
     /// actual signature is two-factor: `AXUnknown` subrole AND no title. An
     /// element with neither a meaningful subrole nor a title could never be
     /// labeled in the HUD/picker anyway, so excluding that combination
-    /// costs nothing real. `title` follows the `windowTitle` client's own
-    /// convention — nil and empty both mean "no title" and are treated
-    /// identically here, regardless of which one a caller passes.
+    /// costs nothing real.
+    ///
+    /// `subrole`/`title` are `AXStringReadOutcome`, not plain `String?`,
+    /// specifically so a transient read failure can be told apart from a
+    /// definitive absence — see that type's doc comment for why collapsing
+    /// them either direction is wrong. `title` is only consulted when
+    /// `subrole` resolves to `AXUnknown`; callers may pass any
+    /// `AXStringReadOutcome` for `title` otherwise (the live closure reads
+    /// it lazily and passes `.value(nil)` as a "not applicable" default).
     /// `nonisolated` because this is pure classification logic, not UI
     /// state (see AGENTS.md actor-boundary guidance).
-    nonisolated static func contentWindowDecision(role: String?, subrole: String?, title: String?) -> Bool? {
+    nonisolated static func contentWindowDecision(
+        role: String?,
+        subrole: AXStringReadOutcome,
+        title: AXStringReadOutcome
+    ) -> Bool? {
         guard let role else { return nil }
         guard role == kAXWindowRole else { return false }
-        let isUntitled = title?.isEmpty ?? true
-        if subrole == kAXUnknownSubrole, isUntitled {
-            return false
+        switch subrole {
+        case .transientFailure:
+            return nil
+        case .value(let subroleValue):
+            guard subroleValue == kAXUnknownSubrole else { return true }
+            switch title {
+            case .transientFailure:
+                return nil
+            case .value(let titleValue):
+                return !(titleValue?.isEmpty ?? true)
+            }
         }
-        return true
     }
 
     struct CycleHUDClient {
@@ -2443,6 +2490,29 @@ private func postMakeKeyWindowEventRecord(psn: ProcessSerialNumber, windowID: CG
     }
 }
 
+/// Reads a string AX attribute and classifies the result into
+/// `AppSwitcher.AXStringReadOutcome` (#389): `.cannotComplete` (busy/
+/// unresponsive target) and `.apiDisabled` (Accessibility revoked
+/// mid-read) are transient — they say nothing about the attribute's actual
+/// value — so they map to `.transientFailure`, the protective path.
+/// Every other non-success code (`.noValue`, `.attributeUnsupported`,
+/// `.invalidUIElement`, …) is a definitive "this attribute has no value",
+/// so it maps to `.value(nil)` exactly like a successful-but-empty read.
+/// File-scope, not an AppSwitcher member, for the same reason as
+/// `postMakeKeyWindowEventRecord` above.
+private func readAXStringOutcome(_ element: AXUIElement, attribute: CFString) -> AppSwitcher.AXStringReadOutcome {
+    var ref: CFTypeRef?
+    let result = AXUIElementCopyAttributeValue(element, attribute, &ref)
+    switch result {
+    case .success:
+        return .value(ref as? String)
+    case .cannotComplete, .apiDisabled:
+        return .transientFailure
+    default:
+        return .value(nil)
+    }
+}
+
 extension AppSwitcher.WindowCycleClient {
     @MainActor
     static let live = AppSwitcher.WindowCycleClient(
@@ -2476,19 +2546,17 @@ extension AppSwitcher.WindowCycleClient {
             var roleRef: CFTypeRef?
             let roleResult = AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef)
             guard roleResult == .success, let role = roleRef as? String else { return nil }
-            var subroleRef: CFTypeRef?
-            let subroleResult = AXUIElementCopyAttributeValue(element, kAXSubroleAttribute as CFString, &subroleRef)
-            let subrole = subroleResult == .success ? subroleRef as? String : nil
+            let subroleOutcome = readAXStringOutcome(element, attribute: kAXSubroleAttribute as CFString)
             // Third AX read, gated to the rare AXUnknown branch: every
             // ordinary window (the common case) resolves off role+subrole
             // alone, so it must not pay for a title read it doesn't need.
-            var title: String?
-            if subrole == kAXUnknownSubrole {
-                var titleRef: CFTypeRef?
-                let titleResult = AXUIElementCopyAttributeValue(element, kAXTitleAttribute as CFString, &titleRef)
-                title = titleResult == .success ? titleRef as? String : nil
+            // `.value(nil)` here is "not applicable" — contentWindowDecision
+            // never consults title unless subrole is exactly AXUnknown.
+            var titleOutcome: AppSwitcher.AXStringReadOutcome = .value(nil)
+            if case .value(let subroleValue) = subroleOutcome, subroleValue == kAXUnknownSubrole {
+                titleOutcome = readAXStringOutcome(element, attribute: kAXTitleAttribute as CFString)
             }
-            return AppSwitcher.contentWindowDecision(role: role, subrole: subrole, title: title)
+            return AppSwitcher.contentWindowDecision(role: role, subrole: subroleOutcome, title: titleOutcome)
         },
         raiseWindow: { element in
             AXUIElementPerformAction(element, kAXRaiseAction as CFString)

--- a/Tests/WinkTests/AppSwitcherCycleTests.swift
+++ b/Tests/WinkTests/AppSwitcherCycleTests.swift
@@ -39,10 +39,22 @@ private final class CycleActionRecorder {
 private struct CycleTestWindows {
     let elements: [AXUIElement]
     let idsByIndex: [CGWindowID]
-    /// IDs modeling auxiliary `kAXWindows` elements (Split View divider
-    /// class: non-AXWindow role, valid window ID) that the eligibility
-    /// filter must exclude from rotation (#376).
+    /// IDs modeling auxiliary `kAXWindows` elements (non-AXWindow role,
+    /// valid window ID — e.g. Finder's desktop `AXScrollArea`, #377's
+    /// fixture) that the eligibility filter must exclude from rotation
+    /// (#376).
     let ineligibleIDs: Set<CGWindowID>
+    /// IDs modeling the Split View divider's actual on-device shape (role
+    /// AXWindow, subrole AXUnknown, no title, #389) — routed through the
+    /// real `AppSwitcher.contentWindowDecision` rather than a boolean
+    /// stand-in, so the fixture exercises the production classification
+    /// directly.
+    let unknownSubroleIDs: Set<CGWindowID>
+    /// IDs modeling a genuine TITLED AXUnknown-subrole window — mpv run
+    /// `--fs --no-native-fs` (#389 P2 regression case). Same subrole as the
+    /// divider but titled, so `contentWindowDecision` must still include
+    /// it; also routed through the real production function.
+    let titledUnknownSubroleIDs: Set<CGWindowID>
     /// IDs whose role read transiently fails (nil eligibility). A reference
     /// box, not a struct field: the fixture closures capture this struct by
     /// value, and a test must be able to establish a session first and THEN
@@ -52,9 +64,16 @@ private struct CycleTestWindows {
     }
     let roleReadFailures = RoleFailureBox()
 
-    init(ids: [CGWindowID], ineligibleIDs: Set<CGWindowID> = []) {
+    init(
+        ids: [CGWindowID],
+        ineligibleIDs: Set<CGWindowID> = [],
+        unknownSubroleIDs: Set<CGWindowID> = [],
+        titledUnknownSubroleIDs: Set<CGWindowID> = []
+    ) {
         self.idsByIndex = ids
         self.ineligibleIDs = ineligibleIDs
+        self.unknownSubroleIDs = unknownSubroleIDs
+        self.titledUnknownSubroleIDs = titledUnknownSubroleIDs
         self.elements = (0..<ids.count).map { AXUIElementCreateApplication(pid_t(90_000 + $0)) }
     }
 
@@ -73,6 +92,12 @@ private struct CycleTestWindows {
     func isContentWindow(_ element: AXUIElement) -> Bool? {
         guard let id = windowID(for: element) else { return false }
         if roleReadFailures.ids.contains(id) { return nil }
+        if unknownSubroleIDs.contains(id) {
+            return AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXUnknownSubrole, title: nil)
+        }
+        if titledUnknownSubroleIDs.contains(id) {
+            return AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXUnknownSubrole, title: "mpv")
+        }
         return !ineligibleIDs.contains(id)
     }
 }
@@ -1083,7 +1108,7 @@ func hudAppearsFromSecondConsecutivePressWithPositionAndTitle() {
     #expect(recorder.hudPresentations.last?.windowTitle == "Window 101")
 }
 
-// MARK: - Auxiliary-window eligibility (#376)
+// MARK: - Auxiliary-window eligibility (#376, #389)
 
 @Test @MainActor
 func cycleExcludesAuxiliaryWindowsFromRotationAndHUD() {
@@ -1095,10 +1120,15 @@ func cycleExcludesAuxiliaryWindowsFromRotationAndHUD() {
 
     let clock = CycleTestClock(time: 100)
     let recorder = CycleActionRecorder()
-    // 103 models the Split View divider: a kAXWindows element with a valid
-    // window ID but a non-AXWindow role. Raising it resizes the panes, so
-    // it must never enter rotation, receive activation, or reach the HUD.
-    let windows = CycleTestWindows(ids: [101, 102, 103], ineligibleIDs: [103])
+    // 103 models the Split View divider's actual on-device shape (#389): a
+    // kAXWindows element with a valid window ID, role AXWindow, and subrole
+    // AXUnknown — indistinguishable from a real window by role alone, which
+    // is why #377's role-only fixture (Finder's AXScrollArea) missed this
+    // class. Routed through the real production decision function, not a
+    // boolean stand-in. Raising it moves the divider and resizes both
+    // panes, so it must never enter rotation, receive activation, or reach
+    // the HUD.
+    let windows = CycleTestWindows(ids: [101, 102, 103], unknownSubroleIDs: [103])
     let switcher = makeCycleSwitcher(
         frontmostApp: frontmostApp,
         bundleIdentifier: bundleIdentifier,
@@ -1130,9 +1160,110 @@ func cycleExcludesAuxiliaryWindowsFromRotationAndHUD() {
     #expect(recorder.raisedWindowIDs == [102, 101, 102])
     #expect(!recorder.activatedWindowIDs.contains(103))
     #expect(!recorder.raisedWindowIDs.contains(103))
-    #expect(recorder.hudPresentations.allSatisfy { $0.windowCount == 2 })
-    #expect(recorder.hudPresentations.allSatisfy { $0.targetWindowID != 103 })
+    // Exact count first: allSatisfy on an empty array is vacuously true, so
+    // pin the presentation count before asserting per-presentation shape.
+    #expect(recorder.hudPresentations.count == 2)
+    #expect(recorder.hudPresentations.map(\.windowCount) == [2, 2])
+    #expect(recorder.hudPresentations.map(\.targetWindowID) == [101, 102])
     #expect(recorder.hideCalls == 0)
+}
+
+@Test @MainActor
+func cycleIncludesTitledAXUnknownSubroleWindowLikeMpv() {
+    guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
+          let bundleIdentifier = frontmostApp.bundleIdentifier else {
+        Issue.record("Expected a frontmost application with a bundle identifier for mpv-shaped eligibility test")
+        return
+    }
+
+    let clock = CycleTestClock(time: 100)
+    let recorder = CycleActionRecorder()
+    // 103 models mpv run with `--fs --no-native-fs` (#389 P2 regression): a
+    // genuine AXWindow that reports subrole AXUnknown but IS titled. Subrole
+    // alone must not exclude it — only the divider's combined
+    // AXUnknown-and-untitled shape does.
+    let windows = CycleTestWindows(ids: [101, 102, 103], titledUnknownSubroleIDs: [103])
+    let switcher = makeCycleSwitcher(
+        frontmostApp: frontmostApp,
+        bundleIdentifier: bundleIdentifier,
+        windows: windows,
+        focusedWindowID: { 101 },
+        recorder: recorder,
+        clock: clock,
+        trackerBundle: bundleIdentifier
+    )
+    switcher.setFrontmostTargetBehavior(.cycleWindows)
+
+    let shortcut = AppShortcut(
+        appName: frontmostApp.localizedName ?? "Frontmost",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "c",
+        modifierFlags: ["command", "option"]
+    )
+
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    clock.time += 0.2
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    clock.time += 0.2
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+
+    // All three windows take part in rotation — the titled AXUnknown window
+    // is a full member, not filtered like the divider.
+    #expect(recorder.raisedWindowIDs == [102, 103, 101])
+    #expect(recorder.hideCalls == 0)
+}
+
+// MARK: - contentWindowDecision pure classification (#389)
+
+@Test @MainActor
+func contentWindowDecisionReturnsNilWhenRoleReadFailed() {
+    // Preserves the roleReadFailed contract exactly: a nil role (the read
+    // itself failed) must stay nil regardless of subrole or title.
+    #expect(AppSwitcher.contentWindowDecision(role: nil, subrole: nil, title: nil) == nil)
+    #expect(AppSwitcher.contentWindowDecision(role: nil, subrole: kAXUnknownSubrole, title: nil) == nil)
+}
+
+@Test @MainActor
+func contentWindowDecisionExcludesNonWindowRoleUnchanged() {
+    // Unchanged #377 behavior: any role other than AXWindow is excluded,
+    // independent of subrole/title (Finder's desktop AXScrollArea shape).
+    #expect(AppSwitcher.contentWindowDecision(role: kAXScrollAreaRole, subrole: nil, title: nil) == false)
+}
+
+@Test @MainActor
+func contentWindowDecisionExcludesTheSplitViewDividerShape() {
+    // The exact on-device tuple from #389: Firefox's Split View divider
+    // reports role=AXWindow subrole=AXUnknown title="" size=13x1080. Both
+    // the unreadable (nil) and empty-string title spellings of "no title"
+    // must exclude it — the pure function treats them identically.
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXUnknownSubrole, title: nil) == false)
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXUnknownSubrole, title: "") == false)
+}
+
+@Test @MainActor
+func contentWindowDecisionIncludesTitledAXUnknownSubroleWindowLikeMpv() {
+    // The #389 P2 regression case: mpv run `--fs --no-native-fs` reports
+    // role=AXWindow subrole=AXUnknown but IS titled. A blanket
+    // reject-on-subrole would wrongly drop it from cycling and the picker.
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXUnknownSubrole, title: "mpv") == true)
+}
+
+@Test @MainActor
+func contentWindowDecisionIncludesAWindowWithUnreadableSubrole() {
+    // A real window whose subrole cannot be read must NOT be dropped: a
+    // false exclusion of a real window is worse than letting a phantom
+    // through.
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: nil, title: nil) == true)
+}
+
+@Test @MainActor
+func contentWindowDecisionIncludesOtherSubrolesRegardlessOfTitle() {
+    // Dialogs, standard windows, and everything else currently included
+    // stays included — this is not a subrole allowlist, and title must not
+    // affect non-AXUnknown windows either way (titled or untitled).
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXStandardWindowSubrole, title: "Notes") == true)
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXStandardWindowSubrole, title: nil) == true)
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXDialogSubrole, title: "Save") == true)
 }
 
 @Test @MainActor
@@ -1282,9 +1413,10 @@ func windowPickerSessionListsEligibleWindowsSortedAndExcludesAuxiliary() {
 
     let clock = CycleTestClock(time: 100)
     let recorder = CycleActionRecorder()
-    // Deliberately unsorted ids + one auxiliary (divider-class) element +
-    // one minimized window.
-    let windows = CycleTestWindows(ids: [203, 201, 202], ineligibleIDs: [202])
+    // Deliberately unsorted ids + one auxiliary (the divider's real
+    // AXUnknown/untitled shape, #389 — routed through the production
+    // decision function, not a boolean stand-in) + one minimized window.
+    let windows = CycleTestWindows(ids: [203, 201, 202], unknownSubroleIDs: [202])
     let switcher = makeCycleSwitcher(
         frontmostApp: frontmostApp,
         bundleIdentifier: bundleIdentifier,

--- a/Tests/WinkTests/AppSwitcherCycleTests.swift
+++ b/Tests/WinkTests/AppSwitcherCycleTests.swift
@@ -63,6 +63,15 @@ private struct CycleTestWindows {
         var ids: Set<CGWindowID> = []
     }
     let roleReadFailures = RoleFailureBox()
+    /// IDs (drawn from `titledUnknownSubroleIDs`) whose TITLE read
+    /// specifically fails transiently on the next press — unlike
+    /// `roleReadFailures`, role and subrole both succeed here; only the
+    /// lazy third read is flaky (#389 P2). Same mutable-box shape as
+    /// `roleReadFailures` for the same mid-session-injection reason.
+    final class TitleTransientFailureBox {
+        var ids: Set<CGWindowID> = []
+    }
+    let titleTransientFailures = TitleTransientFailureBox()
 
     init(
         ids: [CGWindowID],
@@ -93,10 +102,13 @@ private struct CycleTestWindows {
         guard let id = windowID(for: element) else { return false }
         if roleReadFailures.ids.contains(id) { return nil }
         if unknownSubroleIDs.contains(id) {
-            return AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXUnknownSubrole, title: nil)
+            return AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .value(kAXUnknownSubrole), title: .value(nil))
         }
         if titledUnknownSubroleIDs.contains(id) {
-            return AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXUnknownSubrole, title: "mpv")
+            let title: AppSwitcher.AXStringReadOutcome = titleTransientFailures.ids.contains(id)
+                ? .transientFailure
+                : .value("mpv")
+            return AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .value(kAXUnknownSubrole), title: title)
         }
         return !ineligibleIDs.contains(id)
     }
@@ -1219,15 +1231,15 @@ func cycleIncludesTitledAXUnknownSubroleWindowLikeMpv() {
 func contentWindowDecisionReturnsNilWhenRoleReadFailed() {
     // Preserves the roleReadFailed contract exactly: a nil role (the read
     // itself failed) must stay nil regardless of subrole or title.
-    #expect(AppSwitcher.contentWindowDecision(role: nil, subrole: nil, title: nil) == nil)
-    #expect(AppSwitcher.contentWindowDecision(role: nil, subrole: kAXUnknownSubrole, title: nil) == nil)
+    #expect(AppSwitcher.contentWindowDecision(role: nil, subrole: .value(nil), title: .value(nil)) == nil)
+    #expect(AppSwitcher.contentWindowDecision(role: nil, subrole: .value(kAXUnknownSubrole), title: .value(nil)) == nil)
 }
 
 @Test @MainActor
 func contentWindowDecisionExcludesNonWindowRoleUnchanged() {
     // Unchanged #377 behavior: any role other than AXWindow is excluded,
     // independent of subrole/title (Finder's desktop AXScrollArea shape).
-    #expect(AppSwitcher.contentWindowDecision(role: kAXScrollAreaRole, subrole: nil, title: nil) == false)
+    #expect(AppSwitcher.contentWindowDecision(role: kAXScrollAreaRole, subrole: .value(nil), title: .value(nil)) == false)
 }
 
 @Test @MainActor
@@ -1236,8 +1248,8 @@ func contentWindowDecisionExcludesTheSplitViewDividerShape() {
     // reports role=AXWindow subrole=AXUnknown title="" size=13x1080. Both
     // the unreadable (nil) and empty-string title spellings of "no title"
     // must exclude it — the pure function treats them identically.
-    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXUnknownSubrole, title: nil) == false)
-    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXUnknownSubrole, title: "") == false)
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .value(kAXUnknownSubrole), title: .value(nil)) == false)
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .value(kAXUnknownSubrole), title: .value("")) == false)
 }
 
 @Test @MainActor
@@ -1245,15 +1257,16 @@ func contentWindowDecisionIncludesTitledAXUnknownSubroleWindowLikeMpv() {
     // The #389 P2 regression case: mpv run `--fs --no-native-fs` reports
     // role=AXWindow subrole=AXUnknown but IS titled. A blanket
     // reject-on-subrole would wrongly drop it from cycling and the picker.
-    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXUnknownSubrole, title: "mpv") == true)
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .value(kAXUnknownSubrole), title: .value("mpv")) == true)
 }
 
 @Test @MainActor
-func contentWindowDecisionIncludesAWindowWithUnreadableSubrole() {
-    // A real window whose subrole cannot be read must NOT be dropped: a
-    // false exclusion of a real window is worse than letting a phantom
-    // through.
-    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: nil, title: nil) == true)
+func contentWindowDecisionIncludesAWindowWithDefinitivelyUnreadableSubrole() {
+    // A real window whose subrole read definitively found nothing (e.g.
+    // .attributeUnsupported/.invalidUIElement, not a transient failure)
+    // must NOT be dropped: a false exclusion of a real window is worse
+    // than letting a phantom through.
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .value(nil), title: .value(nil)) == true)
 }
 
 @Test @MainActor
@@ -1261,9 +1274,40 @@ func contentWindowDecisionIncludesOtherSubrolesRegardlessOfTitle() {
     // Dialogs, standard windows, and everything else currently included
     // stays included — this is not a subrole allowlist, and title must not
     // affect non-AXUnknown windows either way (titled or untitled).
-    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXStandardWindowSubrole, title: "Notes") == true)
-    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXStandardWindowSubrole, title: nil) == true)
-    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: kAXDialogSubrole, title: "Save") == true)
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .value(kAXStandardWindowSubrole), title: .value("Notes")) == true)
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .value(kAXStandardWindowSubrole), title: .value(nil)) == true)
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .value(kAXDialogSubrole), title: .value("Save")) == true)
+}
+
+// MARK: - Transient AX read failures (#389 P2)
+
+@Test @MainActor
+func contentWindowDecisionSubroleTransientFailureReturnsNilRegardlessOfTitle() {
+    // A transient subrole read failure (.cannotComplete/.apiDisabled) must
+    // route into the protective nil — the same swallow-the-press contract
+    // a role-read failure already gets — never be treated as a definitive
+    // "not the divider" or "is the divider" answer.
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .transientFailure, title: .value(nil)) == nil)
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .transientFailure, title: .value("mpv")) == nil)
+}
+
+@Test @MainActor
+func contentWindowDecisionTitleTransientFailureOnAXUnknownReturnsNil() {
+    // THE P2 regression: a titled AXUnknown window (mpv-shaped) whose
+    // TITLE read is transiently busy must NOT be misclassified as the
+    // untitled divider (which would silently drop a real window from
+    // rotation/the picker) — it must swallow the press like any other
+    // transient AX failure.
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .value(kAXUnknownSubrole), title: .transientFailure) == nil)
+}
+
+@Test @MainActor
+func contentWindowDecisionTitleTransientFailureIsIgnoredWhenSubroleIsNotAXUnknown() {
+    // Title is only consulted on the AXUnknown branch — an ordinary
+    // window's spurious .transientFailure title outcome (should never
+    // happen in practice, since the live closure only reads title lazily
+    // on that branch) must not leak into the decision.
+    #expect(AppSwitcher.contentWindowDecision(role: kAXWindowRole, subrole: .value(kAXStandardWindowSubrole), title: .transientFailure) == true)
 }
 
 @Test @MainActor
@@ -1350,6 +1394,61 @@ func transientRoleReadFailureMidGestureSwallowsThePress() {
 
     // Failure clears → the gesture continues from the preserved cursor.
     windows.roleReadFailures.ids = []
+    clock.time += 0.2
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    #expect(recorder.raisedWindowIDs == [102, 101])
+    #expect(recorder.hideCalls == 0)
+}
+
+@Test @MainActor
+func cycleTitleTransientFailureMidGestureSwallowsThePress() {
+    guard let frontmostApp = NSWorkspace.shared.frontmostApplication,
+          let bundleIdentifier = frontmostApp.bundleIdentifier else {
+        Issue.record("Expected a frontmost application with a bundle identifier for title-failure test")
+        return
+    }
+
+    let clock = CycleTestClock(time: 100)
+    let recorder = CycleActionRecorder()
+    // 102 is mpv-shaped (role AXWindow, subrole AXUnknown, normally
+    // titled) — role and subrole both read fine; only its TITLE read goes
+    // transiently flaky (#389 P2), unlike roleReadFailures above.
+    let windows = CycleTestWindows(ids: [101, 102], titledUnknownSubroleIDs: [102])
+    let switcher = makeCycleSwitcher(
+        frontmostApp: frontmostApp,
+        bundleIdentifier: bundleIdentifier,
+        windows: windows,
+        focusedWindowID: { 101 },
+        recorder: recorder,
+        clock: clock,
+        trackerBundle: bundleIdentifier
+    )
+    switcher.setFrontmostTargetBehavior(.cycleWindows)
+
+    let shortcut = AppShortcut(
+        appName: frontmostApp.localizedName ?? "Frontmost",
+        bundleIdentifier: bundleIdentifier,
+        keyEquivalent: "c",
+        modifierFlags: ["command", "option"]
+    )
+
+    // Establish a live session (102 reads as titled and cycles normally),
+    // then make its title read fail transiently on the next press.
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    #expect(recorder.raisedWindowIDs == [102])
+    windows.titleTransientFailures.ids = [102]
+    clock.time += 0.2
+
+    // The press must be swallowed exactly like a transient role-read
+    // failure — NOT a hide fall-through, and critically NOT a silent
+    // exclusion of 102 from rotation (the P2 bug: misreading the transient
+    // failure as "untitled" would have raised 101 here instead).
+    #expect(switcher.toggleApplication(for: shortcut) == true)
+    #expect(recorder.hideCalls == 0)
+    #expect(recorder.raisedWindowIDs == [102])
+
+    // Failure clears → the gesture continues from the preserved cursor.
+    windows.titleTransientFailures.ids = []
     clock.time += 0.2
     #expect(switcher.toggleApplication(for: shortcut) == true)
     #expect(recorder.raisedWindowIDs == [102, 101])


### PR DESCRIPTION
Fixes #389

## Summary
- Window cycling (and the hold-to-show window picker, which shares the same filter) no longer treats the native fullscreen Split View divider as a window: no more phantom `3/3` count, no empty-title HUD entry, and — critically — no `AXRaise`/`makeKeyWindow` on the divider, which is what dragged it to the pointer on every third step.
- Root cause: Firefox exposes the divider as a genuine `AXWindow` (`subrole=AXUnknown`, `title=""`, 13×1080), and the live `isContentWindow` checked role only. #377's regression fixture (Finder's desktop `AXScrollArea`) fails the role check, so this class survived it.
- The classification is now a pure, tested `AppSwitcher.contentWindowDecision(role:subrole:title:)`: an `AXWindow` is excluded only when it is BOTH `AXUnknown`-subrole AND untitled. The two-factor signature matters: legitimate windows may report `AXUnknown` (live counter-example found in pre-push review: mpv `--fs --no-native-fs` exposes a titled fullscreen `AXWindow`/`AXUnknown`), so subrole alone would wrongly evict them from cycling and the picker. Titled `AXUnknown` windows stay included; an untitled one could never be labeled in the HUD/picker anyway.
- Hot-path cost: the common path stays at two AX attribute reads per candidate (role+subrole); the title read is gated to the rare `AXUnknown` branch. Nothing runs per keyboard event.
- Role-read-failure semantics (`nil` → press swallowed, never falls through to the hide lanes) are preserved bit-for-bit.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

`swift test`: 713/713 green — pure-function coverage of all branches (including the exact on-device divider tuple and the mpv counter-example), a cycle-level test proving a divider-shaped candidate never receives raise/makeKey while the HUD presents exactly `[2, 2]` windows, a cycle-level test proving a titled-`AXUnknown` (mpv-shaped) window still rotates, and the picker exclusion test rerouted through the real decision function. `scripts/e2e-full-test.sh` on the packaged branch build: 6/6 PASS, 0 warnings.

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Physical validation items (operator fixture, deterministic per #389):
- Two-Firefox fullscreen Split View, divider at ~1/3: cycling shows `1/2 → 2/2` with both entries titled; the divider never moves regardless of pointer position.
- Regular non-fullscreen multi-window cycling unchanged (already operator-confirmed correct pre-fix).
- An mpv-style titled borderless window still cycles.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Local Codex pre-push review ran (per `pr-review-loop`): its P2 (blanket `AXUnknown` rejection excluding legitimate windows, with the mpv evidence) and P3 (vacuous `allSatisfy` HUD assertion; picker test bypassing the real decision) are both fixed in this revision.
- The pre-existing #377-era comment describing the divider as "role AXUnknown" was corrected (it conflated role and subrole) per the on-device evidence.
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
