### PR TITLE
chore: release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ Newest first. One `## X.Y.Z` section per release, written by hand **before** run
 `scripts/bump-version.sh X.Y.Z`. `scripts/release-notes.sh X.Y.Z` extracts a section as the
 GitHub Release body; the release workflow fails if the tagged version has no section here.
 
+## 0.7.1
+
+Three sharp edges off the window-switching release.
+
+- **Palette switches land in front** — committing the search palette on an
+  app whose windows sat behind another app's activated it without raising
+  anything: the menu bar said Safari, the screen still showed Terminal.
+  Every activation now orders the target's first real content window key
+  and front (auxiliary elements like Split View dividers are never
+  touched), so the window you asked for is the window you see.
+- **Hand-written configs can't half-arm** — a shortcuts.json or .winkrecipe
+  entry naming a sentinel target (Search Palette, Current App) without the
+  explicit "target" field used to render everywhere and fire nowhere. The
+  unambiguous sentinel now backfills; unknown or malformed target values
+  stay safely disarmed — and stay that way across every save, load,
+  export, and import. The cheat sheet now shows exactly the chords that
+  can fire: duplicate-chord losers and uninstalled apps are excluded.
+- **Badges keep their shape** — the Search Palette row's HYPER and
+  key-combo badges no longer wrap mid-token under tight layouts
+  ("⌃⌥⇧⌘SPAC / E").
+
 ## 0.7.0
 
 The window-switching release: cycle through an app's windows, search-to-switch

--- a/Sources/Wink/Resources/Info.plist
+++ b/Sources/Wink/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.0</string>
+	<string>0.7.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -39,7 +39,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Fixes #413

Release prep for v0.7.1, following #395's precedent.

## Summary
- CHANGELOG 0.7.1 section: the three-fix patch wave — palette-commit activation raises the target's first content window (#403 via #410), sentinel-target backfill limited to an absent `target` key with unknown values staying disarmed across save/load/export/import and the cheat sheet showing only armed chords (#404 via #411), and the Search Palette badges no longer wrapping mid-token (#409 via #412)
- `scripts/bump-version.sh 0.7.1`: CFBundleShortVersionString 0.7.0 → 0.7.1, CFBundleVersion 10 → 11
- Known omission carried forward from #395, deliberate: still no WhatsNewCatalog entry — a patch release is the wrong vehicle for the 0.7.0 showcase panel (new localized strings on a chore branch); it stays with the next feature-release author.

## Test plan
- [x] `swift test` — 730/730 passing
- [x] `swift build -c release`
- [x] `scripts/release-notes.sh 0.7.1` extracts the section cleanly
- [ ] Post-merge: `v0.7.1` tag → release workflow → `scripts/verify-release-feed.sh` → Sparkle update observed on a production install (tracked in #413)

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)