### PR TITLE
feat: codify the guide media recording pipeline as a repo skill

### DIFF
--- a/.claude/skills/guide-media-pipeline/SKILL.md
+++ b/.claude/skills/guide-media-pipeline/SKILL.md
@@ -38,9 +38,11 @@ All scripts live in `scripts/` next to this file. Work dir defaults to
    relaunches Wink, sets the brand wallpaper, pauses PomoFox (noting
    whether it was running), and stages Safari (3 windows, one
    minimized) + Terminal (3 windows, one minimized) on the stage
-   display. Refuses to start while Safari/Terminal are running, and
-   aborts — restored windows untouched — if Resume hands either launch
-   a saved session. **Verifies `shortcuts=4
+   display. Refuses to start while Safari/Terminal are running or while
+   Resume ("keep windows on quit") is enabled for Terminal, and aborts
+   — restored windows untouched — if a Safari launch brings back a
+   saved session. Works on a never-launched install (the config dir is
+   initialized before backup). **Verifies `shortcuts=4
    triggerIndex=4` in `~/.config/Wink/debug.log` before returning.**
 2. `record-clips.sh` — records the five clips (~2 min hands-off).
 3. Screenshot matrix — for each locale × theme, relaunch/switch then

--- a/.claude/skills/guide-media-pipeline/SKILL.md
+++ b/.claude/skills/guide-media-pipeline/SKILL.md
@@ -38,7 +38,9 @@ All scripts live in `scripts/` next to this file. Work dir defaults to
    relaunches Wink, sets the brand wallpaper, pauses PomoFox (noting
    whether it was running), and stages Safari (3 windows, one
    minimized) + Terminal (3 windows, one minimized) on the stage
-   display. **Verifies `shortcuts=4
+   display. Refuses to start while Safari/Terminal are running, and
+   aborts — restored windows untouched — if Resume hands either launch
+   a saved session. **Verifies `shortcuts=4
    triggerIndex=4` in `~/.config/Wink/debug.log` before returning.**
 2. `record-clips.sh` — records the five clips (~2 min hands-off).
 3. Screenshot matrix — for each locale × theme, relaunch/switch then
@@ -62,7 +64,8 @@ All scripts live in `scripts/` next to this file. Work dir defaults to
 6. `restore.sh <backup-dir>` — restores config, defaults, language,
    wallpaper, PomoFox (only if it was running before staging), quits
    staged apps, relaunches Wink. **Never skip
-   this.** Verify the user's shortcut count afterwards (it prints it).
+   this.** Verify the user's shortcut count afterwards (it prints it;
+   a profile that had no shortcuts.json gets its absence back too).
 7. Wire any new media into `docs/design/landing/guide.html` and
    `guide-zh.html` (`.fig` figures; videos 1480×1000, screenshots
    860×816 — keep the width/height attributes truthful), run

