### PR TITLE
feat: add the "As shipped" real-footage reel to the landing page

### DIFF
--- a/docs/design/landing/index.html
+++ b/docs/design/landing/index.html
@@ -592,6 +592,21 @@
   .principle h3 { font-family: var(--mono); font-size: 19px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 8px; }
   .principle p { font-size: 14px; color: var(--muted); }
 
+  /* ---------- as shipped (real footage) ---------- */
+  .reel {
+    margin: 0;
+    border: 1px solid var(--hairline);
+    border-radius: 16px;
+    overflow: hidden;
+    background: var(--panel-inner);
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.10);
+  }
+  .reel video { display: block; width: 100%; height: auto; }
+  .reel-caption {
+    font-family: var(--mono); font-size: 12px; color: var(--muted);
+    letter-spacing: 0.03em; margin-top: 14px; text-align: center;
+  }
+
   /* ---------- download ---------- */
   .download { padding: 108px 0 96px; text-align: center; }
   .download-inner { display: flex; flex-direction: column; align-items: center; gap: 20px; }
@@ -898,6 +913,21 @@
       </div>
     </div>
   </div>
+
+  <!-- ================= as shipped ================= -->
+  <section class="section" id="real">
+    <div class="wrap">
+      <div class="section-head">
+        <p class="eyebrow">As shipped</p>
+        <h2>The mocks above are drawings.<br>This is the app.</h2>
+        <p class="lede">Fifty-five seconds of 0.7.0, recorded straight off the screen — the first chord, the window walk, the picker, the palette, the cheat sheet. Every one of them has a chapter in <a href="/guide">the guide</a>.</p>
+      </div>
+      <figure class="reel">
+        <video autoplay muted loop playsinline src="/media/guide-reel.mp4" width="1480" height="1000" aria-label="Fifty-five seconds of real Wink footage: first chord, window cycling, window picker, search palette, cheat sheet"></video>
+      </figure>
+      <p class="reel-caption">five clips, back to back · no retouching · macOS 15</p>
+    </div>
+  </section>
 
   <!-- ================= download ================= -->
   <section class="download" id="download">
@@ -1219,6 +1249,15 @@
           cell.style.opacity = String(OPACITY[Number(ch)]);
           grid.appendChild(cell);
         });
+      });
+    }
+
+    /* ----- as-shipped reel ----- */
+    if (reduceMotion) {
+      document.querySelectorAll("video[autoplay]").forEach(function (v) {
+        v.removeAttribute("autoplay");
+        v.pause();
+        v.setAttribute("controls", "");
       });
     }
   })();

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -595,6 +595,21 @@ const landingHtml = `<!doctype html>
   .principle h3 { font-family: var(--mono); font-size: 19px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 8px; }
   .principle p { font-size: 14px; color: var(--muted); }
 
+  /* ---------- as shipped (real footage) ---------- */
+  .reel {
+    margin: 0;
+    border: 1px solid var(--hairline);
+    border-radius: 16px;
+    overflow: hidden;
+    background: var(--panel-inner);
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.10);
+  }
+  .reel video { display: block; width: 100%; height: auto; }
+  .reel-caption {
+    font-family: var(--mono); font-size: 12px; color: var(--muted);
+    letter-spacing: 0.03em; margin-top: 14px; text-align: center;
+  }
+
   /* ---------- download ---------- */
   .download { padding: 108px 0 96px; text-align: center; }
   .download-inner { display: flex; flex-direction: column; align-items: center; gap: 20px; }
@@ -901,6 +916,21 @@ const landingHtml = `<!doctype html>
       </div>
     </div>
   </div>
+
+  <!-- ================= as shipped ================= -->
+  <section class="section" id="real">
+    <div class="wrap">
+      <div class="section-head">
+        <p class="eyebrow">As shipped</p>
+        <h2>The mocks above are drawings.<br>This is the app.</h2>
+        <p class="lede">Fifty-five seconds of 0.7.0, recorded straight off the screen — the first chord, the window walk, the picker, the palette, the cheat sheet. Every one of them has a chapter in <a href="/guide">the guide</a>.</p>
+      </div>
+      <figure class="reel">
+        <video autoplay muted loop playsinline src="/media/guide-reel.mp4" width="1480" height="1000" aria-label="Fifty-five seconds of real Wink footage: first chord, window cycling, window picker, search palette, cheat sheet"></video>
+      </figure>
+      <p class="reel-caption">five clips, back to back · no retouching · macOS 15</p>
+    </div>
+  </section>
 
   <!-- ================= download ================= -->
   <section class="download" id="download">
@@ -1222,6 +1252,15 @@ const landingHtml = `<!doctype html>
           cell.style.opacity = String(OPACITY[Number(ch)]);
           grid.appendChild(cell);
         });
+      });
+    }
+
+    /* ----- as-shipped reel ----- */
+    if (reduceMotion) {
+      document.querySelectorAll("video[autoplay]").forEach(function (v) {
+        v.removeAttribute("autoplay");
+        v.pause();
+        v.setAttribute("controls", "");
       });
     }
   })();


### PR DESCRIPTION
Fixes #407

## Summary
- New full-width **"As shipped"** section between the principles strip and the download CTA: the five guide demo clips (#401) concatenated into one 55-second muted autoplay loop, served same-origin at `/media/guide-reel.mp4` (1.37 MB, already uploaded — stream-copy concat of the per-chapter clips, so zero extra encode generations).
- Copy owns the page's central contrast instead of hiding it: *"The mocks above are drawings. This is the app."* — with a cross-link into the guide, whose chapters explain each of the five moments.
- Design intent (raised against proxyman.com's big-real-product hero): the interactive hero stays — it's the page's signature. The real footage lands as a set piece where it's strongest, right before the download ask.
- `prefers-reduced-motion` removes autoplay and surfaces controls (same pattern as the guide pages). `worker/src/index.ts` is regenerated output.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

No Swift sources touched. `wrangler deploy --dry-run` bundles clean (143 KiB / gzip 35.9 KiB). Headless-Chrome full-page render verified: section placement, headline wrap, guide link accent, reel frame, caption, and the unchanged download/footer flow. `/media/guide-reel.mp4` verified in the bucket; the `/media/*` route (merged in #402) already serves it with range support.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- After merge, deploy the worker (`wrangler deploy` in `worker/`).
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
