### PR TITLE
fix: backfill absent sentinel targets without weakening unknown-value gating

### DIFF
--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -179,8 +179,11 @@ final class AppController {
     private lazy var cheatSheetHUD = CheatSheetHUDController(
         rowsProvider: { [weak self] in
             guard let self else { return [] }
+            // Exactly the rows the CURRENT trigger index was built from: one
+            // the index dropped (uninstalled app, unrecognized sentinel)
+            // must not render as an armed chord (#404).
             return self.shortcutStore.shortcuts
-                .filter(\.isEnabled)
+                .filter { self.shortcutManager.isShortcutInTriggerIndex($0) }
                 .map { shortcut in
                     CheatSheetRow(
                         id: shortcut.id,

--- a/Sources/Wink/Models/AppShortcut.swift
+++ b/Sources/Wink/Models/AppShortcut.swift
@@ -107,6 +107,25 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
         }
     }
 
+    /// Export-facing view of a preserved invalid target (#404): the raw
+    /// unknown string when there is one to carry, else nil. Pair with
+    /// `hasPersistedInvalidTarget` to distinguish "valid/absent" from
+    /// "explicit null or malformed".
+    var exportedInvalidTargetRawValue: String? {
+        if case .unknownString(let raw)? = persistedInvalidTarget {
+            return raw
+        }
+        return nil
+    }
+
+    /// True when this row carries a gated (invalid) persisted target that
+    /// every serialization — shortcuts.json AND .winkrecipe — must keep
+    /// expressing, or a later load re-arms the row via the absent-key
+    /// backfill (#404).
+    var hasPersistedInvalidTarget: Bool {
+        persistedInvalidTarget != nil
+    }
+
     var isFrontmostAppTarget: Bool {
         target == .frontmostApp
     }

--- a/Sources/Wink/Models/AppShortcut.swift
+++ b/Sources/Wink/Models/AppShortcut.swift
@@ -88,7 +88,7 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
     /// that was meant to stay unavailable (#404). Unknown strings re-encode
     /// verbatim (a newer build's intent survives round trips); an explicit
     /// null or malformed value re-encodes as null.
-    private enum PersistedInvalidTarget: Hashable, Sendable, Codable {
+    enum PersistedInvalidTarget: Hashable, Sendable {
         case unknownString(String)
         case explicitNullOrMalformed
     }
@@ -164,7 +164,8 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
         isEnabled: Bool = true,
         frontmostBehaviorOverride: FrontmostTargetBehavior? = nil,
         target: ShortcutTarget? = nil,
-        holdAction: HoldAction? = nil
+        holdAction: HoldAction? = nil,
+        persistedInvalidTarget: PersistedInvalidTarget? = nil
     ) {
         self.id = id
         self.appName = appName
@@ -175,7 +176,7 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
         self.frontmostBehaviorOverride = frontmostBehaviorOverride
         self.target = target
         self.holdAction = holdAction
-        self.persistedInvalidTarget = nil
+        self.persistedInvalidTarget = persistedInvalidTarget
     }
 
     /// Explicit so `persistedInvalidTarget` never becomes its own persisted

--- a/Sources/Wink/Models/AppShortcut.swift
+++ b/Sources/Wink/Models/AppShortcut.swift
@@ -81,12 +81,18 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
     /// key-up-or-deadline dispatch: tap = the usual toggle, hold past the
     /// threshold = this action.
     var holdAction: HoldAction?
-    /// Raw persisted `target` string when it names a kind this build does
-    /// not know. Preserved and re-encoded verbatim so a save by this build
-    /// cannot erase a newer build's intent — without it, "unknown value →
-    /// nil → key omitted on save → backfilled as a live trigger on the next
-    /// load" silently arms a row the newer build meant to gate (#404).
-    private var unknownTargetRawValue: String?
+    /// A persisted `target` value that did not resolve to a known kind.
+    /// Preserved and re-encoded so a save by this build cannot erase the
+    /// gating — without it, "invalid value → nil → key omitted on save →
+    /// backfilled as a live trigger on the next load" silently arms a row
+    /// that was meant to stay unavailable (#404). Unknown strings re-encode
+    /// verbatim (a newer build's intent survives round trips); an explicit
+    /// null or malformed value re-encodes as null.
+    private enum PersistedInvalidTarget: Hashable, Sendable, Codable {
+        case unknownString(String)
+        case explicitNullOrMalformed
+    }
+    private var persistedInvalidTarget: PersistedInvalidTarget?
 
     /// The target a KNOWN sentinel bundle identifier unambiguously implies,
     /// used to backfill files whose `target` field is absent (#404).
@@ -150,10 +156,10 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
         self.frontmostBehaviorOverride = frontmostBehaviorOverride
         self.target = target
         self.holdAction = holdAction
-        self.unknownTargetRawValue = nil
+        self.persistedInvalidTarget = nil
     }
 
-    /// Explicit so `unknownTargetRawValue` never becomes its own persisted
+    /// Explicit so `persistedInvalidTarget` never becomes its own persisted
     /// key — it re-encodes INTO `.target` (see `encode(to:)`).
     private enum CodingKeys: String, CodingKey {
         case id
@@ -181,15 +187,19 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
         frontmostBehaviorOverride = (try? container.decodeIfPresent(String.self, forKey: .frontmostBehaviorOverride))
             .flatMap { FrontmostTargetBehavior(rawValue: $0) }
         if container.contains(.target) {
-            // Present: a known string arms the kind. An unknown string is a
-            // newer build's gate — degrade to nil = .app but PRESERVE the
-            // raw value so a save by this build re-encodes it verbatim and
-            // can never convert it into an absent key (#404). A present
-            // null / non-string is corrupt, not newer-format: nil, nothing
-            // preserved, and no backfill on this load.
-            let rawTarget = try? container.decode(String.self, forKey: .target)
-            target = rawTarget.flatMap { ShortcutTarget(rawValue: $0) }
-            unknownTargetRawValue = (target == nil) ? rawTarget : nil
+            // Present: a known string arms the kind. Anything else is a
+            // gate that must hold across saves (#404): an unknown string is
+            // a newer build's intent and re-encodes verbatim; an explicit
+            // null or malformed value re-encodes as null. Either way the
+            // key can never silently become absent and get backfilled by a
+            // later load.
+            if let rawTarget = try? container.decode(String.self, forKey: .target) {
+                target = ShortcutTarget(rawValue: rawTarget)
+                persistedInvalidTarget = (target == nil) ? .unknownString(rawTarget) : nil
+            } else {
+                target = nil
+                persistedInvalidTarget = .explicitNullOrMalformed
+            }
         } else {
             // Absent key: a hand-authored or third-party file that names a
             // KNOWN sentinel bundle and omits "target" means exactly that
@@ -197,7 +207,7 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
             // everywhere and fires nowhere (#404). Unknown future sentinels
             // keep nil = .app and stay unavailable.
             target = Self.impliedTarget(forSentinelBundleIdentifier: bundleIdentifier)
-            unknownTargetRawValue = nil
+            persistedInvalidTarget = nil
         }
         // Same leniency: an unknown hold action from a newer build degrades
         // to plain key-down dispatch instead of quarantining the file.
@@ -207,7 +217,8 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
 
     // Custom encoding mirrors the synthesized shape (nil omits the key,
     // keeping files readable by older builds) with one addition: a
-    // preserved unknown target string re-encodes verbatim under `.target`.
+    // preserved invalid target re-encodes under `.target` — unknown strings
+    // verbatim, explicit null / malformed values as null.
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
@@ -220,7 +231,14 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
         if let target {
             try container.encode(target, forKey: .target)
         } else {
-            try container.encodeIfPresent(unknownTargetRawValue, forKey: .target)
+            switch persistedInvalidTarget {
+            case .unknownString(let raw):
+                try container.encode(raw, forKey: .target)
+            case .explicitNullOrMalformed:
+                try container.encodeNil(forKey: .target)
+            case nil:
+                break
+            }
         }
         try container.encodeIfPresent(holdAction, forKey: .holdAction)
     }

--- a/Sources/Wink/Models/AppShortcut.swift
+++ b/Sources/Wink/Models/AppShortcut.swift
@@ -81,6 +81,25 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
     /// key-up-or-deadline dispatch: tap = the usual toggle, hold past the
     /// threshold = this action.
     var holdAction: HoldAction?
+    /// Raw persisted `target` string when it names a kind this build does
+    /// not know. Preserved and re-encoded verbatim so a save by this build
+    /// cannot erase a newer build's intent — without it, "unknown value →
+    /// nil → key omitted on save → backfilled as a live trigger on the next
+    /// load" silently arms a row the newer build meant to gate (#404).
+    private var unknownTargetRawValue: String?
+
+    /// The target a KNOWN sentinel bundle identifier unambiguously implies,
+    /// used to backfill files whose `target` field is absent (#404).
+    static func impliedTarget(forSentinelBundleIdentifier bundleIdentifier: String) -> ShortcutTarget? {
+        switch bundleIdentifier {
+        case frontmostTargetSentinelBundleIdentifier:
+            return .frontmostApp
+        case searchPaletteTargetSentinelBundleIdentifier:
+            return .searchPalette
+        default:
+            return nil
+        }
+    }
 
     var isFrontmostAppTarget: Bool {
         target == .frontmostApp
@@ -131,13 +150,26 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
         self.frontmostBehaviorOverride = frontmostBehaviorOverride
         self.target = target
         self.holdAction = holdAction
+        self.unknownTargetRawValue = nil
     }
 
-    // Custom decoding solely for the override's leniency: shortcuts.json is
-    // loaded strictly (any decode error quarantines the whole file), so an
-    // unknown behavior rawValue written by a newer build must degrade to
-    // "follow global" instead of throwing. Encoding stays synthesized
-    // (nil omits the key, keeping files readable by older builds).
+    /// Explicit so `unknownTargetRawValue` never becomes its own persisted
+    /// key — it re-encodes INTO `.target` (see `encode(to:)`).
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case appName
+        case bundleIdentifier
+        case keyEquivalent
+        case modifierFlags
+        case isEnabled
+        case frontmostBehaviorOverride
+        case target
+        case holdAction
+    }
+
+    // Custom decoding solely for leniency: shortcuts.json is loaded
+    // strictly (any decode error quarantines the whole file), so an unknown
+    // rawValue written by a newer build must degrade instead of throwing.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(UUID.self, forKey: .id)
@@ -148,14 +180,48 @@ struct AppShortcut: Codable, Identifiable, Hashable, Sendable {
         isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
         frontmostBehaviorOverride = (try? container.decodeIfPresent(String.self, forKey: .frontmostBehaviorOverride))
             .flatMap { FrontmostTargetBehavior(rawValue: $0) }
-        // Unknown target values (from a newer build) decode to nil = .app;
-        // the sentinel bundle then keeps the row harmlessly unavailable
-        // rather than misfiring or failing the file.
-        target = (try? container.decodeIfPresent(String.self, forKey: .target))
-            .flatMap { ShortcutTarget(rawValue: $0) }
+        if container.contains(.target) {
+            // Present: a known string arms the kind. An unknown string is a
+            // newer build's gate — degrade to nil = .app but PRESERVE the
+            // raw value so a save by this build re-encodes it verbatim and
+            // can never convert it into an absent key (#404). A present
+            // null / non-string is corrupt, not newer-format: nil, nothing
+            // preserved, and no backfill on this load.
+            let rawTarget = try? container.decode(String.self, forKey: .target)
+            target = rawTarget.flatMap { ShortcutTarget(rawValue: $0) }
+            unknownTargetRawValue = (target == nil) ? rawTarget : nil
+        } else {
+            // Absent key: a hand-authored or third-party file that names a
+            // KNOWN sentinel bundle and omits "target" means exactly that
+            // kind — backfill it instead of shipping a row that renders
+            // everywhere and fires nowhere (#404). Unknown future sentinels
+            // keep nil = .app and stay unavailable.
+            target = Self.impliedTarget(forSentinelBundleIdentifier: bundleIdentifier)
+            unknownTargetRawValue = nil
+        }
         // Same leniency: an unknown hold action from a newer build degrades
         // to plain key-down dispatch instead of quarantining the file.
         holdAction = (try? container.decodeIfPresent(String.self, forKey: .holdAction))
             .flatMap { HoldAction(rawValue: $0) }
+    }
+
+    // Custom encoding mirrors the synthesized shape (nil omits the key,
+    // keeping files readable by older builds) with one addition: a
+    // preserved unknown target string re-encodes verbatim under `.target`.
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(appName, forKey: .appName)
+        try container.encode(bundleIdentifier, forKey: .bundleIdentifier)
+        try container.encode(keyEquivalent, forKey: .keyEquivalent)
+        try container.encode(modifierFlags, forKey: .modifierFlags)
+        try container.encode(isEnabled, forKey: .isEnabled)
+        try container.encodeIfPresent(frontmostBehaviorOverride, forKey: .frontmostBehaviorOverride)
+        if let target {
+            try container.encode(target, forKey: .target)
+        } else {
+            try container.encodeIfPresent(unknownTargetRawValue, forKey: .target)
+        }
+        try container.encodeIfPresent(holdAction, forKey: .holdAction)
     }
 }

