### PR TITLE
fix: ship top-level lproj markers so macOS sees the app's localizations (#390)

### DIFF
--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -307,6 +307,29 @@ PLIST
     apply_validation_profile "$CONTENTS_DIR/Info.plist"
 fi
 
+# Create top-level localization markers (#390).
+# `Bundle.localizations` and Language & Region's per-app language picker
+# enumerate the app bundle's OWN Contents/Resources/<locale>.lproj
+# directories -- they do not look inside nested SPM resource bundles. Wink's
+# real compiled catalogs live only in $RESOURCE_BUNDLE_NAME, so without this
+# the app bundle declares zero localizations even though Info.plist's
+# CFBundleLocalizations lists more than one, and macOS refuses to offer a
+# per-app language for Wink. These are empty marker catalogs only: app code
+# never resolves localized strings through Bundle.main, only through the
+# nested bundle via WinkResourceBundle.bundle, so nothing here shadows the
+# runtime lookup path.
+# Locale list mirrors CFBundleLocalizations in
+# Sources/Wink/Resources/Info.plist (source of truth) -- keep both in sync.
+APP_LOCALIZATIONS=(en zh-Hans)
+for locale in "${APP_LOCALIZATIONS[@]}"; do
+    lproj_dir="$RESOURCES_DIR/${locale}.lproj"
+    mkdir -p "$lproj_dir"
+    cat > "$lproj_dir/InfoPlist.strings" <<'STRINGS'
+/* Top-level localization marker — real catalogs live in Wink_Wink.bundle; see #390 */
+STRINGS
+done
+echo "    Top-level localization markers created for: ${APP_LOCALIZATIONS[*]}"
+
 # Copy Sparkle.framework into the app bundle while preserving symlinks.
 echo "==> Embedding Sparkle.framework..."
 ditto "$SPARKLE_FRAMEWORK_SOURCE" "$FRAMEWORKS_DIR/Sparkle.framework"


### PR DESCRIPTION
Fixes #390

## Summary
- The packaged app now ships top-level `Contents/Resources/en.lproj` and `zh-Hans.lproj` marker catalogs (each a one-comment `InfoPlist.strings`), created by `scripts/package-app.sh` after Resources assembly and before signing, so they are sealed into the signature.
- Root cause of #390: all real compiled catalogs live inside the nested SPM resource bundle (`Wink_Wink.bundle`), which macOS's Language & Region "Applications" feature cannot see — it enumerates the app bundle's own `.lproj` directories, found none, and refused a per-app language row with "Wink doesn't support additional languages" despite `CFBundleLocalizations = [en, zh-Hans]`.
- The markers are declaration-only: app code never resolves localized strings through `Bundle.main` (always through `WinkResourceBundle.bundle`), so nothing shadows the runtime lookup path. The locale list is documented as mirroring `CFBundleLocalizations` in `Sources/Wink/Resources/Info.plist` (source of truth).

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

`swift test`: green (no Swift sources touched). Packaged build: `codesign --verify --deep --strict` passes; `Bundle(url:).localizations` set = `["en", "zh-Hans"]`; `scripts/e2e-full-test.sh` on the packaged branch build: 6/6 PASS, 0 warnings (also re-proves TCC grant survival with the added files). `package-dmg.sh`/`package-update-zip.sh` confirmed to consume the already-packaged bundle as-is — no changes needed there.

Note for reviewers: `Bundle.localizations` returns the plist array concatenated with the on-disk `.lproj` names WITHOUT deduplication (`["en", "en", "zh-Hans", "zh-Hans"]`) — reproduced against a synthetic minimal bundle on macOS 15.7.5, an inherent Foundation behavior, not an artifact of this change; the locale SET is exact.

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

Physical validation item:
- System Settings → General → Language & Region → Applications → "+" offers 简体中文 for Wink (no "doesn't support additional languages" warning); setting it launches Wink localized without `-AppleLanguages`.

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
