### PR TITLE
chore: remove the landing page's As-shipped reel section

### DIFF
--- a/docs/design/landing/guide-zh.html
+++ b/docs/design/landing/guide-zh.html
@@ -360,7 +360,7 @@
 
   /* final cross-link */
   .guide-cta {
-    padding: 52px 0 0;
+    padding: 52px 0 64px;
     display: flex;
     flex-direction: column;
     align-items: flex-start;

--- a/docs/design/landing/guide.html
+++ b/docs/design/landing/guide.html
@@ -360,7 +360,7 @@
 
   /* final cross-link */
   .guide-cta {
-    padding: 52px 0 0;
+    padding: 52px 0 64px;
     display: flex;
     flex-direction: column;
     align-items: flex-start;

--- a/docs/design/landing/index.html
+++ b/docs/design/landing/index.html
@@ -592,21 +592,6 @@
   .principle h3 { font-family: var(--mono); font-size: 19px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 8px; }
   .principle p { font-size: 14px; color: var(--muted); }
 
-  /* ---------- as shipped (real footage) ---------- */
-  .reel {
-    margin: 0;
-    border: 1px solid var(--hairline);
-    border-radius: 16px;
-    overflow: hidden;
-    background: var(--panel-inner);
-    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.10);
-  }
-  .reel video { display: block; width: 100%; height: auto; }
-  .reel-caption {
-    font-family: var(--mono); font-size: 12px; color: var(--muted);
-    letter-spacing: 0.03em; margin-top: 14px; text-align: center;
-  }
-
   /* ---------- download ---------- */
   .download { padding: 108px 0 96px; text-align: center; }
   .download-inner { display: flex; flex-direction: column; align-items: center; gap: 20px; }
@@ -913,21 +898,6 @@
       </div>
     </div>
   </div>
-
-  <!-- ================= as shipped ================= -->
-  <section class="section" id="real">
-    <div class="wrap">
-      <div class="section-head">
-        <p class="eyebrow">As shipped</p>
-        <h2>The mocks above are drawings.<br>This is the app.</h2>
-        <p class="lede">Fifty-five seconds of 0.7.0, recorded straight off the screen — the first chord, the window walk, the picker, the palette, the cheat sheet. Every one of them has a chapter in <a href="/guide">the guide</a>.</p>
-      </div>
-      <figure class="reel">
-        <video autoplay muted loop playsinline src="/media/guide-reel.mp4" width="1480" height="1000" aria-label="Fifty-five seconds of real Wink footage: first chord, window cycling, window picker, search palette, cheat sheet"></video>
-      </figure>
-      <p class="reel-caption">five clips, back to back · no retouching · macOS 15</p>
-    </div>
-  </section>
 
   <!-- ================= download ================= -->
   <section class="download" id="download">
@@ -1252,14 +1222,6 @@
       });
     }
 
-    /* ----- as-shipped reel ----- */
-    if (reduceMotion) {
-      document.querySelectorAll("video[autoplay]").forEach(function (v) {
-        v.removeAttribute("autoplay");
-        v.pause();
-        v.setAttribute("controls", "");
-      });
-    }
   })();
 </script>
 </body>

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1593,7 +1593,7 @@ const guideHtml = `<!doctype html>
 
   /* final cross-link */
   .guide-cta {
-    padding: 52px 0 0;
+    padding: 52px 0 64px;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -2297,7 +2297,7 @@ const guideZhHtml = `<!doctype html>
 
   /* final cross-link */
   .guide-cta {
-    padding: 52px 0 0;
+    padding: 52px 0 64px;
     display: flex;
     flex-direction: column;
     align-items: flex-start;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -595,21 +595,6 @@ const landingHtml = `<!doctype html>
   .principle h3 { font-family: var(--mono); font-size: 19px; font-weight: 700; letter-spacing: -0.02em; margin-bottom: 8px; }
   .principle p { font-size: 14px; color: var(--muted); }
 
-  /* ---------- as shipped (real footage) ---------- */
-  .reel {
-    margin: 0;
-    border: 1px solid var(--hairline);
-    border-radius: 16px;
-    overflow: hidden;
-    background: var(--panel-inner);
-    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.10);
-  }
-  .reel video { display: block; width: 100%; height: auto; }
-  .reel-caption {
-    font-family: var(--mono); font-size: 12px; color: var(--muted);
-    letter-spacing: 0.03em; margin-top: 14px; text-align: center;
-  }
-
   /* ---------- download ---------- */
   .download { padding: 108px 0 96px; text-align: center; }
   .download-inner { display: flex; flex-direction: column; align-items: center; gap: 20px; }
@@ -916,21 +901,6 @@ const landingHtml = `<!doctype html>
       </div>
     </div>
   </div>
-
-  <!-- ================= as shipped ================= -->
-  <section class="section" id="real">
-    <div class="wrap">
-      <div class="section-head">
-        <p class="eyebrow">As shipped</p>
-        <h2>The mocks above are drawings.<br>This is the app.</h2>
-        <p class="lede">Fifty-five seconds of 0.7.0, recorded straight off the screen — the first chord, the window walk, the picker, the palette, the cheat sheet. Every one of them has a chapter in <a href="/guide">the guide</a>.</p>
-      </div>
-      <figure class="reel">
-        <video autoplay muted loop playsinline src="/media/guide-reel.mp4" width="1480" height="1000" aria-label="Fifty-five seconds of real Wink footage: first chord, window cycling, window picker, search palette, cheat sheet"></video>
-      </figure>
-      <p class="reel-caption">five clips, back to back · no retouching · macOS 15</p>
-    </div>
-  </section>
 
   <!-- ================= download ================= -->
   <section class="download" id="download">
@@ -1255,14 +1225,6 @@ const landingHtml = `<!doctype html>
       });
     }
 
-    /* ----- as-shipped reel ----- */
-    if (reduceMotion) {
-      document.querySelectorAll("video[autoplay]").forEach(function (v) {
-        v.removeAttribute("autoplay");
-        v.pause();
-        v.setAttribute("controls", "");
-      });
-    }
   })();
 </script>
 </body>


### PR DESCRIPTION
Fixes #415

## Summary
- Removes the "As shipped" section (added in #408) from the landing page: the reel opens on two mostly-empty Terminal windows, undercutting the "this is the app" claim, and each of the five features already has a better-framed dedicated clip in /guide.
- Drops all three footprints: the section markup (`#real`), its CSS (`.reel` / `.reel-caption`), and the reduced-motion `video[autoplay]` handler that becomes dead code with the page's only video gone (`reduceMotion` itself stays — the dot-grid animation still uses it).
- Rider (owner request): the guide's closing CTA ("End of the manual.") sat flush against the footer hairline on both editions — `.guide-cta` now carries 64px bottom padding.
- `scripts/generate-worker-site.py` re-run; worker/src/index.ts is in sync.
- Guide entry points are untouched: nav and footer `/guide` links remain. `guide-reel.mp4` stays in R2, unreferenced (regenerable via the guide-media-pipeline skill).

## Test plan
- [x] Headless Chrome render of the edited landing page: the principles row flows straight into the download section, footer intact, no orphaned styles
- [x] Headless Chrome render of the guide bottom: clear space between the Download button and the footer hairline
- [x] `grep` sweep: no remaining references to `#real`, `.reel`, or `guide-reel.mp4` in the landing source

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)