--- a/Sources/Wink/Models/WinkRecipe.swift
+++ b/Sources/Wink/Models/WinkRecipe.swift
@@ -177,4 +177,17 @@ struct WinkRecipeShortcut: Codable, Equatable, Sendable {
     var holdActionValue: HoldAction? {
         holdAction.flatMap(HoldAction.init(rawValue:))
     }
+
+    /// The invalid-target gate this recipe row carries, in AppShortcut's
+    /// own representation, so an accepted import persists the gate instead
+    /// of an absent key the next load would backfill and arm (#404).
+    var invalidTargetGate: AppShortcut.PersistedInvalidTarget? {
+        if let target, ShortcutTarget(rawValue: target) == nil {
+            return .unknownString(target)
+        }
+        if targetKeyPresentButInvalid {
+            return .explicitNullOrMalformed
+        }
+        return nil
+    }
 }

--- a/Sources/Wink/Models/WinkRecipe.swift
+++ b/Sources/Wink/Models/WinkRecipe.swift
@@ -106,9 +106,17 @@ struct WinkRecipeShortcut: Codable, Equatable, Sendable {
         frontmostBehaviorOverride.flatMap(FrontmostTargetBehavior.init(rawValue:))
     }
 
-    /// Lenient enum mapping: absent or unknown raw values mean `.app`.
+    /// Lenient enum mapping with the same absent-key backfill as
+    /// `AppShortcut.init(from:)`: an ABSENT target on a KNOWN sentinel
+    /// bundle means exactly that kind (#404) — which also keeps the import
+    /// planner's search-palette exclusion airtight for hand-authored
+    /// recipes that name the sentinel without the field. Unknown VALUES
+    /// still mean `.app` (unavailable), never a guess.
     var shortcutTarget: ShortcutTarget? {
-        target.flatMap(ShortcutTarget.init(rawValue:))
+        guard let target else {
+            return AppShortcut.impliedTarget(forSentinelBundleIdentifier: bundleIdentifier)
+        }
+        return ShortcutTarget(rawValue: target)
     }
 
     /// Lenient enum mapping: absent or unknown raw values mean no hold action.