--- a/.claude/skills/guide-media-pipeline/SKILL.md
+++ b/.claude/skills/guide-media-pipeline/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: guide-media-pipeline
+description: Reproducible pipeline for the /guide demo videos and Settings screenshots — staging a demo config, scripted CGEvent recording, theme/locale screenshot matrix, encoding, R2 upload, and full environment restore. Load before re-recording guide media, refreshing screenshots after a UI change, or adding a locale.
+---
+
+# Guide Media Pipeline
+
+Everything at `wink.aixie.de/media/*` (five demo videos, twelve Settings
+screenshots) was produced by this pipeline on 2026-07-23. It is fully
+scripted so a UI change means re-running it, not re-doing it by hand.
+
+## Hard preconditions
+
+- **The user must be present and must approve the run.** The pipeline
+  injects global keystrokes, drives the frontmost app, changes system
+  appearance, swaps the wallpaper, and records the screen. The machine
+  must be hands-off during recording windows (announce them).
+- One display whose current Space is **empty** (the stage). Scripts
+  assume it spans `0,0,1920x1080`; adjust the geometry constants if the
+  layout changed (`winlist`-style CGWindowList dumps tell you).
+- TCC for the terminal host: Accessibility (CGEvent posting + System
+  Events UI scripting) and Screen Recording (`screencapture`). Grants
+  persist per host app; a first run may prompt.
+- `wrangler` OAuth able to write bucket `wink-releases` (no S3 keys
+  needed) and `ffmpeg` on PATH.
+- Wink installed at `/Applications/Wink.app` — record the SHIPPED build,
+  never a dev build.
+
+## Run book
+
+All scripts live in `scripts/` next to this file. Work dir defaults to
+`~/.cache/wink-guide-media` (backups live there too — NOT in /tmp).
+
+1. `stage.sh` — backs up `~/Library/Application Support/Wink/` and the
+   `com.wink.app` defaults, installs the demo config (⇪S Safari
+   toggle+picker · ⇪T Terminal cycle · ⇪N Notes · ⇪Space palette),
+   swaps in a synthetic `usage.db`, switches the app to English,
+   relaunches Wink, sets the brand wallpaper, quits PomoFox, and stages
+   Safari (3 windows, one minimized) + Terminal (3 windows, one
+   minimized) on the stage display. **Verifies `shortcuts=4
+   triggerIndex=4` in `~/.config/Wink/debug.log` before returning.**
+2. `record-clips.sh` — records the five clips (~2 min hands-off).
+3. Screenshot matrix — for each locale × theme, relaunch/switch then
+   `shoot-settings.sh <suffix>`:
+   ```
+   shoot-settings.sh en-dark          # system dark, app English
+   (switch appearance to light)       # osascript System Events
+   shoot-settings.sh en-light
+   (defaults write com.wink.app AppleLanguages -array zh-Hans; relaunch)
+   shoot-settings.sh zh-light
+   (switch appearance back to dark)
+   shoot-settings.sh zh-dark
+   ```
+4. **Review every clip and screenshot frame-by-frame for personal
+   content before upload.** Extract frames with ffmpeg and look at them.
+   Palette queries must resolve to STAGED apps only — a broad query
+   surfaces the user's real installed apps (a "term" query once launched
+   the user's Termius).
+5. `encode-and-upload.sh` — crops/encodes the clips and uploads all
+   media to `wink-releases` under `wink/guide/`.
+6. `restore.sh <backup-dir>` — restores config, defaults, language,
+   wallpaper, PomoFox, quits staged apps, relaunches Wink. **Never skip
+   this.** Verify the user's shortcut count afterwards (it prints it).
+7. Wire any new media into `docs/design/landing/guide.html` and
+   `guide-zh.html` (`.fig` figures; videos 1480×1000, screenshots
+   860×816 — keep the width/height attributes truthful), run
+   `scripts/generate-worker-site.py`, and ship through the normal PR
+   flow (`pr-review-loop`).
+
+## Media contract
+
+- Bucket `wink-releases`, key prefix `wink/guide/`, served same-origin
+  by the worker at `/media/<basename>` (allow-list: `[a-z0-9-]+\.(mp4|png)`).
+- The worker implements single-range 206 responses — Safari refuses
+  `<video>` without them. Don't move media to a host that lacks ranges.
+- Screenshots ship as light/dark pairs and follow the page theme via
+  `.only-light` / `.only-dark`; zh pages use zh screenshots.
+
+## Gotchas (each cost a re-take)
+
+1. **`screencapture -v` never overwrites** — `rm -f` the target first,
+   or it records fine and then fails to save.
+2. **Sentinel shortcuts need `"target"`** (`"searchPalette"` /
+   `"frontmostApp"`) in shortcuts.json, or they are silently dropped
+   from the trigger index while the cheat sheet still shows them (#404).
+   Space is the string `"space"`, not `" "`.
+3. **Synthetic usage.db must carry `PRAGMA user_version = 3`** or Wink
+   wipes and re-creates it at launch.
+4. **Palette-commit activation doesn't raise the target's windows**
+   (#403) — for the palette clip, pre-hide the target so the commit
+   visibly springs its windows back.
+5. **Settings sidebar tabs**: AX name-matching is unreliable for zh and
+   row indices shift; click by coordinates (window pinned at 530,130).
+   The Settings window is AX `window "Wink"`; window 1 is the popover.
+6. **Headless Chrome's minimum window width is 500** — a "390px"
+   screenshot is a cropped 500px viewport, not a layout overflow.
+   Measure `document.scrollWidth` before diagnosing.
+7. Quit overlay apps before recording (PomoFox's floating timer
+   photobombs and its break screen can take over mid-clip); restore
+   after. Wallpaper set via System Events needs `killall WallpaperAgent`
+   to actually apply.
+8. Panels appear on the display hosting the **pointer** — park the
+   mouse on the stage display (scripts do this).
+9. F19 chords: hold >80 ms, set flags explicitly — see the synthetic
+   input rules in `AGENTS.md` history and scripts/e2e-lib.sh lineage.
+10. Cycling un-minimizes windows and clip order mutates window state —
+    each clip's script re-establishes its own pre-state; don't reorder
+    clips without re-checking pre-states.

--- a/.claude/skills/guide-media-pipeline/SKILL.md
+++ b/.claude/skills/guide-media-pipeline/SKILL.md
@@ -23,6 +23,9 @@ scripted so a UI change means re-running it, not re-doing it by hand.
   persist per host app; a first run may prompt.
 - `wrangler` OAuth able to write bucket `wink-releases` (no S3 keys
   needed) and `ffmpeg` on PATH.
+- Google Chrome at `/Applications/Google Chrome.app` — it renders the
+  brand wallpaper headlessly; staging aborts without it rather than
+  record (and upload) the user's personal wallpaper.
 - Wink installed at `/Applications/Wink.app` — record the SHIPPED build,
   never a dev build.
 

--- a/.claude/skills/guide-media-pipeline/SKILL.md
+++ b/.claude/skills/guide-media-pipeline/SKILL.md
@@ -35,9 +35,10 @@ All scripts live in `scripts/` next to this file. Work dir defaults to
    `com.wink.app` defaults, installs the demo config (⇪S Safari
    toggle+picker · ⇪T Terminal cycle · ⇪N Notes · ⇪Space palette),
    swaps in a synthetic `usage.db`, switches the app to English,
-   relaunches Wink, sets the brand wallpaper, quits PomoFox, and stages
-   Safari (3 windows, one minimized) + Terminal (3 windows, one
-   minimized) on the stage display. **Verifies `shortcuts=4
+   relaunches Wink, sets the brand wallpaper, pauses PomoFox (noting
+   whether it was running), and stages Safari (3 windows, one
+   minimized) + Terminal (3 windows, one minimized) on the stage
+   display. **Verifies `shortcuts=4
    triggerIndex=4` in `~/.config/Wink/debug.log` before returning.**
 2. `record-clips.sh` — records the five clips (~2 min hands-off).
 3. Screenshot matrix — for each locale × theme, relaunch/switch then
@@ -59,7 +60,8 @@ All scripts live in `scripts/` next to this file. Work dir defaults to
 5. `encode-and-upload.sh` — crops/encodes the clips and uploads all
    media to `wink-releases` under `wink/guide/`.
 6. `restore.sh <backup-dir>` — restores config, defaults, language,
-   wallpaper, PomoFox, quits staged apps, relaunches Wink. **Never skip
+   wallpaper, PomoFox (only if it was running before staging), quits
+   staged apps, relaunches Wink. **Never skip
    this.** Verify the user's shortcut count afterwards (it prints it).
 7. Wire any new media into `docs/design/landing/guide.html` and
    `guide-zh.html` (`.fig` figures; videos 1480×1000, screenshots

--- a/.claude/skills/guide-media-pipeline/scripts/demo-shortcuts.json
+++ b/.claude/skills/guide-media-pipeline/scripts/demo-shortcuts.json
@@ -15,7 +15,8 @@
     "id": "AAAAAAA2-0000-4000-8000-000000000002",
     "isEnabled": true,
     "keyEquivalent": "t",
-    "modifierFlags": ["control", "option", "shift", "command"]
+    "modifierFlags": ["control", "option", "shift", "command"],
+    "frontmostBehaviorOverride": "cycleWindows"
   },
   {
     "appName": "Notes",

--- a/.claude/skills/guide-media-pipeline/scripts/demo-shortcuts.json
+++ b/.claude/skills/guide-media-pipeline/scripts/demo-shortcuts.json
@@ -1,0 +1,38 @@
+[
+  {
+    "appName": "Safari",
+    "bundleIdentifier": "com.apple.Safari",
+    "id": "AAAAAAA1-0000-4000-8000-000000000001",
+    "isEnabled": true,
+    "keyEquivalent": "s",
+    "modifierFlags": ["control", "option", "shift", "command"],
+    "frontmostBehaviorOverride": "toggle",
+    "holdAction": "windowPicker"
+  },
+  {
+    "appName": "Terminal",
+    "bundleIdentifier": "com.apple.Terminal",
+    "id": "AAAAAAA2-0000-4000-8000-000000000002",
+    "isEnabled": true,
+    "keyEquivalent": "t",
+    "modifierFlags": ["control", "option", "shift", "command"]
+  },
+  {
+    "appName": "Notes",
+    "bundleIdentifier": "com.apple.Notes",
+    "id": "AAAAAAA3-0000-4000-8000-000000000003",
+    "isEnabled": true,
+    "keyEquivalent": "n",
+    "modifierFlags": ["control", "option", "shift", "command"],
+    "frontmostBehaviorOverride": "toggle"
+  },
+  {
+    "appName": "Search Palette",
+    "bundleIdentifier": "wink.target.search-palette",
+    "id": "AAAAAAA4-0000-4000-8000-000000000004",
+    "isEnabled": true,
+    "keyEquivalent": "space",
+    "modifierFlags": ["control", "option", "shift", "command"],
+    "target": "searchPalette"
+  }
+]

--- a/.claude/skills/guide-media-pipeline/scripts/encode-and-upload.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/encode-and-upload.sh
@@ -1,0 +1,31 @@
+#!/bin/zsh
+# Encode the recorded clips and upload all media to R2.
+# Contract: worker serves /media/<basename> from wink-releases: wink/guide/.
+# Videos crop to 1480x1000 (guide <video> width/height attrs must match).
+set -eu
+WORK="${WINK_MEDIA_WORK:-$HOME/.cache/wink-guide-media}"
+MEDIA="$WORK/media"
+mkdir -p "$MEDIA"
+
+for src in "$WORK"/rec/clip-*.mov; do
+  name="guide-${${src:t:r}#clip-}"
+  ffmpeg -loglevel error -ss 1.2 -i "$src" -vf "crop=1480:1000:280:80" \
+    -c:v libx264 -preset slow -crf 23 -pix_fmt yuv420p -movflags +faststart -an \
+    -y "$MEDIA/$name.mp4"
+  echo "encoded $name.mp4 ($(du -h "$MEDIA/$name.mp4" | cut -f1))"
+done
+
+echo "REVIEW GATE: inspect every clip and screenshot before uploading."
+echo "  e.g. ffmpeg -ss 3 -i $MEDIA/guide-cycle.mp4 -frames:v 1 frame.jpg"
+read -r "?Upload $MEDIA/*.mp4 and $WORK/shots/*.png to wink-releases/wink/guide/ ? [y/N] " yn
+[ "$yn" = "y" ] || { echo "aborted before upload"; exit 1; }
+
+for f in "$MEDIA"/*.mp4; do
+  npx --yes wrangler@latest r2 object put "wink-releases/wink/guide/${f:t}" \
+    --file "$f" --content-type video/mp4 --remote
+done
+for f in "$WORK"/shots/*.png; do
+  npx --yes wrangler@latest r2 object put "wink-releases/wink/guide/${f:t}" \
+    --file "$f" --content-type image/png --remote
+done
+echo "UPLOAD_DONE — verify: curl -sI -H 'Range: bytes=0-1' https://wink.aixie.de/media/guide-cycle.mp4"

--- a/.claude/skills/guide-media-pipeline/scripts/make-demo-usage.py
+++ b/.claude/skills/guide-media-pipeline/scripts/make-demo-usage.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Build a synthetic usage.db for Insights screenshots (no real user data).
+
+Usage: make-demo-usage.py <output.db>
+
+The schema and user_version MUST match PersistenceService
+(requiredSchemaVersion = 3) or Wink wipes the file at launch.
+"""
+import datetime
+import pathlib
+import sqlite3
+import sys
+
+out = pathlib.Path(sys.argv[1])
+out.unlink(missing_ok=True)
+db = sqlite3.connect(out)
+db.executescript(
+    """
+CREATE TABLE daily_usage (
+    shortcut_id TEXT NOT NULL,
+    date        TEXT NOT NULL,
+    count       INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (shortcut_id, date)
+);
+CREATE TABLE usage_hourly (
+    shortcut_id TEXT NOT NULL,
+    date        TEXT NOT NULL,
+    hour        INTEGER NOT NULL CHECK(hour BETWEEN 0 AND 23),
+    count       INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (shortcut_id, date, hour)
+);
+CREATE INDEX idx_usage_hourly_date_hour ON usage_hourly(date, hour);
+CREATE INDEX idx_daily_usage_date ON daily_usage(date);
+CREATE TABLE app_activations (
+    bundle_id TEXT NOT NULL,
+    date      TEXT NOT NULL,
+    count     INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (bundle_id, date)
+);
+CREATE INDEX idx_app_activations_date ON app_activations(date);
+PRAGMA user_version = 3;
+"""
+)
+
+S = "AAAAAAA1-0000-4000-8000-000000000001"
+T = "AAAAAAA2-0000-4000-8000-000000000002"
+N = "AAAAAAA3-0000-4000-8000-000000000003"
+today = datetime.date.today()
+
+
+def wobble(i, lo, hi):
+    return lo + ((i * 7919 + 104729) % (hi - lo + 1))
+
+
+HOURS = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+WEIGHTS = [4, 9, 10, 7, 3, 2, 6, 8, 9, 8, 5, 3, 2, 1]
+WSUM = sum(WEIGHTS)
+
+for i in range(30):
+    day = today - datetime.timedelta(days=i)
+    if i == 16:
+        continue  # one quiet day caps the streak at 16
+    weekend = day.weekday() >= 5
+    for sid, lo, hi in ((S, 9, 24), (T, 12, 30), (N, 3, 11)):
+        total = wobble(i + hash(sid) % 97, lo, hi)
+        if weekend:
+            total = max(1, total // 3)
+        db.execute("INSERT INTO daily_usage VALUES (?,?,?)", (sid, day.isoformat(), total))
+        left = total
+        for h, w in zip(HOURS, WEIGHTS):
+            c = min(round(total * w / WSUM), left)
+            if c > 0:
+                db.execute("INSERT INTO usage_hourly VALUES (?,?,?,?)", (sid, day.isoformat(), h, c))
+                left -= c
+        if left > 0:
+            db.execute(
+                "UPDATE usage_hourly SET count = count + ? WHERE shortcut_id=? AND date=? AND hour=10",
+                (left, sid, day.isoformat()),
+            )
+
+# suggestion candidates: unbound (but installed) apps with foreground activity
+for i in range(7):
+    day = today - datetime.timedelta(days=i)
+    db.execute("INSERT INTO app_activations VALUES (?,?,?)", ("com.googlecode.iterm2", day.isoformat(), 3 + (i % 4)))
+    db.execute("INSERT INTO app_activations VALUES (?,?,?)", ("ru.keepcoder.Telegram", day.isoformat(), 1 + (i % 2)))
+
+db.commit()
+print("rows:", db.execute("SELECT COUNT(*) FROM usage_hourly").fetchone()[0])
+db.close()

--- a/.claude/skills/guide-media-pipeline/scripts/make-demo-usage.py
+++ b/.claude/skills/guide-media-pipeline/scripts/make-demo-usage.py
@@ -10,6 +10,7 @@ import datetime
 import pathlib
 import sqlite3
 import sys
+import zlib
 
 out = pathlib.Path(sys.argv[1])
 out.unlink(missing_ok=True)
@@ -52,6 +53,11 @@ def wobble(i, lo, hi):
     return lo + ((i * 7919 + 104729) % (hi - lo + 1))
 
 
+def stable_seed(text):
+    # hash() is randomized per process (PYTHONHASHSEED); crc32 is not.
+    return zlib.crc32(text.encode())
+
+
 HOURS = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
 WEIGHTS = [4, 9, 10, 7, 3, 2, 6, 8, 9, 8, 5, 3, 2, 1]
 WSUM = sum(WEIGHTS)
@@ -62,7 +68,7 @@ for i in range(30):
         continue  # one quiet day caps the streak at 16
     weekend = day.weekday() >= 5
     for sid, lo, hi in ((S, 9, 24), (T, 12, 30), (N, 3, 11)):
-        total = wobble(i + hash(sid) % 97, lo, hi)
+        total = wobble(i + stable_seed(sid) % 97, lo, hi)
         if weekend:
             total = max(1, total // 3)
         db.execute("INSERT INTO daily_usage VALUES (?,?,?)", (sid, day.isoformat(), total))
@@ -78,11 +84,27 @@ for i in range(30):
                 (left, sid, day.isoformat()),
             )
 
-# suggestion candidates: unbound (but installed) apps with foreground activity
+# suggestion candidates: unbound apps with foreground activity — but only
+# ones actually installed on THIS machine, or the Suggested card renders
+# nothing on a different host.
+CANDIDATES = [
+    ("com.googlecode.iterm2", "/Applications/iTerm.app"),
+    ("ru.keepcoder.Telegram", "/Applications/Telegram.app"),
+    ("com.tinyspeck.slackmacgap", "/Applications/Slack.app"),
+    ("com.google.Chrome", "/Applications/Google Chrome.app"),
+    ("org.mozilla.firefox", "/Applications/Firefox.app"),
+    ("com.microsoft.VSCode", "/Applications/Visual Studio Code.app"),
+]
+installed = [b for b, path in CANDIDATES if pathlib.Path(path).exists()][:2]
+if not installed:
+    print("warning: no suggestion candidates installed; Suggested card will be empty")
 for i in range(7):
     day = today - datetime.timedelta(days=i)
-    db.execute("INSERT INTO app_activations VALUES (?,?,?)", ("com.googlecode.iterm2", day.isoformat(), 3 + (i % 4)))
-    db.execute("INSERT INTO app_activations VALUES (?,?,?)", ("ru.keepcoder.Telegram", day.isoformat(), 1 + (i % 2)))
+    for rank, bundle in enumerate(installed):
+        db.execute(
+            "INSERT INTO app_activations VALUES (?,?,?)",
+            (bundle, day.isoformat(), (3 + (i % 4)) if rank == 0 else (1 + (i % 2))),
+        )
 
 db.commit()
 print("rows:", db.execute("SELECT COUNT(*) FROM usage_hourly").fetchone()[0])

--- a/.claude/skills/guide-media-pipeline/scripts/record-clips.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/record-clips.sh
@@ -1,7 +1,7 @@
 #!/bin/zsh
 # Record the five guide demo clips on the stage display (0,0,1920x1080).
 # Requires stage.sh to have run. ~2 minutes; the machine must be hands-off.
-set -u
+set -eu
 WORK="${WINK_MEDIA_WORK:-$HOME/.cache/wink-guide-media}"
 K="$WORK/winkkeys"
 R="$WORK/rec"
@@ -23,7 +23,17 @@ record() { # $1=name $2=seconds — screencapture never overwrites (gotcha #1)
   sleep 2.0
 }
 
-finish() { wait $CAP 2>/dev/null; echo "clip done: $1"; }
+# wait propagates screencapture's exit status, so a failed recording
+# (Screen Recording revoked, disk full) aborts here under set -e instead
+# of silently reporting ALL_CLIPS_DONE; the size check catches an exit-0
+# capture that still wrote nothing
+finish() {
+  if ! wait $CAP 2>/dev/null; then
+    echo "CAPTURE FAILED (screencapture exit nonzero): $1" >&2; exit 1
+  fi
+  [ -s "$R/$1.mov" ] || { echo "CAPTURE FAILED (empty/missing): $1" >&2; exit 1; }
+  echo "clip done: $1"
+}
 
 # ---------- A: first chord (Safari summon / dismiss / summon) ----------
 front Terminal; sleep 1.2; park_mouse

--- a/.claude/skills/guide-media-pipeline/scripts/record-clips.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/record-clips.sh
@@ -1,0 +1,72 @@
+#!/bin/zsh
+# Record the five guide demo clips on the stage display (0,0,1920x1080).
+# Requires stage.sh to have run. ~2 minutes; the machine must be hands-off.
+set -u
+WORK="${WINK_MEDIA_WORK:-$HOME/.cache/wink-guide-media}"
+K="$WORK/winkkeys"
+R="$WORK/rec"
+mkdir -p "$R"
+
+park_mouse() {
+  python3 -c "
+import Quartz
+ev = Quartz.CGEventCreateMouseEvent(None, Quartz.kCGEventMouseMoved, (80, 1040), 0)
+Quartz.CGEventPost(Quartz.kCGHIDEventTap, ev)"
+}
+
+front() { osascript -e "tell application \"$1\" to activate" >/dev/null 2>&1; }
+
+record() { # $1=name $2=seconds — screencapture never overwrites (gotcha #1)
+  rm -f "$R/$1.mov"
+  screencapture -v -V "$2" -R 0,0,1920,1080 "$R/$1.mov" &
+  CAP=$!
+  sleep 2.0
+}
+
+finish() { wait $CAP 2>/dev/null; echo "clip done: $1"; }
+
+# ---------- A: first chord (Safari summon / dismiss / summon) ----------
+front Terminal; sleep 1.2; park_mouse
+record clip-first-chord 13
+"$K" chord 1 150;  sleep 2.2
+"$K" chord 1 150;  sleep 2.2
+"$K" chord 1 150;  sleep 2.0
+finish clip-first-chord
+
+# ---------- B: cycle Terminal windows (incl. minimized) ----------
+front Terminal; sleep 1.2; park_mouse
+record clip-cycle 13
+"$K" chord 17 150; sleep 1.8
+"$K" chord 17 150; sleep 1.8
+"$K" chord 17 150; sleep 1.8
+"$K" chord 17 150; sleep 2.0
+finish clip-cycle
+
+# ---------- C: hold to pick a window (Safari picker) ----------
+front Terminal; sleep 1.2; park_mouse
+record clip-picker 15
+"$K" chord 1 1300; sleep 1.6   # hold past threshold; picker stays after release
+"$K" key 125;      sleep 0.9
+"$K" key 125;      sleep 0.9
+"$K" key 36;       sleep 2.2
+finish clip-picker
+
+# ---------- D: search palette (pre-hide Safari — #403 workaround) ----------
+front Terminal; sleep 1.0
+"$K" chord 1 150; sleep 1.2   # summon
+"$K" chord 1 150; sleep 1.0   # hide — commit will visibly spring it back
+front Terminal; sleep 0.8; park_mouse
+record clip-palette 12
+"$K" chord 49 150; sleep 1.4
+"$K" type safa;    sleep 1.6   # staged app ONLY — broad queries surface real apps
+"$K" key 36;       sleep 2.5
+finish clip-palette
+
+# ---------- E: cheat sheet (hold Hyper alone) ----------
+front Terminal; sleep 1.2; park_mouse
+record clip-cheatsheet 9
+"$K" f19 2600;     sleep 1.6
+finish clip-cheatsheet
+
+ls -la "$R"
+echo ALL_CLIPS_DONE

--- a/.claude/skills/guide-media-pipeline/scripts/restore.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/restore.sh
@@ -7,14 +7,19 @@ APPSUP="$HOME/Library/Application Support/Wink"
 [ -d "$BACKUP/AppSupport" ] || { echo "not a stage.sh backup: $BACKUP" >&2; exit 1; }
 
 pkill -x Wink || true; sleep 0.6
-cp "$BACKUP/AppSupport/shortcuts.json" "$BACKUP/AppSupport/usage.db" "$APPSUP/"
-# restore recent-apps.json's absence too: if the user never had one, a
-# file the demo session created must not survive the restore
-if [ -f "$BACKUP/AppSupport/recent-apps.json" ]; then
-  cp "$BACKUP/AppSupport/recent-apps.json" "$APPSUP/"
-else
-  rm -f "$APPSUP/recent-apps.json"
-fi
+# put back exactly what stage.sh backed up: a file absent from the
+# backup must be absent after the restore too. A fresh profile
+# legitimately lacks shortcuts.json (PersistenceService.load() treats a
+# missing file as an empty configuration) — the demo copy must not
+# outlive the shoot, and an unconditional cp would abort the whole
+# restore under set -e before defaults/wallpaper are put back
+for f in shortcuts.json usage.db recent-apps.json; do
+  if [ -f "$BACKUP/AppSupport/$f" ]; then
+    cp "$BACKUP/AppSupport/$f" "$APPSUP/"
+  else
+    rm -f "$APPSUP/$f"
+  fi
+done
 
 # restore the ENTIRE defaults domain from the backup export — the shoot
 # touches more than AppleLanguages (and future stagings may touch more
@@ -57,5 +62,9 @@ if [ ! -f "$BACKUP/notes-was-running" ]; then
   osascript -e 'tell application "Notes" to quit' 2>/dev/null || true
 fi
 
-count=$(python3 -c "import json;print(len(json.load(open('$APPSUP/shortcuts.json'))))")
-echo "RESTORED — $count user shortcuts back in place (verify this matches expectations)"
+if [ -f "$APPSUP/shortcuts.json" ]; then
+  count=$(python3 -c "import json;print(len(json.load(open('$APPSUP/shortcuts.json'))))")
+  echo "RESTORED — $count user shortcuts back in place (verify this matches expectations)"
+else
+  echo "RESTORED — shortcutless profile preserved (no shortcuts.json, same as before staging)"
+fi

--- a/.claude/skills/guide-media-pipeline/scripts/restore.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/restore.sh
@@ -8,7 +8,13 @@ APPSUP="$HOME/Library/Application Support/Wink"
 
 pkill -x Wink || true; sleep 0.6
 cp "$BACKUP/AppSupport/shortcuts.json" "$BACKUP/AppSupport/usage.db" "$APPSUP/"
-[ -f "$BACKUP/AppSupport/recent-apps.json" ] && cp "$BACKUP/AppSupport/recent-apps.json" "$APPSUP/"
+# restore recent-apps.json's absence too: if the user never had one, a
+# file the demo session created must not survive the restore
+if [ -f "$BACKUP/AppSupport/recent-apps.json" ]; then
+  cp "$BACKUP/AppSupport/recent-apps.json" "$APPSUP/"
+else
+  rm -f "$APPSUP/recent-apps.json"
+fi
 
 # restore the ENTIRE defaults domain from the backup export — the shoot
 # touches more than AppleLanguages (and future stagings may touch more

--- a/.claude/skills/guide-media-pipeline/scripts/restore.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/restore.sh
@@ -25,7 +25,19 @@ fi
 
 open -a /Applications/Wink.app; sleep 1
 
-osascript -e 'tell application "System Events" to set picture of every desktop to POSIX file "/System/Library/CoreServices/DefaultDesktop.heic"' || true
+# restore the wallpapers stage.sh recorded (one path per desktop line);
+# fall back to the system default only if nothing was recorded
+if [ -s "$BACKUP/wallpapers.txt" ]; then
+  i=1
+  while IFS= read -r wp; do
+    if [ -n "$wp" ] && [ -e "$wp" ]; then
+      osascript -e "tell application \"System Events\" to set picture of desktop $i to POSIX file \"$wp\"" 2>/dev/null || true
+    fi
+    i=$((i + 1))
+  done < "$BACKUP/wallpapers.txt"
+else
+  osascript -e 'tell application "System Events" to set picture of every desktop to POSIX file "/System/Library/CoreServices/DefaultDesktop.heic"' || true
+fi
 killall WallpaperAgent 2>/dev/null || true
 if [ "$(cat "$BACKUP/appearance.txt" 2>/dev/null)" = "Dark" ]; then
   osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to true' || true

--- a/.claude/skills/guide-media-pipeline/scripts/restore.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/restore.sh
@@ -1,0 +1,41 @@
+#!/bin/zsh
+# Restore the user's environment after a shoot. Usage: restore.sh <backup-dir>
+# (the directory stage.sh printed). NEVER skip this step.
+set -eu
+BACKUP="$1"
+APPSUP="$HOME/Library/Application Support/Wink"
+[ -d "$BACKUP/AppSupport" ] || { echo "not a stage.sh backup: $BACKUP" >&2; exit 1; }
+
+pkill -x Wink || true; sleep 0.6
+cp "$BACKUP/AppSupport/shortcuts.json" "$BACKUP/AppSupport/usage.db" "$APPSUP/"
+[ -f "$BACKUP/AppSupport/recent-apps.json" ] && cp "$BACKUP/AppSupport/recent-apps.json" "$APPSUP/"
+
+# language back to what the backup recorded
+langs=$(python3 - "$BACKUP/com.wink.app.plist" <<'EOF'
+import plistlib, sys
+with open(sys.argv[1], "rb") as f:
+    print(" ".join(plistlib.load(f).get("AppleLanguages", [])))
+EOF
+)
+if [ -n "$langs" ]; then
+  defaults write com.wink.app AppleLanguages -array ${(z)langs}
+else
+  defaults delete com.wink.app AppleLanguages 2>/dev/null || true
+fi
+
+open -a /Applications/Wink.app; sleep 1
+
+osascript -e 'tell application "System Events" to set picture of every desktop to POSIX file "/System/Library/CoreServices/DefaultDesktop.heic"' || true
+killall WallpaperAgent 2>/dev/null || true
+if [ "$(cat "$BACKUP/appearance.txt" 2>/dev/null)" = "Dark" ]; then
+  osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to true' || true
+else
+  osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to false' || true
+fi
+open -g -a PomoFox 2>/dev/null || true
+osascript -e 'tell application "Safari" to quit' 2>/dev/null || true
+osascript -e 'tell application "Terminal" to quit' 2>/dev/null || true
+osascript -e 'tell application "Notes" to quit' 2>/dev/null || true
+
+count=$(python3 -c "import json;print(len(json.load(open('$APPSUP/shortcuts.json'))))")
+echo "RESTORED — $count user shortcuts back in place (verify this matches expectations)"

--- a/.claude/skills/guide-media-pipeline/scripts/restore.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/restore.sh
@@ -10,18 +10,11 @@ pkill -x Wink || true; sleep 0.6
 cp "$BACKUP/AppSupport/shortcuts.json" "$BACKUP/AppSupport/usage.db" "$APPSUP/"
 [ -f "$BACKUP/AppSupport/recent-apps.json" ] && cp "$BACKUP/AppSupport/recent-apps.json" "$APPSUP/"
 
-# language back to what the backup recorded
-langs=$(python3 - "$BACKUP/com.wink.app.plist" <<'EOF'
-import plistlib, sys
-with open(sys.argv[1], "rb") as f:
-    print(" ".join(plistlib.load(f).get("AppleLanguages", [])))
-EOF
-)
-if [ -n "$langs" ]; then
-  defaults write com.wink.app AppleLanguages -array ${(z)langs}
-else
-  defaults delete com.wink.app AppleLanguages 2>/dev/null || true
-fi
+# restore the ENTIRE defaults domain from the backup export — the shoot
+# touches more than AppleLanguages (and future stagings may touch more
+# still); delete-then-import puts back exactly what stage.sh saved
+defaults delete com.wink.app 2>/dev/null || true
+defaults import com.wink.app "$BACKUP/com.wink.app.plist"
 
 open -a /Applications/Wink.app; sleep 1
 

--- a/.claude/skills/guide-media-pipeline/scripts/restore.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/restore.sh
@@ -43,7 +43,11 @@ if [ "$(cat "$BACKUP/appearance.txt" 2>/dev/null)" = "Dark" ]; then
 else
   osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to false' || true
 fi
-open -g -a PomoFox 2>/dev/null || true
+# reopen PomoFox only if stage.sh actually paused it: a full restore
+# must not add apps to a session that never had them
+if [ -f "$BACKUP/pomofox-was-running" ]; then
+  open -g -a PomoFox 2>/dev/null || true
+fi
 osascript -e 'tell application "Safari" to quit' 2>/dev/null || true
 osascript -e 'tell application "Terminal" to quit' 2>/dev/null || true
 osascript -e 'tell application "Notes" to quit' 2>/dev/null || true

--- a/.claude/skills/guide-media-pipeline/scripts/restore.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/restore.sh
@@ -50,7 +50,12 @@ if [ -f "$BACKUP/pomofox-was-running" ]; then
 fi
 osascript -e 'tell application "Safari" to quit' 2>/dev/null || true
 osascript -e 'tell application "Terminal" to quit' 2>/dev/null || true
-osascript -e 'tell application "Notes" to quit' 2>/dev/null || true
+# Notes was only launched by the ⇪N demo chord — quit it unless the
+# user already had it running before staging (Safari/Terminal need no
+# marker: stage.sh refuses to run while they are open)
+if [ ! -f "$BACKUP/notes-was-running" ]; then
+  osascript -e 'tell application "Notes" to quit' 2>/dev/null || true
+fi
 
 count=$(python3 -c "import json;print(len(json.load(open('$APPSUP/shortcuts.json'))))")
 echo "RESTORED — $count user shortcuts back in place (verify this matches expectations)"

--- a/.claude/skills/guide-media-pipeline/scripts/shoot-settings.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/shoot-settings.sh
@@ -1,0 +1,47 @@
+#!/bin/zsh
+# Capture the three Settings tabs. Usage: shoot-settings.sh <suffix>
+# (e.g. en-dark). Caller controls app language and system appearance:
+#   defaults write com.wink.app AppleLanguages -array zh-Hans && relaunch Wink
+#   osascript -e 'tell app "System Events" to tell appearance preferences to set dark mode to false'
+# Tabs are clicked by COORDINATES (window pinned at 530,130) because AX
+# name-matching is unreliable for zh and row indices shift (gotcha #5).
+set -u
+SUF="$1"
+WORK="${WINK_MEDIA_WORK:-$HOME/.cache/wink-guide-media}"
+OUT="$WORK/shots"
+mkdir -p "$OUT"
+
+osascript -e 'tell application "System Events" to tell process "Wink" to click menu bar item 1 of menu bar 2' >/dev/null
+sleep 1
+osascript -e 'tell application "System Events" to tell process "Wink" to click button 2 of group 1 of window 1' >/dev/null
+sleep 1.2
+osascript -e 'tell application "System Events" to tell process "Wink"
+  set position of window "Wink" to {530, 130}
+end tell' >/dev/null
+sleep 0.4
+
+winid=$(python3 -c "
+import Quartz
+wins = Quartz.CGWindowListCopyWindowInfo(Quartz.kCGWindowListOptionOnScreenOnly, Quartz.kCGNullWindowID)
+for w in wins:
+    if w.get('kCGWindowOwnerName') == 'Wink' and w.get('kCGWindowLayer') == 0 and w['kCGWindowBounds']['Width'] > 500:
+        print(w.get('kCGWindowNumber')); break")
+if [ -z "$winid" ]; then echo "NO SETTINGS WINDOW"; exit 1; fi
+
+click_row() { # $1 = global y (sidebar x=620; rows: 200 Shortcuts / 228 Insights / 256 General)
+  python3 -c "
+import Quartz, time
+def ev(t, pos):
+    Quartz.CGEventPost(Quartz.kCGHIDEventTap, Quartz.CGEventCreateMouseEvent(None, t, pos, 0))
+p = (620, $1)
+ev(Quartz.kCGEventMouseMoved, p); time.sleep(0.1)
+ev(Quartz.kCGEventLeftMouseDown, p); time.sleep(0.05)
+ev(Quartz.kCGEventLeftMouseUp, p)"
+  sleep 0.9
+}
+
+click_row 256; screencapture -x -o -l"$winid" "$OUT/settings-general-$SUF.png"
+click_row 200; screencapture -x -o -l"$winid" "$OUT/settings-shortcuts-$SUF.png"
+click_row 228; screencapture -x -o -l"$winid" "$OUT/settings-insights-$SUF.png"
+
+echo "SHOTS_DONE_$SUF"

--- a/.claude/skills/guide-media-pipeline/scripts/shoot-settings.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/shoot-settings.sh
@@ -5,7 +5,7 @@
 #   osascript -e 'tell app "System Events" to tell appearance preferences to set dark mode to false'
 # Tabs are clicked by COORDINATES (window pinned at 530,130) because AX
 # name-matching is unreliable for zh and row indices shift (gotcha #5).
-set -u
+set -eu
 SUF="$1"
 WORK="${WINK_MEDIA_WORK:-$HOME/.cache/wink-guide-media}"
 OUT="$WORK/shots"
@@ -40,8 +40,17 @@ ev(Quartz.kCGEventLeftMouseUp, p)"
   sleep 0.9
 }
 
-click_row 256; screencapture -x -o -l"$winid" "$OUT/settings-general-$SUF.png"
-click_row 200; screencapture -x -o -l"$winid" "$OUT/settings-shortcuts-$SUF.png"
-click_row 228; screencapture -x -o -l"$winid" "$OUT/settings-insights-$SUF.png"
+shot() { # $1 = row y, $2 = output png. Delete the old file first so a
+  # failed capture can never leave a stale same-named PNG for
+  # encode-and-upload.sh to ship as if it were fresh.
+  click_row "$1"
+  rm -f "$2"
+  screencapture -x -o -l"$winid" "$2"
+  [ -s "$2" ] || { echo "CAPTURE FAILED (empty/missing): $2" >&2; exit 1; }
+}
+
+shot 256 "$OUT/settings-general-$SUF.png"
+shot 200 "$OUT/settings-shortcuts-$SUF.png"
+shot 228 "$OUT/settings-insights-$SUF.png"
 
 echo "SHOTS_DONE_$SUF"

--- a/.claude/skills/guide-media-pipeline/scripts/stage.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/stage.sh
@@ -47,7 +47,12 @@ fi
 # so initialize it rather than letting the copy abort the run.
 mkdir -p "$APPSUP"
 cp -a "$APPSUP/" "$BACKUP/AppSupport/"
-defaults export com.wink.app "$BACKUP/com.wink.app.plist"
+# On current macOS an absent com.wink.app domain exports as an empty
+# plist with exit 0 (verified on 15.6); the fallback covers versions
+# where export refuses, so restore.sh always has a file to import (an
+# empty domain and an absent one read identically to the app)
+defaults export com.wink.app "$BACKUP/com.wink.app.plist" 2>/dev/null || \
+  plutil -create binary1 "$BACKUP/com.wink.app.plist"
 defaults read -g AppleInterfaceStyle > "$BACKUP/appearance.txt" 2>/dev/null || echo Light > "$BACKUP/appearance.txt"
 # record current wallpapers, one path per desktop line, for restore.sh
 osascript > "$BACKUP/wallpapers.txt" 2>/dev/null <<'EOS' || true

--- a/.claude/skills/guide-media-pipeline/scripts/stage.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/stage.sh
@@ -26,6 +26,15 @@ done
 # Rule the case out before launching anything: the effective "keep
 # windows on quit" setting (global, with a per-app override) must be off
 # for Terminal.
+# The brand wallpaper is part of the recording contract: without it the
+# full-screen clips capture — and the upload step publishes — whatever
+# personal wallpaper the user runs. Refuse before touching anything.
+if [ ! -x "$CHROME" ]; then
+  echo "ABORT: Google Chrome not found at $CHROME — it renders the brand wallpaper" >&2
+  echo "(a hard prerequisite: recording without it leaks the user's own desktop)." >&2
+  exit 1
+fi
+
 resume_global=$(defaults read -g NSQuitAlwaysKeepsWindows 2>/dev/null || echo 0)
 resume_term=$(defaults read com.apple.Terminal NSQuitAlwaysKeepsWindows 2>/dev/null || echo "$resume_global")
 if [ "$resume_term" = "1" ]; then
@@ -96,27 +105,32 @@ defaults write com.wink.app suggestShortcutsFromUsage -bool true
 defaults write com.wink.app menuBarIconVisible -bool true
 defaults write com.wink.app shortcutsPaused -bool false
 defaults write com.wink.app frontmostExceptionsEnabled -bool false
+# the debug log persists across sessions — remember where it ends so the
+# gate below only accepts evidence from THIS launch, not a qualifying
+# line left by an earlier (possibly staged) session
+WINKLOG="$HOME/.config/Wink/debug.log"
+log_offset=$(wc -l 2>/dev/null < "$WINKLOG" || echo 0)
 open -a /Applications/Wink.app; sleep 1.5
 
 # 3. verify the trigger index took all four entries (gotcha #2)
 "$WORK/winkkeys" chord 45 150 >/dev/null; sleep 0.5   # ⇪N — forces an attemptStart line
 "$WORK/winkkeys" chord 45 150 >/dev/null; sleep 0.3   # toggle Notes back off
-line=$(grep attemptStart "$HOME/.config/Wink/debug.log" | tail -1)
+line=$(tail -n +$((log_offset + 1)) "$WINKLOG" 2>/dev/null | grep attemptStart | tail -1)
 # Gate on BOTH the index count and a live interception tap: eventTap=false
 # (Input Monitoring missing, tap failed) records perfectly inert clips
 # while the counts still look right.
 case "$line" in
   *"shortcuts=4"*"triggerIndex=4"*"eventTap=true"*) echo "trigger index + event tap OK" ;;
-  *) echo "STAGING GATE FAILED (need shortcuts=4 triggerIndex=4 eventTap=true): $line" >&2; exit 1 ;;
+  *) echo "STAGING GATE FAILED (need shortcuts=4 triggerIndex=4 eventTap=true): ${line:-<no fresh attemptStart line from this launch>}" >&2; exit 1 ;;
 esac
 
-# 4. set dressing: brand wallpaper, no overlay apps
-if [ -x "$CHROME" ]; then
-  "$CHROME" --headless=new --disable-gpu --screenshot="$WORK/wink-wallpaper.png" \
-    --window-size=1920,1080 --hide-scrollbars "file://$HERE/wallpaper.html" 2>/dev/null
-  osascript -e "tell application \"System Events\" to set picture of every desktop to POSIX file \"$WORK/wink-wallpaper.png\""
-  killall WallpaperAgent 2>/dev/null || true
-fi
+# 4. set dressing: brand wallpaper (Chrome verified in the preflight), no
+# overlay apps
+"$CHROME" --headless=new --disable-gpu --screenshot="$WORK/wink-wallpaper.png" \
+  --window-size=1920,1080 --hide-scrollbars "file://$HERE/wallpaper.html" 2>/dev/null
+[ -s "$WORK/wink-wallpaper.png" ] || { echo "ABORT: wallpaper render produced no PNG" >&2; exit 1; }
+osascript -e "tell application \"System Events\" to set picture of every desktop to POSIX file \"$WORK/wink-wallpaper.png\""
+killall WallpaperAgent 2>/dev/null || true
 # record whether PomoFox was running before pausing it — restore.sh must
 # not hand back a session with an app the user never had open
 if pgrep -xq PomoFox; then

--- a/.claude/skills/guide-media-pipeline/scripts/stage.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/stage.sh
@@ -38,6 +38,10 @@ tell application "System Events"
 end tell
 return out
 EOS
+# Notes is launched mid-recording by the ⇪N demo chord; record whether
+# it was already running so restore.sh can tell demo cleanup from
+# session damage when it quits Notes
+pgrep -xq Notes && touch "$BACKUP/notes-was-running" || true
 echo "backup: $BACKUP"
 
 # 2. demo config + synthetic usage, app in English

--- a/.claude/skills/guide-media-pipeline/scripts/stage.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/stage.sh
@@ -87,7 +87,13 @@ if [ -x "$CHROME" ]; then
   osascript -e "tell application \"System Events\" to set picture of every desktop to POSIX file \"$WORK/wink-wallpaper.png\""
   killall WallpaperAgent 2>/dev/null || true
 fi
-pkill -x PomoFox 2>/dev/null && echo "PomoFox paused for the shoot" || true
+# record whether PomoFox was running before pausing it — restore.sh must
+# not hand back a session with an app the user never had open
+if pgrep -xq PomoFox; then
+  touch "$BACKUP/pomofox-was-running"
+  pkill -x PomoFox 2>/dev/null || true
+  echo "PomoFox paused for the shoot"
+fi
 
 # 5. stage Safari (3 windows, one minimized) and Terminal (3, one minimized)
 osascript <<'EOF'

--- a/.claude/skills/guide-media-pipeline/scripts/stage.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/stage.sh
@@ -1,0 +1,86 @@
+#!/bin/zsh
+# Stage the demo environment for guide media recording.
+# Backs up the user's Wink state, installs the demo config, dresses the set.
+set -eu
+HERE="${0:A:h}"
+WORK="${WINK_MEDIA_WORK:-$HOME/.cache/wink-guide-media}"
+BACKUP="$WORK/backup-$(date +%Y%m%d-%H%M%S)"
+APPSUP="$HOME/Library/Application Support/Wink"
+CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+mkdir -p "$WORK" "$BACKUP"
+
+# 0. tools
+if [ ! -x "$WORK/winkkeys" ]; then
+  swiftc -O "$HERE/winkkeys.swift" -o "$WORK/winkkeys"
+fi
+
+# 1. backup (config dir + defaults). restore.sh needs this directory.
+cp -a "$APPSUP/" "$BACKUP/AppSupport/"
+defaults export com.wink.app "$BACKUP/com.wink.app.plist"
+defaults read -g AppleInterfaceStyle > "$BACKUP/appearance.txt" 2>/dev/null || echo Light > "$BACKUP/appearance.txt"
+echo "backup: $BACKUP"
+
+# 2. demo config + synthetic usage, app in English
+pkill -x Wink || true; sleep 0.6
+cp "$HERE/demo-shortcuts.json" "$APPSUP/shortcuts.json"
+python3 "$HERE/make-demo-usage.py" "$WORK/demo-usage.db"
+cp "$WORK/demo-usage.db" "$APPSUP/usage.db"
+defaults write com.wink.app AppleLanguages -array en
+open -a /Applications/Wink.app; sleep 1.5
+
+# 3. verify the trigger index took all four entries (gotcha #2)
+"$WORK/winkkeys" chord 45 150 >/dev/null; sleep 0.5   # ⇪N — forces an attemptStart line
+"$WORK/winkkeys" chord 45 150 >/dev/null; sleep 0.3   # toggle Notes back off
+line=$(grep attemptStart "$HOME/.config/Wink/debug.log" | tail -1)
+case "$line" in
+  *"shortcuts=4"*"triggerIndex=4"*) echo "trigger index OK" ;;
+  *) echo "TRIGGER INDEX MISMATCH: $line" >&2; exit 1 ;;
+esac
+
+# 4. set dressing: brand wallpaper, no overlay apps
+if [ -x "$CHROME" ]; then
+  "$CHROME" --headless=new --disable-gpu --screenshot="$WORK/wink-wallpaper.png" \
+    --window-size=1920,1080 --hide-scrollbars "file://$HERE/wallpaper.html" 2>/dev/null
+  osascript -e "tell application \"System Events\" to set picture of every desktop to POSIX file \"$WORK/wink-wallpaper.png\""
+  killall WallpaperAgent 2>/dev/null || true
+fi
+pkill -x PomoFox 2>/dev/null && echo "PomoFox paused for the shoot" || true
+
+# 5. stage Safari (3 windows, one minimized) and Terminal (3, one minimized)
+osascript <<'EOF'
+tell application "Safari"
+  launch
+  delay 1
+  close every window
+  make new document with properties {URL:"https://wink.aixie.de"}
+  delay 1
+  make new document with properties {URL:"https://wink.aixie.de/guide"}
+  delay 1
+  make new document with properties {URL:"https://github.com/xrf9268-hue/Wink"}
+  delay 2
+  set bounds of window 3 to {320, 120, 1600, 960}
+  set bounds of window 2 to {360, 160, 1640, 1000}
+  set bounds of window 1 to {400, 200, 1680, 1040}
+  set miniaturized of window 3 to true
+end tell
+tell application "Terminal"
+  launch
+  delay 1
+  close every window
+  delay 0.5
+  do script ""
+  delay 0.5
+  do script ""
+  delay 0.5
+  do script ""
+  delay 1
+  set custom title of window 3 to "api — zsh"
+  set custom title of window 2 to "build — watch"
+  set custom title of window 1 to "deploy — ssh"
+  set bounds of window 3 to {380, 180, 1450, 780}
+  set bounds of window 2 to {430, 230, 1500, 830}
+  set bounds of window 1 to {480, 280, 1550, 880}
+  set miniaturized of window 3 to true
+end tell
+EOF
+echo "STAGED — record with record-clips.sh, restore with restore.sh $BACKUP"

--- a/.claude/skills/guide-media-pipeline/scripts/stage.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/stage.sh
@@ -46,15 +46,24 @@ cp "$HERE/demo-shortcuts.json" "$APPSUP/shortcuts.json"
 python3 "$HERE/make-demo-usage.py" "$WORK/demo-usage.db"
 cp "$WORK/demo-usage.db" "$APPSUP/usage.db"
 defaults write com.wink.app AppleLanguages -array en
+# The demo shortcuts live on the Hyper layer and winkkeys drives them as
+# F19 chords through the interception tap. A profile with Hyper off would
+# route them via Carbon, every injected chord would be inert, and the
+# count gate below would still pass — so force it on for the shoot; the
+# defaults backup restores the user's real setting.
+defaults write com.wink.app hyperKeyEnabled -bool true
 open -a /Applications/Wink.app; sleep 1.5
 
 # 3. verify the trigger index took all four entries (gotcha #2)
 "$WORK/winkkeys" chord 45 150 >/dev/null; sleep 0.5   # ⇪N — forces an attemptStart line
 "$WORK/winkkeys" chord 45 150 >/dev/null; sleep 0.3   # toggle Notes back off
 line=$(grep attemptStart "$HOME/.config/Wink/debug.log" | tail -1)
+# Gate on BOTH the index count and a live interception tap: eventTap=false
+# (Input Monitoring missing, tap failed) records perfectly inert clips
+# while the counts still look right.
 case "$line" in
-  *"shortcuts=4"*"triggerIndex=4"*) echo "trigger index OK" ;;
-  *) echo "TRIGGER INDEX MISMATCH: $line" >&2; exit 1 ;;
+  *"shortcuts=4"*"triggerIndex=4"*"eventTap=true"*) echo "trigger index + event tap OK" ;;
+  *) echo "STAGING GATE FAILED (need shortcuts=4 triggerIndex=4 eventTap=true): $line" >&2; exit 1 ;;
 esac
 
 # 4. set dressing: brand wallpaper, no overlay apps

--- a/.claude/skills/guide-media-pipeline/scripts/stage.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/stage.sh
@@ -9,9 +9,11 @@ APPSUP="$HOME/Library/Application Support/Wink"
 CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 mkdir -p "$WORK" "$BACKUP"
 
-# Refuse to stage over a live user session: step 5 closes every Safari and
-# Terminal window, which must never eat real work. Quit them yourself
-# (saving your session), then re-run.
+# Refuse to stage over a live user session: step 5 creates and closes
+# Safari and Terminal windows, which must never eat real work. Quit them
+# yourself, then re-run. (Step 5 additionally aborts — windows untouched —
+# if Resume hands the launch a saved session; running is not the only way
+# real windows can be present.)
 for app in Safari Terminal; do
   if pgrep -xq "$app"; then
     echo "ABORT: $app is running — quit it first, then re-run stage.sh" >&2
@@ -99,11 +101,24 @@ if pgrep -xq PomoFox; then
   echo "PomoFox paused for the shoot"
 fi
 
-# 5. stage Safari (3 windows, one minimized) and Terminal (3, one minimized)
-osascript <<'EOF'
+# 5. stage Safari (3 windows, one minimized) and Terminal (3, one minimized).
+# The preflight only proves neither app is RUNNING — Resume (or Safari's
+# "opens with: All windows from last session") can hand `launch` the
+# user's saved session as live windows. Never close a window carrying
+# real content: quit the app untouched instead (quit re-saves the session
+# losslessly) and abort.
+if ! osascript <<'EOF'
 tell application "Safari"
   launch
-  delay 1
+  delay 1.5
+  repeat with w in (get every window)
+    repeat with t in (get every tab of w)
+      set u to URL of t
+      if u is not missing value and u is not "" and u is not "favorites://" then
+        error "session window restored at launch"
+      end if
+    end repeat
+  end repeat
   close every window
   make new document with properties {URL:"https://wink.aixie.de"}
   delay 1
@@ -116,9 +131,21 @@ tell application "Safari"
   set bounds of window 1 to {400, 200, 1680, 1040}
   set miniaturized of window 3 to true
 end tell
+EOF
+then
+  osascript -e 'tell application "Safari" to quit' 2>/dev/null || true
+  echo "ABORT: Safari restored a saved session at launch — staging would destroy it." >&2
+  echo "Safari was quit with those windows intact. Close them in Safari yourself (or" >&2
+  echo "set Safari opens with 'A new window'), quit it again, then re-run stage.sh." >&2
+  exit 1
+fi
+# Terminal opens at most one fresh shell window on a plain launch; more
+# than one window at this point means Resume brought saved sessions back.
+if ! osascript <<'EOF'
 tell application "Terminal"
   launch
   delay 1
+  if (count of windows) > 1 then error "saved windows restored at launch"
   close every window
   delay 0.5
   do script ""
@@ -136,4 +163,11 @@ tell application "Terminal"
   set miniaturized of window 3 to true
 end tell
 EOF
+then
+  osascript -e 'tell application "Terminal" to quit' 2>/dev/null || true
+  echo "ABORT: Terminal restored saved windows at launch — staging would destroy" >&2
+  echo "their scrollback. Terminal was quit with them intact. Close them yourself," >&2
+  echo "quit it again, then re-run stage.sh." >&2
+  exit 1
+fi
 echo "STAGED — record with record-clips.sh, restore with restore.sh $BACKUP"

--- a/.claude/skills/guide-media-pipeline/scripts/stage.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/stage.sh
@@ -9,6 +9,16 @@ APPSUP="$HOME/Library/Application Support/Wink"
 CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 mkdir -p "$WORK" "$BACKUP"
 
+# Refuse to stage over a live user session: step 5 closes every Safari and
+# Terminal window, which must never eat real work. Quit them yourself
+# (saving your session), then re-run.
+for app in Safari Terminal; do
+  if pgrep -xq "$app"; then
+    echo "ABORT: $app is running — quit it first, then re-run stage.sh" >&2
+    exit 1
+  fi
+done
+
 # 0. tools
 if [ ! -x "$WORK/winkkeys" ]; then
   swiftc -O "$HERE/winkkeys.swift" -o "$WORK/winkkeys"
@@ -18,6 +28,16 @@ fi
 cp -a "$APPSUP/" "$BACKUP/AppSupport/"
 defaults export com.wink.app "$BACKUP/com.wink.app.plist"
 defaults read -g AppleInterfaceStyle > "$BACKUP/appearance.txt" 2>/dev/null || echo Light > "$BACKUP/appearance.txt"
+# record current wallpapers, one path per desktop line, for restore.sh
+osascript > "$BACKUP/wallpapers.txt" 2>/dev/null <<'EOS' || true
+set out to ""
+tell application "System Events"
+  repeat with d in desktops
+    set out to out & (picture of d) & linefeed
+  end repeat
+end tell
+return out
+EOS
 echo "backup: $BACKUP"
 
 # 2. demo config + synthetic usage, app in English

--- a/.claude/skills/guide-media-pipeline/scripts/stage.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/stage.sh
@@ -21,12 +21,31 @@ for app in Safari Terminal; do
   fi
 done
 
+# A single Resume-restored Terminal window is indistinguishable from the
+# fresh window a plain launch creates, and step 5 closes that window.
+# Rule the case out before launching anything: the effective "keep
+# windows on quit" setting (global, with a per-app override) must be off
+# for Terminal.
+resume_global=$(defaults read -g NSQuitAlwaysKeepsWindows 2>/dev/null || echo 0)
+resume_term=$(defaults read com.apple.Terminal NSQuitAlwaysKeepsWindows 2>/dev/null || echo "$resume_global")
+if [ "$resume_term" = "1" ]; then
+  echo "ABORT: Resume is enabled for Terminal (NSQuitAlwaysKeepsWindows) — a restored" >&2
+  echo "window would be indistinguishable from the fresh launch window and staging" >&2
+  echo "would close it. Turn ON 'Close windows when quitting an application' in" >&2
+  echo "System Settings > Desktop & Dock, then re-run stage.sh." >&2
+  exit 1
+fi
+
 # 0. tools
 if [ ! -x "$WORK/winkkeys" ]; then
   swiftc -O "$HERE/winkkeys.swift" -o "$WORK/winkkeys"
 fi
 
 # 1. backup (config dir + defaults). restore.sh needs this directory.
+# A never-launched install has no Application Support dir yet (the app
+# creates it lazily); an empty one is behaviorally identical for Wink,
+# so initialize it rather than letting the copy abort the run.
+mkdir -p "$APPSUP"
 cp -a "$APPSUP/" "$BACKUP/AppSupport/"
 defaults export com.wink.app "$BACKUP/com.wink.app.plist"
 defaults read -g AppleInterfaceStyle > "$BACKUP/appearance.txt" 2>/dev/null || echo Light > "$BACKUP/appearance.txt"
@@ -139,8 +158,9 @@ then
   echo "set Safari opens with 'A new window'), quit it again, then re-run stage.sh." >&2
   exit 1
 fi
-# Terminal opens at most one fresh shell window on a plain launch; more
-# than one window at this point means Resume brought saved sessions back.
+# The resume preflight up top rules out a Resume-restored single window,
+# so one window here is Terminal's own fresh launch window; more than one
+# means something restored anyway — abort without touching them.
 if ! osascript <<'EOF'
 tell application "Terminal"
   launch

--- a/.claude/skills/guide-media-pipeline/scripts/stage.sh
+++ b/.claude/skills/guide-media-pipeline/scripts/stage.sh
@@ -46,12 +46,26 @@ cp "$HERE/demo-shortcuts.json" "$APPSUP/shortcuts.json"
 python3 "$HERE/make-demo-usage.py" "$WORK/demo-usage.db"
 cp "$WORK/demo-usage.db" "$APPSUP/usage.db"
 defaults write com.wink.app AppleLanguages -array en
-# The demo shortcuts live on the Hyper layer and winkkeys drives them as
-# F19 chords through the interception tap. A profile with Hyper off would
-# route them via Carbon, every injected chord would be inert, and the
-# count gate below would still pass — so force it on for the shoot; the
-# defaults backup restores the user's real setting.
+# Pin EVERY setting the shoot depends on instead of inheriting the user's
+# profile — the whole-domain defaults backup restores their real values:
+# - hyperKeyEnabled: the demo chords are F19-driven through the
+#   interception tap; a Hyper-off profile routes them via Carbon and every
+#   injected chord is inert while the count gate still passes.
+# - hyperCheatSheetEnabled: the cheat-sheet clip records nothing if the
+#   user turned the sheet off.
+# - suggestShortcutsFromUsage: the Insights screenshot's Suggested card
+#   renders only when the toggle is on (and seeding app_activations is
+#   pointless otherwise).
+# - menuBarIconVisible: shoot-settings.sh opens Settings through the menu
+#   bar item; a hidden icon breaks the whole screenshot matrix.
+# - shortcutsPaused / frontmostExceptionsEnabled: a paused profile or an
+#   exception rule matching a staged app would silently disarm the demos.
 defaults write com.wink.app hyperKeyEnabled -bool true
+defaults write com.wink.app hyperCheatSheetEnabled -bool true
+defaults write com.wink.app suggestShortcutsFromUsage -bool true
+defaults write com.wink.app menuBarIconVisible -bool true
+defaults write com.wink.app shortcutsPaused -bool false
+defaults write com.wink.app frontmostExceptionsEnabled -bool false
 open -a /Applications/Wink.app; sleep 1.5
 
 # 3. verify the trigger index took all four entries (gotcha #2)

--- a/.claude/skills/guide-media-pipeline/scripts/wallpaper.html
+++ b/.claude/skills/guide-media-pipeline/scripts/wallpaper.html
@@ -1,0 +1,7 @@
+<!doctype html><meta charset="utf-8"><style>
+html,body{margin:0;width:1920px;height:1080px;overflow:hidden}
+body{background-color:#0A0D14;
+background-image:radial-gradient(1400px 700px at 50% -200px, rgba(255,180,84,0.07), transparent 70%),
+radial-gradient(rgba(152,163,189,0.05) 1px, transparent 1px);
+background-size:auto,18px 18px}
+</style><body></body>

--- a/.claude/skills/guide-media-pipeline/scripts/winkkeys.swift
+++ b/.claude/skills/guide-media-pipeline/scripts/winkkeys.swift
@@ -1,0 +1,170 @@
+import Foundation
+import CoreGraphics
+
+// Deterministic key driver for Wink runtime validation.
+// Every posted event has its flags set EXPLICITLY so nothing is inherited
+// from the shared HID flags state (a stale secondaryFn bit silently breaks
+// chord identity: KeyMatcher tracks .function as a real modifier).
+//
+//   winkkeys chord <keyCode> <holdMs>   F19 down -> key down -> hold -> key up -> F19 up
+//   winkkeys f19 <holdMs>               F19 held alone for holdMs (cheat sheet / idle hold)
+//   winkkeys key <keyCode> [holdMs]     plain key press
+//   winkkeys chord-nokeyup <keyCode>    F19 down -> key down, then leave both down (lost-keyUp probe)
+//   winkkeys release                    F19 up + safety-release of common keys
+//   winkkeys type <text>                unicode string, one keyDown/Up per character
+//
+// Events post at .cghidEventTap so they traverse session event taps exactly
+// like hardware input (same rationale as scripts/cgevent-helper).
+
+let src = CGEventSource(stateID: .hidSystemState)
+let F19: CGKeyCode = 80
+
+func post(_ code: CGKeyCode, _ down: Bool, flags: CGEventFlags = []) {
+    guard let e = CGEvent(keyboardEventSource: src, virtualKey: code, keyDown: down) else {
+        FileHandle.standardError.write("failed to create event \(code)\n".data(using: .utf8)!)
+        exit(1)
+    }
+    e.flags = flags
+    e.post(tap: .cghidEventTap)
+}
+
+func ms(_ n: Double) { usleep(UInt32(n * 1000)) }
+
+let a = CommandLine.arguments
+guard a.count >= 2 else { print("usage: winkkeys <chord|f19|key|chord-nokeyup|release|type> ..."); exit(1) }
+
+switch a[1] {
+case "chord":
+    let code = CGKeyCode(a[2])!
+    let hold = Double(a.count > 3 ? a[3] : "20")!
+    // warm the event pipeline so lazy init is not charged to the measured span
+    _ = CGEvent(keyboardEventSource: src, virtualKey: F19, keyDown: false)
+    post(F19, true); ms(12)
+    let tDown = Date()
+    post(code, true); ms(hold)
+    post(code, false)
+    let downSpan = Date().timeIntervalSince(tDown) * 1000
+    ms(12)
+    post(F19, false)
+    print(String(format: "chord keyCode=%d requestedHoldMs=%.0f actualKeyDownSpanMs=%.1f", code, hold, downSpan))
+case "f19":
+    let hold = Double(a[2])!
+    post(F19, true); ms(hold); post(F19, false)
+    print("f19 heldMs=\(hold)")
+case "key":
+    let code = CGKeyCode(a[2])!
+    let hold = Double(a.count > 3 ? a[3] : "20")!
+    post(code, true); ms(hold); post(code, false)
+    print("key \(code)")
+case "chord-modfirst":
+    // Modifiers-first release: F19 goes up BEFORE the letter, so the letter's
+    // up edge no longer carries the Hyper union and cannot be delivered as
+    // the same phased chord — the real-world "lost keyUp" the arbiter must
+    // resolve via its physical keyState probe.
+    let code = CGKeyCode(a[2])!
+    let hold = Double(a.count > 3 ? a[3] : "100")!
+    post(F19, true); ms(12)
+    post(code, true); ms(hold)
+    post(F19, false); ms(30)
+    post(code, false)
+    print("chord-modfirst keyCode=\(code) letterHeldMs=\(hold + 30)")
+case "chord-nokeyup":
+    let code = CGKeyCode(a[2])!
+    post(F19, true); ms(12); post(code, true)
+    print("chord-nokeyup keyCode=\(code) — both edges left DOWN")
+case "cooldown-probe":
+    // #382 acceptance: hide an app with its shortcut, then commit the SAME app
+    // from the palette inside the 400ms per-bundle toggle cooldown. One process
+    // so the whole sequence fits the window; every F19 hold stays above the
+    // 80ms Caps-Lock toggle-quirk threshold so no keystroke inherits Hyper.
+    let appKey = CGKeyCode(a[2])!
+    let trigKey = CGKeyCode(a[3])!
+    let text = a[4]
+    _ = CGEvent(keyboardEventSource: src, virtualKey: F19, keyDown: false)
+    let t0 = Date()
+    post(F19, true); ms(12)
+    post(appKey, true)                       // hide dispatches here (non-phased)
+    let tHide = Date()
+    ms(25); post(appKey, false); ms(70); post(F19, false)
+    post(F19, true); ms(12); post(trigKey, true); ms(20); post(trigKey, false); ms(65); post(F19, false)
+    ms(35)
+    for ch in text {
+        guard let e = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: true) else { continue }
+        var buf = Array(String(ch).utf16); e.flags = []
+        e.keyboardSetUnicodeString(stringLength: buf.count, unicodeString: &buf); e.post(tap: .cghidEventTap); ms(8)
+        guard let u = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: false) else { continue }
+        u.flags = []; u.keyboardSetUnicodeString(stringLength: buf.count, unicodeString: &buf); u.post(tap: .cghidEventTap); ms(8)
+    }
+    ms(10)
+    post(36, true); ms(20); post(36, false)   // Enter commits
+    print(String(format: "cooldown-probe: hide->commit = %.0fms (cooldown window is 400ms), total=%.0fms",
+                 Date().timeIntervalSince(tHide) * 1000, Date().timeIntervalSince(t0) * 1000))
+case "stdchord":
+    // Standard (non-Hyper) chord: control+option+command+<key>, exercising the
+    // Carbon EventHotKey route rather than the interception tap.
+    let code = CGKeyCode(a[2])!
+    let f: CGEventFlags = [.maskControl, .maskAlternate, .maskCommand]
+    post(59, true, flags: [.maskControl]); ms(10)
+    post(58, true, flags: [.maskControl, .maskAlternate]); ms(10)
+    post(55, true, flags: f); ms(10)
+    post(code, true, flags: f); ms(30); post(code, false, flags: f); ms(10)
+    post(55, false, flags: [.maskControl, .maskAlternate]); ms(8)
+    post(58, false, flags: [.maskControl]); ms(8)
+    post(59, false, flags: [])
+    print("stdchord ctrl+opt+cmd+\(code)")
+case "f19-repeat":
+    // Emulates a REAL held key: the initial down, then autorepeat downs
+    // (kCGKeyboardEventAutorepeat = 1) every repeatMs, then the up.
+    let total = Double(a[2])!
+    let every = Double(a.count > 3 ? a[3] : "40")!
+    post(F19, true)
+    var elapsed = 0.0
+    while elapsed < total {
+        ms(every); elapsed += every
+        if let e = CGEvent(keyboardEventSource: src, virtualKey: F19, keyDown: true) {
+            e.flags = []
+            e.setIntegerValueField(.keyboardEventAutorepeat, value: 1)
+            e.post(tap: .cghidEventTap)
+        }
+    }
+    post(F19, false)
+    print("f19-repeat totalMs=\(total) everyMs=\(every)")
+case "click":
+    // Left click at a global (top-left origin) point.
+    let x = Double(a[2])!, y = Double(a[3])!
+    let pt = CGPoint(x: x, y: y)
+    if let move = CGEvent(mouseEventSource: src, mouseType: .mouseMoved, mouseCursorPosition: pt, mouseButton: .left) {
+        move.post(tap: .cghidEventTap)
+    }
+    ms(40)
+    if let down = CGEvent(mouseEventSource: src, mouseType: .leftMouseDown, mouseCursorPosition: pt, mouseButton: .left) {
+        down.post(tap: .cghidEventTap)
+    }
+    ms(50)
+    if let up = CGEvent(mouseEventSource: src, mouseType: .leftMouseUp, mouseCursorPosition: pt, mouseButton: .left) {
+        up.post(tap: .cghidEventTap)
+    }
+    print("click \(x),\(y)")
+case "release":
+    post(F19, false)
+    for c in [CGKeyCode(0), 1, 2, 3, 15, 17, 35, 49] { post(c, false) }
+    print("released")
+case "type":
+    let text = a[2]
+    for ch in text {
+        guard let e = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: true) else { continue }
+        var buf = Array(String(ch).utf16)
+        e.flags = []
+        e.keyboardSetUnicodeString(stringLength: buf.count, unicodeString: &buf)
+        e.post(tap: .cghidEventTap)
+        ms(18)
+        guard let u = CGEvent(keyboardEventSource: src, virtualKey: 0, keyDown: false) else { continue }
+        u.flags = []
+        u.keyboardSetUnicodeString(stringLength: buf.count, unicodeString: &buf)
+        u.post(tap: .cghidEventTap)
+        ms(18)
+    }
+    print("typed \(text)")
+default:
+    print("unknown: \(a[1])"); exit(1)
+}


### PR DESCRIPTION
Fixes #405

## Summary
- New repo skill `.claude/skills/guide-media-pipeline`: the complete, reproducible pipeline that produced the `/guide` demo videos and Settings screenshots (#401), so a UI change or a new locale means re-running scripts instead of re-inventing the shoot.
- `SKILL.md` is the run book: hard preconditions (user present, TCC, empty stage display), the six-step sequence, the R2/`/media/*` contract, a mandatory human privacy-review gate before upload, and ten hard-won gotchas — including the #403 palette z-order workaround and the #404 sentinel `target` trap.
- `scripts/`: `stage.sh` (backup + demo config + synthetic usage.db + set dressing, with a trigger-index verification gate), `record-clips.sh` (five scripted CGEvent clips), `shoot-settings.sh` (coordinate-clicked Settings tab matrix, locale/theme agnostic), `make-demo-usage.py` (schema + `user_version 3`), `winkkeys.swift` (the input driver, compiled on first stage), `encode-and-upload.sh` (crop/x264 + wrangler R2 upload behind an explicit confirm), `restore.sh` (config, language, recorded appearance, wallpaper, PomoFox — prints the restored shortcut count).

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

No Swift sources touched (winkkeys.swift is skill tooling, not app code; it compiles clean with `swiftc -O`). All zsh scripts pass `zsh -n`; the Python generator compiles and its output was accepted by shipped 0.7.0 (682 rows survive launch). Every script is a cleaned-up version of the exact commands that produced the shipped media on 2026-07-23.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- The skill's synthetic-input rules descend from the #371 validation batch; the pipeline intentionally records the shipped `/Applications/Wink.app`, never a dev build.
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
