### PR TITLE
fix: capture recorder chords through a session event monitor

### DIFF
--- a/Sources/Wink/Services/ShortcutEditorState.swift
+++ b/Sources/Wink/Services/ShortcutEditorState.swift
@@ -73,7 +73,9 @@ final class ShortcutEditorState {
     var selectedAppName: String = ""
     var selectedBundleIdentifier: String = ""
     var recordedShortcut: RecordedShortcut?
-    var isRecordingShortcut: Bool = false
+    var isRecordingShortcut: Bool = false {
+        didSet { syncRecordingSessionGate() }
+    }
     var conflictMessage: String?
     var saveErrorMessage: String?
     /// Recording state for the #356 search-palette trigger's dedicated
@@ -81,7 +83,9 @@ final class ShortcutEditorState {
     /// `isRecordingShortcut` above so recording one control never clobbers
     /// an in-progress draft in the other.
     var recordedSearchPaletteShortcut: RecordedShortcut?
-    var isRecordingSearchPaletteShortcut: Bool = false
+    var isRecordingSearchPaletteShortcut: Bool = false {
+        didSet { syncRecordingSessionGate() }
+    }
     var searchPaletteConflictMessage: String?
     /// Palette-scoped mirror of `saveErrorMessage` — the General tab's card
     /// shows this instead of the shared property so a persistence failure
@@ -227,6 +231,17 @@ final class ShortcutEditorState {
         // removeShortcut(id:) is shared with the per-app list and calls
         // persist() itself; mirror its outcome the same way as above.
         searchPaletteSaveErrorMessage = saveErrorMessage
+    }
+
+    /// #417: while either recorder is live, matched chords are consumed but
+    /// not dispatched (`ShortcutManager.setRecordingSessionActive`) so an
+    /// already-bound chord pressed mid-recording cannot toggle its target
+    /// over the Settings window. The manager ignores same-value calls, so
+    /// SwiftUI re-writing a binding with an unchanged value is a no-op.
+    private func syncRecordingSessionGate() {
+        shortcutManager.setRecordingSessionActive(
+            isRecordingShortcut || isRecordingSearchPaletteShortcut
+        )
     }
 
     func removeShortcut(id: UUID) {

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -107,6 +107,15 @@ final class ShortcutManager {
     /// no toggleApplication re-entry while the panel is up — holds because
     /// dispatch, not capture, is what's gated.
     private var interactivePanelSessionActive = false
+    /// #417: while a Settings recorder session is live, matched chords must
+    /// not dispatch — pressing an already-bound chord mid-recording would
+    /// toggle its target (or open the palette) over the Settings window.
+    /// Same dispatch-not-capture shape as `interactivePanelSessionActive`,
+    /// but a separate flag: recording starts from a mouse click, so none of
+    /// the panel session's chord-straddling side effects (#385 release-
+    /// deferral suppression) apply, and sharing the panels' bool would let
+    /// closing a panel silently unlatch an active recording gate.
+    private var recordingSessionActive = false
 
     private var effectivePaused: Bool {
         shortcutsPaused || autoPausedByException
@@ -211,7 +220,8 @@ final class ShortcutManager {
             // already key: a gesture started mid-session would survive the
             // session's dismissal and its deadline would resurrect the
             // picker the user just closed.
-            guard let self, !self.effectivePaused, !self.interactivePanelSessionActive else {
+            guard let self, !self.effectivePaused, !self.interactivePanelSessionActive,
+                  !self.recordingSessionActive else {
                 return
             }
             arbiter?.handle(keyPress, phase)
@@ -236,6 +246,18 @@ final class ShortcutManager {
         captureCoordinator.setHyperReleaseDeferralSuppressed(active)
     }
 
+    func setRecordingSessionActive(_ active: Bool) {
+        guard recordingSessionActive != active else { return }
+        recordingSessionActive = active
+        // Drop a gesture straddling the session boundary, mirroring the
+        // panel seam: a hold whose deadline fires mid-recording must not
+        // dispatch, and one armed just before recording ends must not
+        // resurrect after it. No release-deferral suppression here — the
+        // recorder needs Caps Lock to keep behaving as Hyper so Hyper
+        // chords remain recordable.
+        holdGestureArbiter?.reset()
+    }
+
     private func handleHoldGesture(_ keyPress: KeyPress) {
         // Second layer of the late-delivery guard: an arbiter deadline
         // scheduled before a pause can still fire after it.
@@ -245,6 +267,10 @@ final class ShortcutManager {
         }
         guard !interactivePanelSessionActive else {
             diagnosticClient.log("HOLD_GESTURE_IGNORED: interactive panel session active")
+            return
+        }
+        guard !recordingSessionActive else {
+            diagnosticClient.log("HOLD_GESTURE_IGNORED: recording session active")
             return
         }
         let key = keyMatcher.trigger(for: keyPress)
@@ -717,6 +743,14 @@ final class ShortcutManager {
             // gated, so a press can never re-enter toggleApplication under
             // an open picker.
             diagnosticClient.log("KEYPRESS_IGNORED: interactive panel session active")
+            return true
+        }
+        guard !recordingSessionActive else {
+            // Consumed, not dispatched: an already-bound chord pressed while
+            // a recorder is live must not toggle its target. (It cannot be
+            // captured either — both providers consume it upstream of
+            // AppKit — surfacing it as a conflict is #419.)
+            diagnosticClient.log("KEYPRESS_IGNORED: recording session active")
             return true
         }
         let key = keyMatcher.trigger(for: keyPress)

--- a/Sources/Wink/UI/ShortcutRecorderView.swift
+++ b/Sources/Wink/UI/ShortcutRecorderView.swift
@@ -144,6 +144,18 @@ final class RecorderField: NSView {
         // but a leaked monitor would keep swallowing key-downs app-wide).
         if newWindow == nil {
             removeSessionMonitorIfNeeded()
+            if isRecording {
+                // Closing Settings (or switching tabs) mid-recording must
+                // end the session: the editor's recording flag drives the
+                // #417 dispatch gate in ShortcutManager, and a latched gate
+                // with no live recorder would silently kill every shortcut.
+                // Deferred a tick — this fires during view dismantling, and
+                // the cancel writes SwiftUI state.
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, self.isRecording else { return }
+                    self.onCancel?()
+                }
+            }
         } else if isRecording {
             // Recording started before the view was attached (makeNSView →
             // updateNSView precedes window insertion on first swap-in).

--- a/Sources/Wink/UI/ShortcutRecorderView.swift
+++ b/Sources/Wink/UI/ShortcutRecorderView.swift
@@ -91,6 +91,15 @@ private struct RecorderKeyCaptureRepresentable: NSViewRepresentable {
         nsView.updateRecordingState(isRecording: isRecording)
     }
 
+    static func dismantleNSView(_ nsView: RecorderField, coordinator: ()) {
+        // Belt over the viewWillMove(toWindow: nil) path: a field discarded
+        // before it was ever attached to a window gets no window callbacks
+        // at all, which would leak the session monitor and leave the #417
+        // dispatch gate latched. Teardown is idempotent, so covering both
+        // hooks costs nothing.
+        nsView.endSessionForTeardown()
+    }
+
     private func updateCallbacks(on field: RecorderField) {
         field.onCapture = onCapture
         field.onRecordingChange = onRecordingChange
@@ -123,7 +132,14 @@ final class RecorderField: NSView {
     private var sessionMonitor: Any?
     private var resignKeyObserver: (any NSObjectProtocol)?
 
+    /// Injection seam for the nullable AppKit registration — tests drive the
+    /// nil-return path, which cannot be forced through the real API.
+    var installMonitorImpl: (_ mask: NSEvent.EventTypeMask, _ handler: @escaping (NSEvent) -> NSEvent?) -> Any? = { mask, handler in
+        NSEvent.addLocalMonitorForEvents(matching: mask, handler: handler)
+    }
+
     var isMonitoringForTesting: Bool { sessionMonitor != nil }
+    var isObservingResignKeyForTesting: Bool { resignKeyObserver != nil }
 
     override var acceptsFirstResponder: Bool { true }
 
@@ -144,23 +160,32 @@ final class RecorderField: NSView {
         // monitor must not outlive it (its closure only holds `self` weakly,
         // but a leaked monitor would keep swallowing key-downs app-wide).
         if newWindow == nil {
-            removeSessionMonitorIfNeeded()
-            if isRecording {
-                // Closing Settings (or switching tabs) mid-recording must
-                // end the session: the editor's recording flag drives the
-                // #417 dispatch gate in ShortcutManager, and a latched gate
-                // with no live recorder would silently kill every shortcut.
-                // Deferred a tick — this fires during view dismantling, and
-                // the cancel writes SwiftUI state.
-                DispatchQueue.main.async { [weak self] in
-                    guard let self, self.isRecording else { return }
-                    self.onCancel?()
-                }
-            }
+            endSessionForTeardown()
         } else if isRecording {
             // Recording started before the view was attached (makeNSView →
             // updateNSView precedes window insertion on first swap-in).
             installSessionMonitorIfNeeded()
+        }
+    }
+
+    /// Ends a live session on the way out of the hierarchy — window detach
+    /// or representable dismantle, whichever comes first (idempotent).
+    /// The session must not outlive the field: the editor's recording flag
+    /// drives the #417 dispatch gate in ShortcutManager, and a latched gate
+    /// with no live recorder would silently kill every shortcut.
+    func endSessionForTeardown() {
+        removeSessionMonitorIfNeeded()
+        guard isRecording else { return }
+        // Deferred a tick — teardown fires during view dismantling, and the
+        // cancel writes SwiftUI state. The callback is captured strongly,
+        // independent of self: SwiftUI can release the detached field
+        // before the next main-queue turn, and a weak-self guard would
+        // silently drop the cancel and leave the gate latched. Local state
+        // flips synchronously so no late observer double-cancels.
+        isRecording = false
+        let cancel = onCancel
+        DispatchQueue.main.async {
+            cancel?()
         }
     }
 
@@ -197,12 +222,22 @@ final class RecorderField: NSView {
 
     private func installSessionMonitorIfNeeded() {
         guard sessionMonitor == nil else { return }
-        sessionMonitor = NSEvent.addLocalMonitorForEvents(
-            matching: [.keyDown, .flagsChanged, .leftMouseDown, .rightMouseDown]
-        ) { [weak self] event in
-            guard let self else { return event }
-            return self.handleMonitoredEvent(event)
+        // The registration is nullable. A "recording" session without a
+        // monitor could neither capture nor cancel from inside the app —
+        // only the dispatch gate would be live, silently consuming every
+        // matched chord. Treat nil as session-start failure and end the
+        // session immediately rather than latching that state.
+        guard let monitor = installMonitorImpl(
+            [.keyDown, .flagsChanged, .leftMouseDown, .rightMouseDown],
+            { [weak self] event in
+                guard let self else { return event }
+                return self.handleMonitoredEvent(event)
+            }
+        ) else {
+            endSessionForTeardown()
+            return
         }
+        sessionMonitor = monitor
         // The local monitor only sees events delivered to Wink — Cmd-Tab or
         // a click into another app would leave the session (and the #417
         // dispatch gate, which swallows every matched chord while latched)
@@ -210,7 +245,10 @@ final class RecorderField: NSView {
         // in the key Settings window, so ANY key-window resignation while
         // recording means focus left the recording context: end the
         // session. Unscoped on purpose (object: nil) — the observer can be
-        // installed before the field is attached to its window.
+        // installed before the field is attached to its window. Installed
+        // only after the monitor succeeded, and guarded, so a retry can
+        // never stack a second unscoped observer and orphan the first.
+        guard resignKeyObserver == nil else { return }
         resignKeyObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.didResignKeyNotification,
             object: nil,

--- a/Sources/Wink/UI/ShortcutRecorderView.swift
+++ b/Sources/Wink/UI/ShortcutRecorderView.swift
@@ -101,9 +101,16 @@ private struct RecorderKeyCaptureRepresentable: NSViewRepresentable {
 }
 
 /// Invisible key-capture surface for the recording composer. Owns no visible
-/// chrome — `ShortcutRecorderView` draws the designed dashed control on top —
-/// but still needs real `NSView` first-responder status to receive
-/// `keyDown`/`flagsChanged` events.
+/// chrome — `ShortcutRecorderView` draws the designed dashed control on top.
+///
+/// Capture is monitor-based, not responder-based (#417): SwiftUI never
+/// routes first-responder status to a `.background` NSView (the settings
+/// sidebar keeps `AXFocusedUIElement` throughout), and the SwiftUI content
+/// drawn on top swallows clicks before they reach `mouseDown` here. So while
+/// recording, a local `NSEvent` monitor owns the session: it captures chords
+/// and swallows key-downs wherever keyboard focus sits, and cancels on a
+/// click outside the field. The responder overrides remain as a harmless
+/// fallback for the case where the field does end up first responder.
 final class RecorderField: NSView {
     var onCapture: ((RecordedShortcut) -> Void)?
     var onRecordingChange: ((Bool) -> Void)?
@@ -113,14 +120,34 @@ final class RecorderField: NSView {
 
     private let keySymbolMapper = KeySymbolMapper()
     private var isRecording = false
+    private var sessionMonitor: Any?
+
+    var isMonitoringForTesting: Bool { sessionMonitor != nil }
 
     override var acceptsFirstResponder: Bool { true }
 
     func updateRecordingState(isRecording: Bool) {
         self.isRecording = isRecording
-        if !isRecording {
+        if isRecording {
+            installSessionMonitorIfNeeded()
+        } else {
+            removeSessionMonitorIfNeeded()
             onLiveModifiersChange?([])
             onErrorChange?(nil)
+        }
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+        // SwiftUI dismantles this view by detaching it from the window; the
+        // monitor must not outlive it (its closure only holds `self` weakly,
+        // but a leaked monitor would keep swallowing key-downs app-wide).
+        if newWindow == nil {
+            removeSessionMonitorIfNeeded()
+        } else if isRecording {
+            // Recording started before the view was attached (makeNSView →
+            // updateNSView precedes window insertion on first swap-in).
+            installSessionMonitorIfNeeded()
         }
     }
 
@@ -130,8 +157,81 @@ final class RecorderField: NSView {
     }
 
     override func keyDown(with event: NSEvent) {
+        // Normally unreachable while recording — the session monitor swallows
+        // key-downs before dispatch — but kept as a fallback if the field is
+        // first responder and the monitor is somehow absent.
         guard isRecording else { return }
+        handleRecordingKeyDown(event)
+    }
 
+    override func flagsChanged(with event: NSEvent) {
+        guard isRecording else {
+            super.flagsChanged(with: event)
+            return
+        }
+        onLiveModifiersChange?(normalizedModifiers(from: event.modifierFlags))
+        super.flagsChanged(with: event)
+    }
+
+    override func resignFirstResponder() -> Bool {
+        if isRecording {
+            onCancel?()
+        }
+        return super.resignFirstResponder()
+    }
+
+    // MARK: - Session monitor
+
+    private func installSessionMonitorIfNeeded() {
+        guard sessionMonitor == nil else { return }
+        sessionMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.keyDown, .flagsChanged, .leftMouseDown, .rightMouseDown]
+        ) { [weak self] event in
+            guard let self else { return event }
+            return self.handleMonitoredEvent(event)
+        }
+    }
+
+    private func removeSessionMonitorIfNeeded() {
+        if let sessionMonitor {
+            NSEvent.removeMonitor(sessionMonitor)
+            self.sessionMonitor = nil
+        }
+    }
+
+    /// Routes one monitored event through the recording session. Returning
+    /// `nil` swallows the event; returning it lets dispatch continue.
+    /// Internal (not private) so tests can drive capture with synthesized
+    /// `NSEvent`s — the monitor itself needs a running event loop.
+    func handleMonitoredEvent(_ event: NSEvent) -> NSEvent? {
+        guard isRecording else { return event }
+
+        switch event.type {
+        case .keyDown:
+            // Swallow every key-down during recording: it is either the
+            // captured chord or feedback about an invalid one. Letting it
+            // through would double-dispatch into whatever holds focus
+            // (typing into the filter field, moving the sidebar selection).
+            handleRecordingKeyDown(event)
+            return nil
+        case .flagsChanged:
+            onLiveModifiersChange?(normalizedModifiers(from: event.modifierFlags))
+            return event
+        case .leftMouseDown, .rightMouseDown:
+            // A click anywhere outside the field ends the session — the
+            // responder-based cancel (`resignFirstResponder`) never fires
+            // when the field was never first responder. The click itself
+            // passes through so the control the user aimed at still works.
+            if !isInsideRecorder(event) {
+                onCancel?()
+            }
+            return event
+        default:
+            return event
+        }
+    }
+
+    private func handleRecordingKeyDown(_ event: NSEvent) {
         // Escape cancels recording
         if event.keyCode == 53 {
             onCancel?()
@@ -155,20 +255,10 @@ final class RecorderField: NSView {
         onCapture?(RecordedShortcut(keyEquivalent: keyEquivalent, modifierFlags: modifiers))
     }
 
-    override func flagsChanged(with event: NSEvent) {
-        guard isRecording else {
-            super.flagsChanged(with: event)
-            return
-        }
-        onLiveModifiersChange?(normalizedModifiers(from: event.modifierFlags))
-        super.flagsChanged(with: event)
-    }
-
-    override func resignFirstResponder() -> Bool {
-        if isRecording {
-            onCancel?()
-        }
-        return super.resignFirstResponder()
+    private func isInsideRecorder(_ event: NSEvent) -> Bool {
+        guard let window, event.window === window else { return false }
+        let point = convert(event.locationInWindow, from: nil)
+        return bounds.contains(point)
     }
 
     private func normalizedModifiers(from flags: NSEvent.ModifierFlags) -> [String] {

--- a/Sources/Wink/UI/ShortcutRecorderView.swift
+++ b/Sources/Wink/UI/ShortcutRecorderView.swift
@@ -121,6 +121,7 @@ final class RecorderField: NSView {
     private let keySymbolMapper = KeySymbolMapper()
     private var isRecording = false
     private var sessionMonitor: Any?
+    private var resignKeyObserver: (any NSObjectProtocol)?
 
     var isMonitoringForTesting: Bool { sessionMonitor != nil }
 
@@ -202,12 +203,34 @@ final class RecorderField: NSView {
             guard let self else { return event }
             return self.handleMonitoredEvent(event)
         }
+        // The local monitor only sees events delivered to Wink — Cmd-Tab or
+        // a click into another app would leave the session (and the #417
+        // dispatch gate, which swallows every matched chord while latched)
+        // stuck with nothing left to cancel it. Recording only ever starts
+        // in the key Settings window, so ANY key-window resignation while
+        // recording means focus left the recording context: end the
+        // session. Unscoped on purpose (object: nil) — the observer can be
+        // installed before the field is attached to its window.
+        resignKeyObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.didResignKeyNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self, self.isRecording else { return }
+                self.onCancel?()
+            }
+        }
     }
 
     private func removeSessionMonitorIfNeeded() {
         if let sessionMonitor {
             NSEvent.removeMonitor(sessionMonitor)
             self.sessionMonitor = nil
+        }
+        if let resignKeyObserver {
+            NotificationCenter.default.removeObserver(resignKeyObserver)
+            self.resignKeyObserver = nil
         }
     }
 

--- a/Tests/WinkTests/RecordingSessionGateTests.swift
+++ b/Tests/WinkTests/RecordingSessionGateTests.swift
@@ -1,0 +1,251 @@
+import Carbon.HIToolbox
+import Foundation
+import Testing
+@testable import Wink
+
+// MARK: - Local fakes (per-file-fakes convention; mirrors the
+// SearchPaletteDispatchTests harness shape)
+
+@MainActor
+private final class FakeCaptureProvider: ShortcutCaptureProvider {
+    var isRunning = false
+    var inputMonitoringRequired = false
+    private(set) var registeredShortcuts: Set<KeyPress> = []
+    private var onKeyPress: (@MainActor @Sendable (KeyPress) -> Void)?
+
+    var registrationState: ShortcutCaptureRegistrationState {
+        ShortcutCaptureRegistrationState(
+            desiredShortcutCount: registeredShortcuts.count,
+            registeredShortcutCount: registeredShortcuts.count,
+            failures: []
+        )
+    }
+
+    func start(onKeyPress: @escaping @MainActor @Sendable (KeyPress) -> Void) {
+        self.onKeyPress = onKeyPress
+        isRunning = true
+    }
+
+    func stop() {
+        isRunning = false
+        onKeyPress = nil
+    }
+
+    func updateRegisteredShortcuts(_ keyPresses: Set<KeyPress>) {
+        registeredShortcuts = keyPresses
+    }
+
+    func emit(_ keyPress: KeyPress) {
+        onKeyPress?(keyPress)
+    }
+}
+
+@MainActor
+private final class FakeHyperCaptureProvider: HyperShortcutCaptureProvider {
+    var isRunning = false
+    private(set) var hyperReleaseDeferralSuppressionCalls: [Bool] = []
+    private var onKeyPress: (@MainActor @Sendable (KeyPress) -> Void)?
+
+    var registrationState: ShortcutCaptureRegistrationState {
+        ShortcutCaptureRegistrationState(desiredShortcutCount: 0, registeredShortcutCount: 0, failures: [])
+    }
+
+    func start(onKeyPress: @escaping @MainActor @Sendable (KeyPress) -> Void) {
+        self.onKeyPress = onKeyPress
+    }
+
+    func stop() {
+        onKeyPress = nil
+    }
+
+    func updateRegisteredShortcuts(_ keyPresses: Set<KeyPress>) {}
+    func setHyperKeyEnabled(_ enabled: Bool) {}
+
+    func setHyperReleaseDeferralSuppressed(_ suppressed: Bool) {
+        hyperReleaseDeferralSuppressionCalls.append(suppressed)
+    }
+}
+
+private struct FakePermissionService: PermissionServicing {
+    func isTrusted() -> Bool { true }
+    func isAccessibilityTrusted() -> Bool { true }
+    func isInputMonitoringTrusted() -> Bool { true }
+    @discardableResult
+    func requestIfNeeded(prompt: Bool, inputMonitoringRequired: Bool) -> Bool { true }
+}
+
+@MainActor
+private final class RecordingAppSwitcher: AppSwitching {
+    private(set) var toggledBundleIdentifiers: [String] = []
+
+    @discardableResult
+    func toggleApplication(for shortcut: AppShortcut, bypassCooldown: Bool) -> Bool {
+        toggledBundleIdentifiers.append(shortcut.bundleIdentifier)
+        return true
+    }
+}
+
+private func safariShortcut() -> AppShortcut {
+    AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "s",
+        modifierFlags: ["command", "shift"]
+    )
+}
+
+private func safariKeyPress() -> KeyPress {
+    KeyPress(keyCode: UInt16(kVK_ANSI_S), modifiers: [.command, .shift])
+}
+
+private func paletteTriggerShortcut() -> AppShortcut {
+    AppShortcut(
+        appName: AppShortcut.searchPaletteTargetStableName,
+        bundleIdentifier: AppShortcut.searchPaletteTargetSentinelBundleIdentifier,
+        keyEquivalent: "space",
+        modifierFlags: ["command", "option"],
+        target: .searchPalette
+    )
+}
+
+private func paletteTriggerKeyPress() -> KeyPress {
+    KeyPress(keyCode: UInt16(kVK_Space), modifiers: [.command, .option])
+}
+
+@MainActor
+private func makeContext(
+    shortcuts: [AppShortcut]
+) -> (
+    manager: ShortcutManager,
+    editor: ShortcutEditorState,
+    appSwitcher: RecordingAppSwitcher,
+    standardProvider: FakeCaptureProvider,
+    hyperProvider: FakeHyperCaptureProvider
+) {
+    let shortcutStore = ShortcutStore()
+    shortcutStore.replaceAll(with: shortcuts)
+    let standardProvider = FakeCaptureProvider()
+    let hyperProvider = FakeHyperCaptureProvider()
+    let appSwitcher = RecordingAppSwitcher()
+    let manager = ShortcutManager(
+        shortcutStore: shortcutStore,
+        persistenceService: TestPersistenceHarness().makePersistenceService(),
+        appSwitcher: appSwitcher,
+        captureCoordinator: ShortcutCaptureCoordinator(
+            standardProvider: standardProvider,
+            hyperProvider: hyperProvider
+        ),
+        permissionService: FakePermissionService(),
+        appBundleLocator: TestAppBundleLocator(entries: [
+            "com.apple.Safari": URL(fileURLWithPath: "/Applications/Safari.app"),
+        ]).locator,
+        diagnosticClient: .init(log: { _ in })
+    )
+    manager.start()
+    let editor = ShortcutEditorState(
+        shortcutStore: shortcutStore,
+        shortcutManager: manager
+    )
+    return (manager, editor, appSwitcher, standardProvider, hyperProvider)
+}
+
+// MARK: - #417/#418 P1: recording sessions gate matched-chord dispatch
+
+@Test @MainActor
+func recordingSessionSwallowsAnAlreadyBoundChordInsteadOfTogglingItsTarget() {
+    let context = makeContext(shortcuts: [safariShortcut()])
+
+    context.manager.setRecordingSessionActive(true)
+    context.standardProvider.emit(safariKeyPress())
+
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+}
+
+@Test @MainActor
+func recordingSessionSwallowsTheSearchPaletteTrigger() {
+    let context = makeContext(shortcuts: [paletteTriggerShortcut()])
+    var firedCount = 0
+    context.manager.onSearchPaletteTriggered = {
+        firedCount += 1
+    }
+
+    context.manager.setRecordingSessionActive(true)
+    context.standardProvider.emit(paletteTriggerKeyPress())
+
+    #expect(firedCount == 0)
+}
+
+@Test @MainActor
+func dispatchResumesOnceTheRecordingSessionEnds() {
+    let context = makeContext(shortcuts: [safariShortcut()])
+
+    context.manager.setRecordingSessionActive(true)
+    context.standardProvider.emit(safariKeyPress())
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+
+    context.manager.setRecordingSessionActive(false)
+    context.standardProvider.emit(safariKeyPress())
+    #expect(context.appSwitcher.toggledBundleIdentifiers == ["com.apple.Safari"])
+}
+
+@Test @MainActor
+func recordingSessionNeverTouchesTheHyperReleaseDeferral() {
+    // Divergence from the interactive-panel seam is deliberate: recording
+    // starts from a mouse click (no chord straddles the boundary), and the
+    // recorder needs Caps Lock to keep acting as Hyper so Hyper chords stay
+    // recordable. Suppressing the deferral here would change Caps Lock
+    // semantics for the whole session.
+    let context = makeContext(shortcuts: [safariShortcut()])
+
+    context.manager.setRecordingSessionActive(true)
+    context.manager.setRecordingSessionActive(false)
+
+    #expect(context.hyperProvider.hyperReleaseDeferralSuppressionCalls.isEmpty)
+}
+
+// MARK: - Editor wiring: the recording flags drive the gate
+
+@Test @MainActor
+func editorComposerRecordingFlagDrivesTheDispatchGate() {
+    let context = makeContext(shortcuts: [safariShortcut()])
+
+    context.editor.isRecordingShortcut = true
+    context.standardProvider.emit(safariKeyPress())
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+
+    context.editor.isRecordingShortcut = false
+    context.standardProvider.emit(safariKeyPress())
+    #expect(context.appSwitcher.toggledBundleIdentifiers == ["com.apple.Safari"])
+}
+
+@Test @MainActor
+func editorPaletteRecordingFlagDrivesTheDispatchGate() {
+    let context = makeContext(shortcuts: [safariShortcut()])
+
+    context.editor.isRecordingSearchPaletteShortcut = true
+    context.standardProvider.emit(safariKeyPress())
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+
+    context.editor.isRecordingSearchPaletteShortcut = false
+    context.standardProvider.emit(safariKeyPress())
+    #expect(context.appSwitcher.toggledBundleIdentifiers == ["com.apple.Safari"])
+}
+
+@Test @MainActor
+func gateHoldsUntilBothRecordersHaveEnded() {
+    // Both recorders live at once cannot happen through the UI, but the OR
+    // in syncRecordingSessionGate must still hold: ending one session while
+    // the other is live may not unlatch the gate.
+    let context = makeContext(shortcuts: [safariShortcut()])
+
+    context.editor.isRecordingShortcut = true
+    context.editor.isRecordingSearchPaletteShortcut = true
+    context.editor.isRecordingShortcut = false
+
+    context.standardProvider.emit(safariKeyPress())
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+
+    context.editor.isRecordingSearchPaletteShortcut = false
+    context.standardProvider.emit(safariKeyPress())
+    #expect(context.appSwitcher.toggledBundleIdentifiers == ["com.apple.Safari"])
+}

--- a/Tests/WinkTests/ShortcutRecorderFieldTests.swift
+++ b/Tests/WinkTests/ShortcutRecorderFieldTests.swift
@@ -18,10 +18,13 @@ struct ShortcutRecorderFieldTests {
         var errorMessages: [String?] = []
 
         init(recording: Bool = true) {
-            field.onCapture = { [unowned self] in captured.append($0) }
-            field.onCancel = { [unowned self] in cancelCount += 1 }
-            field.onLiveModifiersChange = { [unowned self] in liveModifiers.append($0) }
-            field.onErrorChange = { [unowned self] in errorMessages.append($0) }
+            // weak, not unowned: the window-detach cancel retains the
+            // callback beyond the field's lifetime and may run it after a
+            // test's harness has been released.
+            field.onCapture = { [weak self] in self?.captured.append($0) }
+            field.onCancel = { [weak self] in self?.cancelCount += 1 }
+            field.onLiveModifiersChange = { [weak self] in self?.liveModifiers.append($0) }
+            field.onErrorChange = { [weak self] in self?.errorMessages.append($0) }
             field.updateRecordingState(isRecording: recording)
         }
     }
@@ -180,6 +183,78 @@ struct ShortcutRecorderFieldTests {
         NotificationCenter.default.post(name: NSWindow.didResignKeyNotification, object: Self.makeResigningWindow())
 
         #expect(harness.cancelCount == 0)
+    }
+
+    @Test @MainActor
+    func windowDetachCancelSurvivesFieldRelease() async {
+        // #418 round-4 P1: SwiftUI can release the detached field before the
+        // deferred cancel runs. The callback must be retained independently
+        // of self — a weak-self guard would silently drop the cancel and
+        // leave the dispatch gate latched with no live recorder.
+        var cancelCount = 0
+        var field: RecorderField? = RecorderField()
+        field?.onCancel = { cancelCount += 1 }
+        field?.updateRecordingState(isRecording: true)
+
+        field?.viewWillMove(toWindow: nil)
+        field = nil
+
+        // Queue behind the deferred cancel so it has run when we assert.
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+        #expect(cancelCount == 1)
+    }
+
+    @Test @MainActor
+    func failedMonitorRegistrationEndsTheSessionInsteadOfLatchingTheGate() async {
+        // Codex pre-push review (medium): NSEvent.addLocalMonitorForEvents
+        // is nullable. A nil token with isRecording left true would keep
+        // the dispatch gate latched with no way to capture or cancel from
+        // inside the app.
+        var cancelCount = 0
+        let field = RecorderField()
+        field.installMonitorImpl = { _, _ in nil }
+        field.onCancel = { cancelCount += 1 }
+
+        field.updateRecordingState(isRecording: true)
+
+        #expect(!field.isMonitoringForTesting)
+        // The resign observer must not install on the failure path either —
+        // an unguarded retry used to stack a second unscoped observer and
+        // orphan the first for the process lifetime.
+        #expect(!field.isObservingResignKeyForTesting)
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+        #expect(cancelCount == 1)
+    }
+
+    @Test @MainActor
+    func dismantleTeardownEndsTheSessionWithoutAnyWindowCallback() async {
+        // A field discarded before it was ever attached to a window gets no
+        // viewWillMove(toWindow:) at all — dismantleNSView must end the
+        // session on its own or the monitor leaks and the gate stays latched.
+        var cancelCount = 0
+        let field = RecorderField()
+        field.onCancel = { cancelCount += 1 }
+        field.updateRecordingState(isRecording: true)
+        #expect(field.isMonitoringForTesting)
+
+        field.endSessionForTeardown()
+
+        #expect(!field.isMonitoringForTesting)
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+        #expect(cancelCount == 1)
+
+        // Idempotent: the window-detach path may fire after dismantle.
+        field.endSessionForTeardown()
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+        #expect(cancelCount == 1)
     }
 
     @Test @MainActor

--- a/Tests/WinkTests/ShortcutRecorderFieldTests.swift
+++ b/Tests/WinkTests/ShortcutRecorderFieldTests.swift
@@ -1,0 +1,158 @@
+import AppKit
+import Testing
+@testable import Wink
+
+/// #417: `RecorderField` capture must not depend on first-responder status.
+/// These tests drive `handleMonitoredEvent(_:)` — the session monitor's
+/// routing seam — with synthesized `NSEvent`s on a field that has no window
+/// and was never made first responder, exactly the state the live bug left
+/// it in (SwiftUI kept `AXFocusedUIElement` on the settings sidebar).
+@Suite("Shortcut recorder field")
+struct ShortcutRecorderFieldTests {
+    @MainActor
+    private final class Harness {
+        let field = RecorderField()
+        var captured: [RecordedShortcut] = []
+        var cancelCount = 0
+        var liveModifiers: [[String]] = []
+        var errorMessages: [String?] = []
+
+        init(recording: Bool = true) {
+            field.onCapture = { [unowned self] in captured.append($0) }
+            field.onCancel = { [unowned self] in cancelCount += 1 }
+            field.onLiveModifiersChange = { [unowned self] in liveModifiers.append($0) }
+            field.onErrorChange = { [unowned self] in errorMessages.append($0) }
+            field.updateRecordingState(isRecording: recording)
+        }
+    }
+
+    @MainActor
+    private static func keyEvent(
+        type: NSEvent.EventType = .keyDown,
+        keyCode: UInt16,
+        characters: String = "",
+        modifiers: NSEvent.ModifierFlags = []
+    ) -> NSEvent {
+        NSEvent.keyEvent(
+            with: type,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode
+        )!
+    }
+
+    @MainActor
+    private static func mouseEvent(type: NSEvent.EventType = .leftMouseDown) -> NSEvent {
+        NSEvent.mouseEvent(
+            with: type,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )!
+    }
+
+    @Test @MainActor
+    func capturesChordWithoutFirstResponderAndSwallowsKeyDown() {
+        let harness = Harness()
+        // kVK_ANSI_A with a full non-Hyper modifier set
+        let event = Self.keyEvent(keyCode: 0, characters: "a", modifiers: [.command, .option])
+
+        let passthrough = harness.field.handleMonitoredEvent(event)
+
+        #expect(passthrough == nil)
+        #expect(harness.captured == [RecordedShortcut(keyEquivalent: "a", modifierFlags: ["option", "command"])])
+        // The capture path clears any prior error explicitly: one nil entry.
+        #expect(harness.errorMessages == [nil])
+    }
+
+    @Test @MainActor
+    func modifierlessKeySurfacesErrorAndIsStillSwallowed() {
+        let harness = Harness()
+
+        let passthrough = harness.field.handleMonitoredEvent(Self.keyEvent(keyCode: 0, characters: "a"))
+
+        #expect(passthrough == nil)
+        #expect(harness.captured.isEmpty)
+        #expect(harness.errorMessages.last != nil)
+    }
+
+    @Test @MainActor
+    func escapeCancelsTheSession() {
+        let harness = Harness()
+
+        let passthrough = harness.field.handleMonitoredEvent(Self.keyEvent(keyCode: 53))
+
+        #expect(passthrough == nil)
+        #expect(harness.cancelCount == 1)
+        #expect(harness.captured.isEmpty)
+    }
+
+    @Test @MainActor
+    func flagsChangedUpdatesLiveModifiersAndPassesThrough() {
+        let harness = Harness()
+        let event = Self.keyEvent(type: .flagsChanged, keyCode: 55, modifiers: [.control, .shift])
+
+        let passthrough = harness.field.handleMonitoredEvent(event)
+
+        #expect(passthrough === event)
+        #expect(harness.liveModifiers.last == ["control", "shift"])
+    }
+
+    @Test @MainActor
+    func mouseDownOutsideTheFieldCancelsButPassesThrough() {
+        // A windowless field can never contain the click — the "outside" case.
+        let harness = Harness()
+        let event = Self.mouseEvent()
+
+        let passthrough = harness.field.handleMonitoredEvent(event)
+
+        #expect(passthrough === event)
+        #expect(harness.cancelCount == 1)
+    }
+
+    @Test @MainActor
+    func eventsPassThroughUntouchedWhenNotRecording() {
+        let harness = Harness(recording: false)
+        let event = Self.keyEvent(keyCode: 0, characters: "a", modifiers: [.command])
+
+        let passthrough = harness.field.handleMonitoredEvent(event)
+
+        #expect(passthrough === event)
+        #expect(harness.captured.isEmpty)
+        #expect(harness.cancelCount == 0)
+    }
+
+    @Test @MainActor
+    func sessionMonitorFollowsRecordingStateAndWindowDetach() {
+        let harness = Harness(recording: false)
+        #expect(!harness.field.isMonitoringForTesting)
+
+        harness.field.updateRecordingState(isRecording: true)
+        #expect(harness.field.isMonitoringForTesting)
+
+        // Re-entrant updates (SwiftUI calls updateNSView repeatedly) must
+        // not stack a second monitor; state stays installed.
+        harness.field.updateRecordingState(isRecording: true)
+        #expect(harness.field.isMonitoringForTesting)
+
+        // Dismantling mid-recording (window detach) tears the monitor down
+        // even though isRecording never flipped false.
+        harness.field.viewWillMove(toWindow: nil)
+        #expect(!harness.field.isMonitoringForTesting)
+
+        harness.field.updateRecordingState(isRecording: true)
+        harness.field.updateRecordingState(isRecording: false)
+        #expect(!harness.field.isMonitoringForTesting)
+    }
+}

--- a/Tests/WinkTests/ShortcutRecorderFieldTests.swift
+++ b/Tests/WinkTests/ShortcutRecorderFieldTests.swift
@@ -134,6 +134,38 @@ struct ShortcutRecorderFieldTests {
     }
 
     @Test @MainActor
+    func keyWindowResignationCancelsTheSession() {
+        // #418 P2: the local monitor never sees events delivered to other
+        // apps, so Cmd-Tab (or a click into another app) must end the
+        // session through the resign-key observer — otherwise the dispatch
+        // gate stays latched and swallows every matched chord globally.
+        let harness = Harness()
+
+        NotificationCenter.default.post(name: NSWindow.didResignKeyNotification, object: nil)
+
+        #expect(harness.cancelCount == 1)
+    }
+
+    @Test @MainActor
+    func keyWindowResignationIsIgnoredWhenNotRecording() {
+        let harness = Harness(recording: false)
+
+        NotificationCenter.default.post(name: NSWindow.didResignKeyNotification, object: nil)
+
+        #expect(harness.cancelCount == 0)
+    }
+
+    @Test @MainActor
+    func keyWindowResignationIsIgnoredAfterRecordingEnds() {
+        let harness = Harness()
+        harness.field.updateRecordingState(isRecording: false)
+
+        NotificationCenter.default.post(name: NSWindow.didResignKeyNotification, object: nil)
+
+        #expect(harness.cancelCount == 0)
+    }
+
+    @Test @MainActor
     func sessionMonitorFollowsRecordingStateAndWindowDetach() {
         let harness = Harness(recording: false)
         #expect(!harness.field.isMonitoringForTesting)

--- a/Tests/WinkTests/ShortcutRecorderFieldTests.swift
+++ b/Tests/WinkTests/ShortcutRecorderFieldTests.swift
@@ -47,6 +47,23 @@ struct ShortcutRecorderFieldTests {
         )!
     }
 
+    /// A real window for resign-key notification posts: broadcasting the
+    /// notification with `object: nil` trips an `NSRemoteView` assertion
+    /// (`[window isKindOfClass:NSWindow.class]`) in CI test processes that
+    /// host ViewBridge listeners — the production observer is unscoped, so
+    /// any window object reaches it just the same.
+    @MainActor
+    private static func makeResigningWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: .zero,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: true
+        )
+        window.isReleasedWhenClosed = false
+        return window
+    }
+
     @MainActor
     private static func mouseEvent(type: NSEvent.EventType = .leftMouseDown) -> NSEvent {
         NSEvent.mouseEvent(
@@ -141,7 +158,7 @@ struct ShortcutRecorderFieldTests {
         // gate stays latched and swallows every matched chord globally.
         let harness = Harness()
 
-        NotificationCenter.default.post(name: NSWindow.didResignKeyNotification, object: nil)
+        NotificationCenter.default.post(name: NSWindow.didResignKeyNotification, object: Self.makeResigningWindow())
 
         #expect(harness.cancelCount == 1)
     }
@@ -150,7 +167,7 @@ struct ShortcutRecorderFieldTests {
     func keyWindowResignationIsIgnoredWhenNotRecording() {
         let harness = Harness(recording: false)
 
-        NotificationCenter.default.post(name: NSWindow.didResignKeyNotification, object: nil)
+        NotificationCenter.default.post(name: NSWindow.didResignKeyNotification, object: Self.makeResigningWindow())
 
         #expect(harness.cancelCount == 0)
     }
@@ -160,7 +177,7 @@ struct ShortcutRecorderFieldTests {
         let harness = Harness()
         harness.field.updateRecordingState(isRecording: false)
 
-        NotificationCenter.default.post(name: NSWindow.didResignKeyNotification, object: nil)
+        NotificationCenter.default.post(name: NSWindow.didResignKeyNotification, object: Self.makeResigningWindow())
 
         #expect(harness.cancelCount == 0)
     }


### PR DESCRIPTION
Fixes #417

## Summary
- Both shortcut recorders (Search Palette card in General, New Shortcut composer in Shortcuts) sat in "Recording…" forever: `RecorderField` depended on first-responder `keyDown` delivery, but SwiftUI never routes first-responder status to a `.background` NSView (AX inspection during a live repro showed `AXFocusedUIElement` pinned to the settings sidebar), and the SwiftUI content drawn on top swallows the clicks that would have grabbed it in `mouseDown`.
- While recording, a local `NSEvent` monitor now owns the session: it captures chords and swallows key-downs wherever keyboard focus sits, updates live modifiers on `flagsChanged`, and cancels on Escape or a click outside the field. The monitor installs on recording start (and on window attach when recording began before insertion), and tears down on recording end or window detach so it can never outlive the field. The responder overrides remain as a fallback.
- Review P1 follow-through (cf1426d): with recording actually working, an already-bound chord pressed mid-recording would dispatch — toggling its target (or opening the palette) over Settings — because both capture routes consume the event upstream of the recorder's monitor. `ShortcutManager` gains `recordingSessionActive` (same dispatch-not-capture shape as `interactivePanelSessionActive`, same three guard sites), deliberately without the panel seam's #385 release-deferral suppression so Caps Lock keeps acting as Hyper and Hyper chords stay recordable. `ShortcutEditorState` drives the gate from both recording flags; `RecorderField` cancels the session on window detach so closing Settings mid-recording can never leave the gate latched. Surfacing the swallowed chord as an immediate conflict is #419.
- Review P2 follow-through (7394453): the local monitor only sees events delivered to Wink, so Cmd-Tab or a click into another app left the session — and the latched gate — stuck. Recording only ever starts in the key Settings window, so a session-scoped `NSWindow.didResignKeyNotification` observer (installed and torn down with the monitor) cancels the session on any key-window resignation: Cmd-Tab, other-app clicks, minimize, lock screen, Space switches.
- Teardown hardening (9b2dc5f, review round-4 P1 + two sibling holes from a local Codex pre-push review of the full branch): the window-detach cancel captures its callback strongly (SwiftUI can release the detached field before the deferred main-queue turn — a weak-self guard silently dropped the cancel); `dismantleNSView` routes through the same idempotent `endSessionForTeardown()` (a field discarded before ever attaching to a window gets no `viewWillMove` at all); and a nil return from `NSEvent.addLocalMonitorForEvents` ends the session immediately instead of latching a monitor-less "recording" state, with the resign-key observer installing only after the monitor succeeds (also fixes a retry stacking a second unscoped observer).
- New suites: `ShortcutRecorderFieldTests` (13) drives the monitor's routing seam with synthesized `NSEvent`s on a windowless, never-focused field — capture, swallow, modifierless error, Escape/click-outside cancel, resign-key cancel (recording / idle / post-session), pass-through when idle, monitor lifecycle, post-release deferred cancel, dismantle teardown, failed-registration teardown. `RecordingSessionGateTests` (7) covers the dispatch gate at the manager level (swallow bound chord / palette trigger, resume on end, no release-deferral coupling) and the editor wiring (both flags, OR-latch across overlapping sessions).

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

`swift test`: 750 tests / 56 suites pass. On-device validation (packaged signed build, macOS 15.7.5, zh-Hans dark, CGEvent-driven at `.cghidEventTap`):

Recorder (commit 0e173c1):
1. Click 录制 → send `⌃⌥⌘K` directly (no Tab workaround) → chord captured and rendered as keycaps.
2. Start recording → click elsewhere → recording cancels back to idle (previously the responder-based cancel was dead code).
3. Modifierless key → red "至少需要一个修饰键" inline error, still recording.
4. Escape → cancels back to idle.
5. After recording ends, the monitor is torn down: typing (incl. IME composition) reaches the shortcuts filter field normally.
6. Search Palette card end-to-end: record `⌃⌥⌘9` → auto-commit renders badge/toggle/delete → pressing the chord opens the palette HUD with ranked results → deleted the test shortcut; `shortcuts.json` verified byte-equivalent to the pre-test backup.

Dispatch gate (commit cf1426d, real F19 Hyper route):
1. While recording, press bound Hyper chord `F19+F` (Finder) → Finder NOT activated, Wink stays frontmost, recorder unaffected.
2. While recording, press unbound Hyper chord `F19+9` → injected and captured as `^⌥⇧⌘9` (gate blocks dispatch only, not capture).
3. After recording ends, `F19+F` activates Finder normally; second press toggles it away.
4. Close Settings mid-recording (red light) → gate unlatches via the window-detach cancel: `F19+F` still activates Finder afterwards.

Focus-loss cancel (commit 7394453):
1. While recording, activate another app (Settings resigns key) → press bound `F19+B` → Chrome activates immediately (gate unlatched), recorder back to idle.

Teardown hardening (commit 9b2dc5f):
1. Mid-recording tab switch (view swap teardown) → `F19+F` activates Finder immediately.
2. Mid-recording window close → `F19+F` activates Finder immediately.

`shortcuts.json` byte-equivalent after the full pass; production Wink restored.

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