--- a/Sources/Wink/Models/WinkRecipe.swift
+++ b/Sources/Wink/Models/WinkRecipe.swift
@@ -49,6 +49,22 @@ struct WinkRecipeShortcut: Codable, Equatable, Sendable {
     /// Raw string, same leniency pattern: absent/unknown means no hold
     /// action, and older builds ignore the extra optional key (schema v1).
     var holdAction: String?
+    /// True when the source carried a `target` key whose value was null or
+    /// malformed (non-string). The gate must survive re-encoding as an
+    /// explicit null so `shortcutTarget`'s absent-key backfill can never
+    /// arm it (#404) — mirroring AppShortcut's persistedInvalidTarget.
+    private var targetKeyPresentButInvalid: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case appName
+        case bundleIdentifier
+        case keyEquivalent
+        case modifierFlags
+        case isEnabled
+        case frontmostBehaviorOverride
+        case target
+        case holdAction
+    }
 
     init(
         appName: String,
@@ -58,7 +74,8 @@ struct WinkRecipeShortcut: Codable, Equatable, Sendable {
         isEnabled: Bool,
         frontmostBehaviorOverride: String? = nil,
         target: String? = nil,
-        holdAction: String? = nil
+        holdAction: String? = nil,
+        targetKeyPresentButInvalid: Bool = false
     ) {
         self.appName = appName
         self.bundleIdentifier = bundleIdentifier
@@ -68,13 +85,16 @@ struct WinkRecipeShortcut: Codable, Equatable, Sendable {
         self.frontmostBehaviorOverride = frontmostBehaviorOverride
         self.target = target
         self.holdAction = holdAction
+        self.targetKeyPresentButInvalid = targetKeyPresentButInvalid
     }
 
     /// Custom decoding so the optional raw-string fields are fully lenient:
     /// a wrong-TYPE value (e.g. `"holdAction": 42` from a hand-edited or
     /// future-schema file) degrades that field to nil instead of rejecting
     /// the entire recipe — matching shortcuts.json's leniency contract.
-    /// Required fields stay strict.
+    /// Required fields stay strict. Target-key PRESENCE is tracked so a
+    /// null/malformed value stays distinguishable from a genuinely absent
+    /// key (only the latter may backfill a sentinel kind, #404).
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         appName = try container.decode(String.self, forKey: .appName)
@@ -83,11 +103,39 @@ struct WinkRecipeShortcut: Codable, Equatable, Sendable {
         modifierFlags = try container.decode([String].self, forKey: .modifierFlags)
         isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
         frontmostBehaviorOverride = try? container.decodeIfPresent(String.self, forKey: .frontmostBehaviorOverride)
-        target = try? container.decodeIfPresent(String.self, forKey: .target)
+        if container.contains(.target) {
+            target = try? container.decode(String.self, forKey: .target)
+            targetKeyPresentButInvalid = (target == nil)
+        } else {
+            target = nil
+            targetKeyPresentButInvalid = false
+        }
         holdAction = try? container.decodeIfPresent(String.self, forKey: .holdAction)
     }
 
+    /// Custom encoding mirrors the synthesized omit-nil shape, except a
+    /// present-but-invalid target re-encodes as explicit null (#404).
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(appName, forKey: .appName)
+        try container.encode(bundleIdentifier, forKey: .bundleIdentifier)
+        try container.encode(keyEquivalent, forKey: .keyEquivalent)
+        try container.encode(modifierFlags, forKey: .modifierFlags)
+        try container.encode(isEnabled, forKey: .isEnabled)
+        try container.encodeIfPresent(frontmostBehaviorOverride, forKey: .frontmostBehaviorOverride)
+        if let target {
+            try container.encode(target, forKey: .target)
+        } else if targetKeyPresentButInvalid {
+            try container.encodeNil(forKey: .target)
+        }
+        try container.encodeIfPresent(holdAction, forKey: .holdAction)
+    }
+
     init(_ shortcut: AppShortcut) {
+        // A locally gated invalid target must keep its gate in the export:
+        // unknown strings travel verbatim; explicit null/malformed travels
+        // as the invalid marker — otherwise importing the recipe elsewhere
+        // would backfill and arm the row (#404).
         self.init(
             appName: shortcut.appName,
             bundleIdentifier: shortcut.bundleIdentifier,
@@ -95,8 +143,10 @@ struct WinkRecipeShortcut: Codable, Equatable, Sendable {
             modifierFlags: shortcut.modifierFlags,
             isEnabled: shortcut.isEnabled,
             frontmostBehaviorOverride: shortcut.frontmostBehaviorOverride?.rawValue,
-            target: shortcut.target?.rawValue,
-            holdAction: shortcut.holdAction?.rawValue
+            target: shortcut.target?.rawValue ?? shortcut.exportedInvalidTargetRawValue,
+            holdAction: shortcut.holdAction?.rawValue,
+            targetKeyPresentButInvalid: shortcut.hasPersistedInvalidTarget
+                && shortcut.exportedInvalidTargetRawValue == nil
         )
     }
 
@@ -107,13 +157,17 @@ struct WinkRecipeShortcut: Codable, Equatable, Sendable {
     }
 
     /// Lenient enum mapping with the same absent-key backfill as
-    /// `AppShortcut.init(from:)`: an ABSENT target on a KNOWN sentinel
-    /// bundle means exactly that kind (#404) — which also keeps the import
-    /// planner's search-palette exclusion airtight for hand-authored
-    /// recipes that name the sentinel without the field. Unknown VALUES
+    /// `AppShortcut.init(from:)`: a GENUINELY ABSENT target on a KNOWN
+    /// sentinel bundle means exactly that kind (#404) — which also keeps
+    /// the import planner's search-palette exclusion airtight for
+    /// hand-authored recipes that name the sentinel without the field.
+    /// Unknown VALUES and present-but-invalid (null/malformed) values
     /// still mean `.app` (unavailable), never a guess.
     var shortcutTarget: ShortcutTarget? {
         guard let target else {
+            if targetKeyPresentButInvalid {
+                return nil
+            }
             return AppShortcut.impliedTarget(forSentinelBundleIdentifier: bundleIdentifier)
         }
         return ShortcutTarget(rawValue: target)

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -59,6 +59,11 @@ final class ShortcutManager {
     private var lastAccessibilityState: Bool = false
     private var lastInputMonitoringState: Bool = false
     private var lastAvailableShortcutBundleIdentifiers: Set<String> = []
+    /// IDs retained by the CURRENT `triggerIndex` — the exact set of rows
+    /// whose chords can fire. Duplicate chords collapse to one winner in
+    /// `KeyMatcher.buildIndex`, so bundle-availability alone overstates
+    /// what is armed (#404).
+    private var lastIndexedShortcutIDs: Set<UUID> = []
     private var hyperKeyEnabled = false
     private var shortcutsPaused = false
     private var autoPausedByException = false
@@ -668,14 +673,13 @@ final class ShortcutManager {
             || appBundleLocator.applicationURL(for: shortcut.bundleIdentifier) != nil
     }
 
-    /// Whether a shortcut survived the availability filter the CURRENT
-    /// trigger index was built from. Display surfaces (the cheat sheet) use
-    /// this — not a live locator probe — so a row can never render as armed
-    /// while the index dropped it, nor appear seconds before the periodic
-    /// rebuild actually arms its chord (#404).
+    /// Whether a shortcut is IN the current trigger index — availability,
+    /// enablement, and duplicate-chord resolution included. Display
+    /// surfaces (the cheat sheet) use this — not a live locator probe — so
+    /// a row can never render as armed while the index dropped it, lost its
+    /// chord to a duplicate, or is waiting on the periodic rebuild (#404).
     func isShortcutInTriggerIndex(_ shortcut: AppShortcut) -> Bool {
-        shortcut.isEnabled
-            && lastAvailableShortcutBundleIdentifiers.contains(shortcut.bundleIdentifier)
+        lastIndexedShortcutIDs.contains(shortcut.id)
     }
 
     private func availabilitySnapshot() -> (activeShortcuts: [AppShortcut], availableBundleIdentifiers: Set<String>) {
@@ -699,6 +703,10 @@ final class ShortcutManager {
     ) -> Bool {
         lastAvailableShortcutBundleIdentifiers = snapshot.availableBundleIdentifiers
         triggerIndex = keyMatcher.buildIndex(for: snapshot.activeShortcuts)
+        // The IDs that actually survived index construction — availability
+        // AND duplicate-chord resolution (buildIndex keeps one row per
+        // trigger). This is what display surfaces must mirror (#404).
+        lastIndexedShortcutIDs = Set(triggerIndex.values.map(\.id))
         return captureCoordinator.updateShortcuts(snapshot.activeShortcuts)
     }
 

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -657,19 +657,33 @@ final class ShortcutManager {
         )
     }
 
+    /// The availability predicate the trigger index is built from.
+    /// Frontmost-app pseudo-targets and the search-palette trigger have no
+    /// app URL by design (their sentinel bundles name no installed app) and
+    /// are always available: skipping the locator check is what makes them
+    /// register with Carbon and enter the trigger index.
+    func isShortcutCurrentlyAvailable(_ shortcut: AppShortcut) -> Bool {
+        shortcut.isFrontmostAppTarget
+            || shortcut.isSearchPaletteTarget
+            || appBundleLocator.applicationURL(for: shortcut.bundleIdentifier) != nil
+    }
+
+    /// Whether a shortcut survived the availability filter the CURRENT
+    /// trigger index was built from. Display surfaces (the cheat sheet) use
+    /// this — not a live locator probe — so a row can never render as armed
+    /// while the index dropped it, nor appear seconds before the periodic
+    /// rebuild actually arms its chord (#404).
+    func isShortcutInTriggerIndex(_ shortcut: AppShortcut) -> Bool {
+        shortcut.isEnabled
+            && lastAvailableShortcutBundleIdentifiers.contains(shortcut.bundleIdentifier)
+    }
+
     private func availabilitySnapshot() -> (activeShortcuts: [AppShortcut], availableBundleIdentifiers: Set<String>) {
         var activeShortcuts: [AppShortcut] = []
         var availableBundleIdentifiers = Set<String>()
 
         for shortcut in shortcutStore.shortcuts where shortcut.isEnabled {
-            // Frontmost-app pseudo-targets and the search-palette trigger
-            // have no app URL by design (their sentinel bundles name no
-            // installed app) and are always available: skipping the locator
-            // check here is what makes them register with Carbon and enter
-            // the trigger index.
-            guard shortcut.isFrontmostAppTarget
-                    || shortcut.isSearchPaletteTarget
-                    || appBundleLocator.applicationURL(for: shortcut.bundleIdentifier) != nil else {
+            guard isShortcutCurrentlyAvailable(shortcut) else {
                 continue
             }
 

--- a/Sources/Wink/Services/WinkRecipeImportPlanner.swift
+++ b/Sources/Wink/Services/WinkRecipeImportPlanner.swift
@@ -24,6 +24,9 @@ struct WinkRecipeImportPlanner {
         let frontmostBehaviorOverride: FrontmostTargetBehavior?
         let holdAction: HoldAction?
         let target: ShortcutTarget?
+        /// Carried through from the recipe row (#404): an accepted import
+        /// must persist the same invalid-target gate the source expressed.
+        let invalidTargetGate: AppShortcut.PersistedInvalidTarget?
         let resolution: AppResolution
 
         var isUnresolved: Bool {
@@ -55,7 +58,8 @@ struct WinkRecipeImportPlanner {
                 isEnabled: isEnabled,
                 frontmostBehaviorOverride: frontmostBehaviorOverride,
                 target: target,
-                holdAction: holdAction
+                holdAction: holdAction,
+                persistedInvalidTarget: invalidTargetGate
             )
         }
     }
@@ -214,6 +218,7 @@ struct WinkRecipeImportPlanner {
                 frontmostBehaviorOverride: recipeShortcut.behaviorOverride,
                 holdAction: recipeShortcut.holdActionValue,
                 target: .frontmostApp,
+                invalidTargetGate: nil,
                 resolution: .matchedByBundleIdentifier
             )
         }
@@ -233,6 +238,7 @@ struct WinkRecipeImportPlanner {
                 frontmostBehaviorOverride: recipeShortcut.behaviorOverride,
                 holdAction: recipeShortcut.holdActionValue,
                 target: recipeShortcut.shortcutTarget,
+                invalidTargetGate: recipeShortcut.invalidTargetGate,
                 resolution: .matchedByBundleIdentifier
             )
         }
@@ -257,6 +263,7 @@ struct WinkRecipeImportPlanner {
                 frontmostBehaviorOverride: recipeShortcut.behaviorOverride,
                 holdAction: recipeShortcut.holdActionValue,
                 target: recipeShortcut.shortcutTarget,
+                invalidTargetGate: recipeShortcut.invalidTargetGate,
                 resolution: .matchedByAppName
             )
         }
@@ -273,6 +280,7 @@ struct WinkRecipeImportPlanner {
             frontmostBehaviorOverride: recipeShortcut.behaviorOverride,
                 holdAction: recipeShortcut.holdActionValue,
             target: recipeShortcut.shortcutTarget,
+            invalidTargetGate: recipeShortcut.invalidTargetGate,
             resolution: .unresolved
         )
     }

--- a/Tests/WinkTests/PerShortcutBehaviorOverrideTests.swift
+++ b/Tests/WinkTests/PerShortcutBehaviorOverrideTests.swift
@@ -408,6 +408,31 @@ import Testing
     #expect(recipeShortcut.shortcutTarget == nil)
 }
 
+@Test func acceptedImportOfGatedRecipeRowPersistsTheGate() throws {
+    // Unresolved entries ARE importable (only conflicts filter out), so a
+    // gated recipe row must reach shortcuts.json still gated — an absent
+    // key would be backfilled and armed by the next launch.
+    let json = """
+    {"schemaVersion":2,"shortcuts":[
+      {"appName":"Current App","bundleIdentifier":"wink.target.frontmost-app",
+       "keyEquivalent":"g","modifierFlags":["command"],"isEnabled":true,"target":null}
+    ]}
+    """
+    let recipe = try WinkRecipeCodec().decode(Data(json.utf8))
+    let planner = WinkRecipeImportPlanner()
+    let plan = planner.planImport(recipe: recipe, existingShortcuts: [], installedApps: [])
+    let imported = planner.applying(plan: plan, to: [], strategy: .skipConflicts)
+    let persisted = try #require(imported.first)
+    #expect(persisted.target == nil)
+    #expect(persisted.hasPersistedInvalidTarget)
+
+    let reencoded = String(decoding: try JSONEncoder().encode(persisted), as: UTF8.self)
+    #expect(reencoded.contains("\"target\":null"))
+    let nextLaunch = try JSONDecoder().decode(AppShortcut.self, from: Data(reencoded.utf8))
+    #expect(nextLaunch.target == nil)
+    #expect(!nextLaunch.isFrontmostAppTarget)
+}
+
 @Test func explicitTargetStillWinsOverBackfill() throws {
     let json = """
     [

--- a/Tests/WinkTests/PerShortcutBehaviorOverrideTests.swift
+++ b/Tests/WinkTests/PerShortcutBehaviorOverrideTests.swift
@@ -329,7 +329,7 @@ import Testing
     #expect(!secondLoad.isSearchPaletteTarget)
 }
 
-@Test func presentNullTargetOnSentinelDoesNotArm() throws {
+@Test func presentNullTargetOnSentinelStaysDisarmedAcrossSaves() throws {
     let json = """
     {"id":"11111111-1111-1111-1111-111111111111","appName":"Search Palette",
      "bundleIdentifier":"wink.target.search-palette","keyEquivalent":"space",
@@ -338,6 +338,15 @@ import Testing
     let decoded = try JSONDecoder().decode(AppShortcut.self, from: Data(json.utf8))
     #expect(decoded.target == nil)
     #expect(!decoded.isSearchPaletteTarget)
+
+    // The null must survive re-encoding — an omitted key would be
+    // backfilled (armed) by the next load.
+    let reencoded = String(decoding: try JSONEncoder().encode(decoded), as: UTF8.self)
+    #expect(reencoded.contains("\"target\":null"))
+
+    let secondLoad = try JSONDecoder().decode(AppShortcut.self, from: Data(reencoded.utf8))
+    #expect(secondLoad.target == nil)
+    #expect(!secondLoad.isSearchPaletteTarget)
 }
 
 @Test func recipeSentinelWithoutTargetResolvesAndStaysExcludedFromImport() throws {

--- a/Tests/WinkTests/PerShortcutBehaviorOverrideTests.swift
+++ b/Tests/WinkTests/PerShortcutBehaviorOverrideTests.swift
@@ -253,3 +253,123 @@ import Testing
     #expect(recipe.shortcuts.first?.behaviorOverride == nil)
     #expect(recipe.shortcuts.first?.appName == "Safari")
 }
+
+// MARK: - Sentinel target backfill (#404)
+
+@Test func missingTargetBackfillsFromKnownSentinelBundles() throws {
+    // Hand-authored or third-party files may name a sentinel bundle without
+    // the explicit "target" field. Known sentinels are unambiguous — the
+    // row must decode into a working trigger, not a silently dead one.
+    let json = """
+    [
+      {"id":"11111111-1111-1111-1111-111111111111","appName":"Search Palette",
+       "bundleIdentifier":"wink.target.search-palette","keyEquivalent":"space",
+       "modifierFlags":["control","option","shift","command"],"isEnabled":true},
+      {"id":"22222222-2222-2222-2222-222222222222","appName":"Current App",
+       "bundleIdentifier":"wink.target.frontmost-app","keyEquivalent":"g",
+       "modifierFlags":["control","option","shift","command"],"isEnabled":true}
+    ]
+    """
+    let decoded = try JSONDecoder().decode([AppShortcut].self, from: Data(json.utf8))
+    #expect(decoded[0].target == .searchPalette)
+    #expect(decoded[0].isSearchPaletteTarget)
+    #expect(decoded[1].target == .frontmostApp)
+    #expect(decoded[1].isFrontmostAppTarget)
+}
+
+@Test func missingTargetStaysNilForOrdinaryBundles() throws {
+    let json = """
+    [
+      {"id":"11111111-1111-1111-1111-111111111111","appName":"Safari",
+       "bundleIdentifier":"com.apple.Safari","keyEquivalent":"s",
+       "modifierFlags":["command"],"isEnabled":true}
+    ]
+    """
+    let decoded = try JSONDecoder().decode([AppShortcut].self, from: Data(json.utf8))
+    #expect(decoded[0].target == nil)
+    #expect(!decoded[0].isSearchPaletteTarget)
+    #expect(!decoded[0].isFrontmostAppTarget)
+}
+
+@Test func unknownFutureSentinelStaysUnavailableNotMisfired() throws {
+    // A future build's sentinel this build doesn't know must keep the
+    // pre-existing degrade-to-unavailable behavior, never guess a kind.
+    let json = """
+    [
+      {"id":"11111111-1111-1111-1111-111111111111","appName":"Window Switcher",
+       "bundleIdentifier":"wink.target.window-switcher","keyEquivalent":"w",
+       "modifierFlags":["control","option","shift","command"],"isEnabled":true,
+       "target":"windowSwitcher"}
+    ]
+    """
+    let decoded = try JSONDecoder().decode([AppShortcut].self, from: Data(json.utf8))
+    #expect(decoded[0].target == nil)
+    #expect(!decoded[0].isSearchPaletteTarget)
+    #expect(!decoded[0].isFrontmostAppTarget)
+}
+
+@Test func unknownTargetValueSurvivesReencodeWithoutArming() throws {
+    // The round-trip hole: unknown value → nil → key omitted on save →
+    // backfilled as a LIVE trigger on the next load. The raw string must
+    // re-encode verbatim so the row stays gated forever.
+    let json = """
+    {"id":"11111111-1111-1111-1111-111111111111","appName":"Search Palette",
+     "bundleIdentifier":"wink.target.search-palette","keyEquivalent":"space",
+     "modifierFlags":["command"],"isEnabled":true,"target":"someFutureTarget"}
+    """
+    let decoded = try JSONDecoder().decode(AppShortcut.self, from: Data(json.utf8))
+    #expect(decoded.target == nil)
+    #expect(!decoded.isSearchPaletteTarget)
+
+    let reencoded = String(decoding: try JSONEncoder().encode(decoded), as: UTF8.self)
+    #expect(reencoded.contains("someFutureTarget"))
+
+    let secondLoad = try JSONDecoder().decode(AppShortcut.self, from: Data(reencoded.utf8))
+    #expect(secondLoad.target == nil)
+    #expect(!secondLoad.isSearchPaletteTarget)
+}
+
+@Test func presentNullTargetOnSentinelDoesNotArm() throws {
+    let json = """
+    {"id":"11111111-1111-1111-1111-111111111111","appName":"Search Palette",
+     "bundleIdentifier":"wink.target.search-palette","keyEquivalent":"space",
+     "modifierFlags":["command"],"isEnabled":true,"target":null}
+    """
+    let decoded = try JSONDecoder().decode(AppShortcut.self, from: Data(json.utf8))
+    #expect(decoded.target == nil)
+    #expect(!decoded.isSearchPaletteTarget)
+}
+
+@Test func recipeSentinelWithoutTargetResolvesAndStaysExcludedFromImport() throws {
+    // A hand-authored recipe naming the palette sentinel without "target"
+    // must resolve to .searchPalette so the planner's device-local
+    // exclusion still catches it — never import as a hidden armed trigger.
+    let json = """
+    {"schemaVersion":2,"shortcuts":[
+      {"appName":"Search Palette","bundleIdentifier":"wink.target.search-palette",
+       "keyEquivalent":"space","modifierFlags":["command","option"],"isEnabled":true}
+    ]}
+    """
+    let recipe = try WinkRecipeCodec().decode(Data(json.utf8))
+    #expect(recipe.shortcuts.first?.shortcutTarget == .searchPalette)
+
+    let plan = WinkRecipeImportPlanner().planImport(
+        recipe: recipe,
+        existingShortcuts: [],
+        installedApps: []
+    )
+    #expect(plan.entries.isEmpty)
+}
+
+@Test func explicitTargetStillWinsOverBackfill() throws {
+    let json = """
+    [
+      {"id":"11111111-1111-1111-1111-111111111111","appName":"Search Palette",
+       "bundleIdentifier":"wink.target.search-palette","keyEquivalent":"space",
+       "modifierFlags":["control","option","shift","command"],"isEnabled":true,
+       "target":"searchPalette"}
+    ]
+    """
+    let decoded = try JSONDecoder().decode([AppShortcut].self, from: Data(json.utf8))
+    #expect(decoded[0].target == .searchPalette)
+}

--- a/Tests/WinkTests/PerShortcutBehaviorOverrideTests.swift
+++ b/Tests/WinkTests/PerShortcutBehaviorOverrideTests.swift
@@ -370,6 +370,44 @@ import Testing
     #expect(plan.entries.isEmpty)
 }
 
+@Test func recipeNullTargetOnSentinelStaysGatedAndRoundTrips() throws {
+    let json = """
+    {"schemaVersion":2,"shortcuts":[
+      {"appName":"Current App","bundleIdentifier":"wink.target.frontmost-app",
+       "keyEquivalent":"g","modifierFlags":["command"],"isEnabled":true,"target":null}
+    ]}
+    """
+    let codec = WinkRecipeCodec()
+    let recipe = try codec.decode(Data(json.utf8))
+    #expect(recipe.shortcuts.first?.shortcutTarget == nil)
+
+    // The gate must survive a re-encode: explicit null, never an absent key.
+    let reencoded = String(decoding: try codec.encode(shortcuts: []), as: UTF8.self)
+    _ = reencoded
+    let reencodedRecipe = String(
+        decoding: try JSONEncoder().encode(recipe),
+        as: UTF8.self
+    )
+    #expect(reencodedRecipe.contains("\"target\":null"))
+    let secondLoad = try JSONDecoder().decode(WinkRecipe.self, from: Data(reencodedRecipe.utf8))
+    #expect(secondLoad.shortcuts.first?.shortcutTarget == nil)
+}
+
+@Test func exportingAGatedShortcutKeepsTheGateInTheRecipe() throws {
+    // A shortcuts.json row with an unknown target string, exported to a
+    // recipe, must carry the unknown string — importing it elsewhere may
+    // never backfill and arm the sentinel.
+    let json = """
+    {"id":"11111111-1111-1111-1111-111111111111","appName":"Search Palette",
+     "bundleIdentifier":"wink.target.search-palette","keyEquivalent":"space",
+     "modifierFlags":["command"],"isEnabled":true,"target":"someFutureTarget"}
+    """
+    let gated = try JSONDecoder().decode(AppShortcut.self, from: Data(json.utf8))
+    let recipeShortcut = WinkRecipeShortcut(gated)
+    #expect(recipeShortcut.target == "someFutureTarget")
+    #expect(recipeShortcut.shortcutTarget == nil)
+}
+
 @Test func explicitTargetStillWinsOverBackfill() throws {
     let json = """
     [


### PR DESCRIPTION
Fixes #404

## Summary
- **Absent-key backfill**: an ABSENT `target` key on a KNOWN sentinel bundle (`wink.target.search-palette` / `wink.target.frontmost-app`) now decodes to the unambiguous kind, so hand-authored shortcuts.json and third-party `.winkrecipe` files stop producing rows that render everywhere and fire nowhere. Unknown future sentinels keep degrading to unavailable.
- **Unknown values stay gated — permanently**: an unknown target STRING still degrades to `.app`/unavailable, and the raw string is now preserved and re-encoded verbatim (`unknownTargetRawValue`, custom `encode(to:)`). This closes the round-trip hole the local Codex review caught as a P1: previously, one save would omit the unknown value, turning it into an absent key that the next load's backfill would silently arm. A present `null`/non-string is treated as corrupt (nil, no arm on that load).
- **Recipe path shares the backfill**: `WinkRecipe.shortcutTarget` implies the sentinel kind when the field is absent, which keeps the import planner's device-local search-palette exclusion airtight for hand-authored recipes (previously such a row bypassed the exclusion and could persist into a hidden armed trigger after a restart).
- **Cheat sheet honesty**: rows now filter through `isShortcutInTriggerIndex` — exactly what the CURRENT trigger index was built from — instead of the raw store (the reported mismatch) or a live locator probe (which could show a row seconds before the periodic rebuild arms its chord).

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

724 tests pass, including seven new ones: sentinel backfill (both kinds), ordinary-bundle absent key stays nil, unknown future sentinel stays unavailable, explicit target wins, unknown value survives re-encode without arming (the P1 round-trip), present-null does not arm, and recipe-without-target resolves to `.searchPalette` and yields an empty import plan.

On-device validation (packaged build): a shortcuts.json whose palette entry omits `target` plus a fifth entry naming an uninstalled bundle produced `shortcuts=5 triggerIndex=4` (backfilled palette IN, ghost app OUT — pre-fix the palette was dropped too), ⇪Space opened the palette, and the cheat sheet rendered exactly the four indexed rows.

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Local Codex deep review ran over the branch diff before push; its P1 (round-trip arming) and both applicable P2s (present-null handling, recipe path) are fixed in this PR; the third P2 (locator-vs-index skew) is what `isShortcutInTriggerIndex` addresses.
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
