### PR TITLE
fix: pad the suggested-shortcuts card and widen the Insights scroll region (#393)

### DIFF
--- a/Sources/Wink/UI/InsightsTabView.swift
+++ b/Sources/Wink/UI/InsightsTabView.swift
@@ -47,12 +47,38 @@ struct InsightsTabView: View {
 
             InsightsHourlyHeatmap(buckets: viewModel.heatmapBuckets)
 
-            mostUsedCard
+            // The tab keeps the repo's one-scroller-per-surface contract
+            // (see LayoutRegressionTests' scroller tests), but the region
+            // now spans ranking + nudge + suggestions instead of the ranking
+            // card alone: with the nudge AND a populated suggestions card,
+            // the fixed blocks' natural heights exceeded the window and the
+            // tail cards were silently clipped at the window edge (#393 —
+            // the suggestions card showed 1.5 of its 3 rows). Header, KPIs,
+            // and heatmap stay fixed; everything below shares the scroller,
+            // so every card is always reachable at any window height.
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    mostUsedCard
 
-            InsightsUnusedNudge(appNames: viewModel.unusedShortcutNames)
+                    InsightsUnusedNudge(appNames: viewModel.unusedShortcutNames)
 
-            if !viewModel.suggestedApps.isEmpty {
-                WinkCard(title: { Text("Suggested shortcuts", bundle: WinkResourceBundle.bundle) }) {
+                    suggestedShortcutsCard
+                }
+            }
+            .scrollIndicators(.automatic, axes: .vertical)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .padding(.top, 18)
+        .padding(.bottom, 22)
+        .padding(.horizontal, 22)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(palette.windowBg)
+    }
+
+    @ViewBuilder
+    private var suggestedShortcutsCard: some View {
+        if !viewModel.suggestedApps.isEmpty {
+            WinkCard(title: { Text("Suggested shortcuts", bundle: WinkResourceBundle.bundle) }) {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Apps you switch to often that have no shortcut yet. Add one in Shortcuts.", bundle: WinkResourceBundle.bundle)
                             .font(WinkType.labelSmall)
@@ -70,14 +96,14 @@ struct InsightsTabView: View {
                             }
                         }
                     }
-                }
+                    // WinkCard pads only its title row; content insets are
+                    // each caller's job (cf. the ranking card's empty state)
+                    // — omitting them here is what glued the subtitle to the
+                    // divider and the count labels to the card edge (#393).
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
             }
         }
-        .padding(.top, 18)
-        .padding(.bottom, 22)
-        .padding(.horizontal, 22)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(palette.windowBg)
     }
 
     private var header: some View {
@@ -117,29 +143,24 @@ struct InsightsTabView: View {
                     .font(WinkType.bodyText)
                     .foregroundStyle(palette.textSecondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .frame(maxHeight: .infinity, alignment: .topLeading)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 18)
             } else {
-                GeometryReader { proxy in
-                    ScrollView {
-                        LazyVStack(spacing: 0) {
-                            ForEach(Array(viewModel.appRows.enumerated()), id: \.element.id) { index, item in
-                                InsightsAppRow(
-                                    item: item,
-                                    showsDivider: index < viewModel.appRows.count - 1
-                                )
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .frame(minHeight: proxy.size.height, alignment: .top)
+                // Full-flow rows, no internal ScrollView: the surrounding
+                // region scroller in `body` is the tab's single scroller
+                // (LayoutRegressionTests pins that contract), and the row
+                // count is bounded by the shortcut count. Plain VStack, not
+                // Lazy — every row participates in the region's layout.
+                VStack(spacing: 0) {
+                    ForEach(Array(viewModel.appRows.enumerated()), id: \.element.id) { index, item in
+                        InsightsAppRow(
+                            item: item,
+                            showsDivider: index < viewModel.appRows.count - 1
+                        )
                     }
-                    .scrollIndicators(.automatic, axes: .vertical)
                 }
-                .frame(minHeight: 140, maxHeight: .infinity, alignment: .top)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .frame(maxHeight: .infinity, alignment: .topLeading)
-        .layoutPriority(1)
     }
 }

--- a/Sources/Wink/UI/InsightsTabView.swift
+++ b/Sources/Wink/UI/InsightsTabView.swift
@@ -66,7 +66,11 @@ struct InsightsTabView: View {
                 }
             }
             .scrollIndicators(.automatic, axes: .vertical)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            // The 140pt floor carries over from the pre-#393 ranking region:
+            // at compact window heights the fixed blocks above would
+            // otherwise compress this flexible region to zero, leaving the
+            // tail cards neither visible nor scrollable.
+            .frame(maxWidth: .infinity, minHeight: 140, maxHeight: .infinity, alignment: .topLeading)
         }
         .padding(.top, 18)
         .padding(.bottom, 22)


### PR DESCRIPTION
Fixes #393

## Summary
- The "Suggested shortcuts" card now carries the standard content insets (`.padding(.horizontal, 14)` + vertical 12): the subtitle no longer sits flush against the title divider, and the "N× this period" labels no longer touch the card edge. `WinkCard` pads only its title row by design — content insets are each caller's job, and this card (added in #366) shipped without any.
- The Insights tab's single scroll region now spans ranking + unused-nudge + suggestions instead of the ranking card alone. Header, KPIs, and the hourly heatmap stay fixed; everything below shares the one scroller, so the tail cards can never be pushed off the window again. Previously, with the nudge AND a populated suggestions card, the fixed blocks' natural heights exceeded the 816 pt window and the suggestions card was silently clipped (observed at 1.5 of its 3 rows, zh-Hans).
- The ranking card renders its rows in full flow inside the region (plain `VStack`; row count is bounded by the shortcut count) — the repo's one-scroller-per-surface contract holds, and both `LayoutRegressionTests` scroller tests (`insightsMostUsedRegionOwnsVerticalScroller`, `insightsMostUsedExposesSingleVerticalScroller`) pass **unchanged**.
- Window sizing untouched; the fix is locale-independent (zh-Hans line wrapping made it more visible but English clips identically with enough content).

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

`swift test`: 717/717 green, including both pre-existing layout-regression scroller contracts with zero test edits. Packaged build visually verified in zh-Hans: all three suggestion rows reachable via the region scroll, insets correct, dashboard top fixed (`build/validation/batch-386-388-2026-07-23/screenshots/insights-zh-fixed-bottom.png` vs `insights-zh-clipped.png` before). `scripts/e2e-full-test.sh`: 6/6 PASS, 0 warnings.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Purely presentational (one SwiftUI view file); per `pr-review-loop`, the local pre-push Codex review is not required for this class.
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
