### PR TITLE
fix: keep the Search Palette badges on one line

### DIFF
--- a/Sources/Wink/UI/DesignSystem/WinkPrimitives.swift
+++ b/Sources/Wink/UI/DesignSystem/WinkPrimitives.swift
@@ -216,6 +216,10 @@ struct WinkHyperBadge: View {
         Text("HYPER")
             .font(font)
             .tracking(0.4)
+            .lineLimit(1)
+            // Same rule as the combo badge next to it: never yield to row
+            // compression — "HYPE / R" on two lines is not a badge (#409).
+            .fixedSize()
             .foregroundStyle(palette.accent)
             .padding(.horizontal, 6)
             .frame(minHeight: height)

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -349,6 +349,10 @@ struct GeneralTabView: View {
                 Text(shortcut.displayText)
                     .font(WinkType.monoBadge)
                     .tracking(0.5)
+                    .lineLimit(1)
+                    // Never yield to row compression: a key combo that wraps
+                    // ("⌃⌥⇧⌘SPAC / E") reads as two chords (#409).
+                    .fixedSize()
                     .foregroundStyle(palette.textPrimary)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)


### PR DESCRIPTION
Fixes #409

## Summary
- The Search Palette accessory's combo badge (`⌃⌥⇧⌘SPACE`) wrapped mid-token under the row's horizontal compression (user-reported screenshot: `^⌃⌘SPAC` / `E`). `lineLimit(1)` + `fixedSize()` keeps the chord intact and lets the row lay out around it.
- Validation surfaced the sibling: with the combo badge fixed, the squeeze shifted onto the `HYPER` badge (`HYPE` / `R`). `WinkHyperBadge` gets the same two modifiers.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

No behavioral code paths touched; full suite passes. On-device validation (packaged build, Settings → General): both badges render on one line in the Search Palette row, English and dark theme checked via window capture before/after.

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
