### PR TITLE
feat: surface already-bound chords in the live recorder

### DIFF
--- a/Sources/Wink/AppController.swift
+++ b/Sources/Wink/AppController.swift
@@ -390,6 +390,9 @@ final class AppController {
         shortcutManager.onSearchPaletteTriggered = { [weak self] in
             self?.searchPaletteHUD.present()
         }
+        shortcutManager.onRecordingSessionKeyPress = { [weak self] keyPress in
+            self?.shortcutEditor.handleRecordingSessionKeyPress(keyPress)
+        }
 
         Self.runStartupSequence(
             startUpdateService: { _ = updateService },

--- a/Sources/Wink/Models/RecordedShortcut.swift
+++ b/Sources/Wink/Models/RecordedShortcut.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 // MARK: - Shared modifier helpers
@@ -33,6 +34,31 @@ struct RecordedShortcut: Equatable {
 
     var isHyper: Bool { ModifierFormatting.isHyperCombo(modifierFlags) }
     var displayText: String { ModifierFormatting.displayText(modifierFlags: modifierFlags, keyEquivalent: keyEquivalent) }
+
+    /// Chord identity → recorder value (#419). The modifier order matches
+    /// `RecorderField.normalizedModifiers` so a rerouted capture is
+    /// indistinguishable from a monitor-captured one. Returns nil for keys
+    /// outside the recorder's contract (no `KeySymbolMapper` mapping) or a
+    /// modifierless press — neither can name a bound chord.
+    init?(keyPress: KeyPress) {
+        guard let keyEquivalent = KeySymbolMapper().keyEquivalent(for: keyPress.keyCode) else {
+            return nil
+        }
+        var modifiers: [String] = []
+        let flags = keyPress.modifiers
+        if flags.contains(.control) { modifiers.append("control") }
+        if flags.contains(.option) { modifiers.append("option") }
+        if flags.contains(.shift) { modifiers.append("shift") }
+        if flags.contains(.command) { modifiers.append("command") }
+        if flags.contains(.function) { modifiers.append("function") }
+        guard !modifiers.isEmpty else { return nil }
+        self.init(keyEquivalent: keyEquivalent, modifierFlags: modifiers)
+    }
+
+    init(keyEquivalent: String, modifierFlags: [String]) {
+        self.keyEquivalent = keyEquivalent
+        self.modifierFlags = modifierFlags
+    }
 }
 
 // MARK: - AppShortcut display extensions

--- a/Sources/Wink/Services/ShortcutEditorState.swift
+++ b/Sources/Wink/Services/ShortcutEditorState.swift
@@ -233,6 +233,40 @@ final class ShortcutEditorState {
         searchPaletteSaveErrorMessage = saveErrorMessage
     }
 
+    /// #419: an already-bound chord pressed while a recorder is live is
+    /// consumed by its capture route upstream of AppKit, so the recorder's
+    /// NSEvent monitor never sees it. `ShortcutManager` reroutes it here:
+    /// the press becomes the live recorder's captured value and runs the
+    /// exact path a monitor-captured chord would have run — the palette
+    /// commits (surfacing its conflict message immediately), the composer
+    /// fills its draft (conflicts surface on Add, as always). A key with no
+    /// recorder mapping is dropped and the session stays live, mirroring
+    /// the monitor's unsupported-key behavior.
+    func handleRecordingSessionKeyPress(_ keyPress: KeyPress) {
+        // Escape cancels — checked before any mapping and regardless of
+        // modifiers, mirroring `RecorderField.handleRecordingKeyDown`'s
+        // ordering. A persisted/imported ⌘⎋-style binding arrives here as a
+        // bound chord, and it must cancel exactly like the unbound ⎋ the
+        // monitor path would have seen.
+        if keyPress.keyCode == 53 {
+            if isRecordingSearchPaletteShortcut {
+                isRecordingSearchPaletteShortcut = false
+            } else if isRecordingShortcut {
+                isRecordingShortcut = false
+            }
+            return
+        }
+        guard let recorded = RecordedShortcut(keyPress: keyPress) else { return }
+        if isRecordingSearchPaletteShortcut {
+            isRecordingSearchPaletteShortcut = false
+            recordedSearchPaletteShortcut = recorded
+            commitSearchPaletteShortcut(recorded)
+        } else if isRecordingShortcut {
+            recordedShortcut = recorded
+            isRecordingShortcut = false
+        }
+    }
+
     /// #417: while either recorder is live, matched chords are consumed but
     /// not dispatched (`ShortcutManager.setRecordingSessionActive`) so an
     /// already-bound chord pressed mid-recording cannot toggle its target

--- a/Sources/Wink/Services/ShortcutManager.swift
+++ b/Sources/Wink/Services/ShortcutManager.swift
@@ -97,6 +97,13 @@ final class ShortcutManager {
     /// `AppSwitcher.toggleApplication`. The consumer (AppController) owns
     /// presenting the palette.
     var onSearchPaletteTriggered: (@MainActor () -> Void)?
+    /// #419: while a Settings recorder session is live, a matched chord is
+    /// consumed but cannot reach the recorder's AppKit monitor (both
+    /// capture routes swallow it upstream). Instead of dropping the press,
+    /// the recording gate reroutes it here so the live recorder can render
+    /// it and run the standard conflict path. The consumer (AppController)
+    /// forwards to `ShortcutEditorState.handleRecordingSessionKeyPress`.
+    var onRecordingSessionKeyPress: (@MainActor (KeyPress) -> Void)?
     private var holdGestureArbiter: HoldGestureArbiter?
     /// True while an interactive Wink panel (the hold-to-show window picker)
     /// is key. Matched shortcut dispatch is gated on it instead of the full
@@ -220,8 +227,17 @@ final class ShortcutManager {
             // already key: a gesture started mid-session would survive the
             // session's dismissal and its deadline would resurrect the
             // picker the user just closed.
-            guard let self, !self.effectivePaused, !self.interactivePanelSessionActive,
-                  !self.recordingSessionActive else {
+            guard let self, !self.effectivePaused, !self.interactivePanelSessionActive else {
+                return
+            }
+            if self.recordingSessionActive {
+                // #419: phased chords bypass handleKeyPress entirely, so
+                // the reroute lives here too. Down edge only — the up edge
+                // carries no chord the recorder could capture, and a
+                // gesture must not enter the arbiter mid-recording.
+                if phase == .down {
+                    self.onRecordingSessionKeyPress?(keyPress)
+                }
                 return
             }
             arbiter?.handle(keyPress, phase)
@@ -747,10 +763,12 @@ final class ShortcutManager {
         }
         guard !recordingSessionActive else {
             // Consumed, not dispatched: an already-bound chord pressed while
-            // a recorder is live must not toggle its target. (It cannot be
-            // captured either — both providers consume it upstream of
-            // AppKit — surfacing it as a conflict is #419.)
-            diagnosticClient.log("KEYPRESS_IGNORED: recording session active")
+            // a recorder is live must not toggle its target. Rerouted to
+            // the live recorder instead (#419) — both providers consume the
+            // press upstream of AppKit, so this is the only path on which
+            // the recorder can ever see it.
+            diagnosticClient.log("KEYPRESS_REROUTED: recording session active")
+            onRecordingSessionKeyPress?(keyPress)
             return true
         }
         let key = keyMatcher.trigger(for: keyPress)

--- a/Tests/WinkTests/RecordingSessionGateTests.swift
+++ b/Tests/WinkTests/RecordingSessionGateTests.swift
@@ -12,6 +12,15 @@ private final class FakeCaptureProvider: ShortcutCaptureProvider {
     var inputMonitoringRequired = false
     private(set) var registeredShortcuts: Set<KeyPress> = []
     private var onKeyPress: (@MainActor @Sendable (KeyPress) -> Void)?
+    private var phasedObserver: (@MainActor @Sendable (KeyPress, KeyEventPhase) -> Void)?
+
+    func setPhasedKeyObserver(_ observer: (@MainActor @Sendable (KeyPress, KeyEventPhase) -> Void)?) {
+        phasedObserver = observer
+    }
+
+    func emitPhased(_ keyPress: KeyPress, _ phase: KeyEventPhase) {
+        phasedObserver?(keyPress, phase)
+    }
 
     var registrationState: ShortcutCaptureRegistrationState {
         ShortcutCaptureRegistrationState(
@@ -85,12 +94,13 @@ private final class RecordingAppSwitcher: AppSwitching {
     }
 }
 
-private func safariShortcut() -> AppShortcut {
+private func safariShortcut(holdAction: HoldAction? = nil) -> AppShortcut {
     AppShortcut(
         appName: "Safari",
         bundleIdentifier: "com.apple.Safari",
         keyEquivalent: "s",
-        modifierFlags: ["command", "shift"]
+        modifierFlags: ["command", "shift"],
+        holdAction: holdAction
     )
 }
 
@@ -201,6 +211,187 @@ func recordingSessionNeverTouchesTheHyperReleaseDeferral() {
     context.manager.setRecordingSessionActive(false)
 
     #expect(context.hyperProvider.hyperReleaseDeferralSuppressionCalls.isEmpty)
+}
+
+// MARK: - #419: bound chords reroute to the live recorder
+
+@Test @MainActor
+func recordingSessionReroutesTheBoundChordToTheCallbackInsteadOfDropping() {
+    let context = makeContext(shortcuts: [safariShortcut()])
+    var rerouted: [KeyPress] = []
+    context.manager.onRecordingSessionKeyPress = { rerouted.append($0) }
+
+    context.manager.setRecordingSessionActive(true)
+    context.standardProvider.emit(safariKeyPress())
+
+    #expect(rerouted == [safariKeyPress()])
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+}
+
+@Test @MainActor
+func reroutedBoundChordSurfacesThePaletteConflictImmediately() {
+    let context = makeContext(shortcuts: [safariShortcut()])
+    context.manager.onRecordingSessionKeyPress = { [weak editor = context.editor] in
+        editor?.handleRecordingSessionKeyPress($0)
+    }
+
+    context.editor.isRecordingSearchPaletteShortcut = true
+    context.standardProvider.emit(safariKeyPress())
+
+    #expect(context.editor.searchPaletteConflictMessage != nil)
+    #expect(!context.editor.isRecordingSearchPaletteShortcut)
+    #expect(context.editor.searchPaletteShortcut == nil)
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+}
+
+@Test @MainActor
+func reroutedReRecordOfThePalettesOwnTriggerCommitsCleanly() {
+    // The one non-conflict reroute: the palette trigger IS a bound chord,
+    // so re-recording the same combo arrives via the reroute — the
+    // validator excludes the candidate's own id and the commit replaces
+    // the binding in place.
+    let context = makeContext(shortcuts: [paletteTriggerShortcut()])
+    context.manager.onRecordingSessionKeyPress = { [weak editor = context.editor] in
+        editor?.handleRecordingSessionKeyPress($0)
+    }
+
+    context.editor.isRecordingSearchPaletteShortcut = true
+    context.standardProvider.emit(paletteTriggerKeyPress())
+
+    #expect(context.editor.searchPaletteConflictMessage == nil)
+    #expect(context.editor.searchPaletteShortcut != nil)
+    #expect(!context.editor.isRecordingSearchPaletteShortcut)
+}
+
+@Test @MainActor
+func reroutedBoundChordFillsTheComposerDraft() {
+    let context = makeContext(shortcuts: [safariShortcut()])
+    context.manager.onRecordingSessionKeyPress = { [weak editor = context.editor] in
+        editor?.handleRecordingSessionKeyPress($0)
+    }
+
+    context.editor.isRecordingShortcut = true
+    context.standardProvider.emit(safariKeyPress())
+
+    #expect(context.editor.recordedShortcut == RecordedShortcut(keyEquivalent: "s", modifierFlags: ["shift", "command"]))
+    #expect(!context.editor.isRecordingShortcut)
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+}
+
+@Test @MainActor
+func unmappableKeyLeavesTheRecordingSessionLive() {
+    let context = makeContext(shortcuts: [safariShortcut()])
+
+    context.editor.isRecordingShortcut = true
+    context.editor.handleRecordingSessionKeyPress(KeyPress(keyCode: 0xFFFF, modifiers: [.command]))
+
+    #expect(context.editor.recordedShortcut == nil)
+    #expect(context.editor.isRecordingShortcut)
+}
+
+@Test @MainActor
+func phasedDownEdgeReroutesWhileRecordingAndUpEdgeDoesNot() {
+    // Phased chords bypass handleKeyPress entirely — the reroute must live
+    // on the phased-observer path too, down edge only.
+    let context = makeContext(shortcuts: [safariShortcut(holdAction: .windowPicker)])
+    var rerouted: [KeyPress] = []
+    context.manager.onRecordingSessionKeyPress = { rerouted.append($0) }
+
+    context.manager.setRecordingSessionActive(true)
+    context.standardProvider.emitPhased(safariKeyPress(), .down)
+    context.standardProvider.emitPhased(safariKeyPress(), .up)
+
+    #expect(rerouted == [safariKeyPress()])
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+}
+
+@Test @MainActor
+func reroutedBoundEscapeChordCancelsTheSessionLikeTheMonitorPath() {
+    // Codex pre-push review (medium): KeyMatcher permits persisted ⌘⎋-style
+    // bindings, and the recorder's monitor treats keyCode 53 as cancel
+    // BEFORE inspecting modifiers. The reroute must not diverge: a bound
+    // modified-Escape cancels, it never becomes a captured chord.
+    let escapeShortcut = AppShortcut(
+        appName: "Safari",
+        bundleIdentifier: "com.apple.Safari",
+        keyEquivalent: "escape",
+        modifierFlags: ["command"]
+    )
+    let context = makeContext(shortcuts: [escapeShortcut])
+    context.manager.onRecordingSessionKeyPress = { [weak editor = context.editor] in
+        editor?.handleRecordingSessionKeyPress($0)
+    }
+
+    context.editor.isRecordingSearchPaletteShortcut = true
+    context.standardProvider.emit(KeyPress(keyCode: 53, modifiers: [.command]))
+
+    #expect(!context.editor.isRecordingSearchPaletteShortcut)
+    #expect(context.editor.searchPaletteShortcut == nil)
+    #expect(context.editor.searchPaletteConflictMessage == nil)
+
+    context.editor.isRecordingShortcut = true
+    context.editor.handleRecordingSessionKeyPress(KeyPress(keyCode: 53, modifiers: [.command]))
+    #expect(!context.editor.isRecordingShortcut)
+    #expect(context.editor.recordedShortcut == nil)
+}
+
+@Test @MainActor
+func rerouteWithNoLiveRecorderIsANoOp() {
+    // A stale gate flag (manager on, both editor flags off) must not let a
+    // rerouted press corrupt either draft.
+    let context = makeContext(shortcuts: [safariShortcut()])
+
+    context.editor.handleRecordingSessionKeyPress(safariKeyPress())
+
+    #expect(context.editor.recordedShortcut == nil)
+    #expect(context.editor.recordedSearchPaletteShortcut == nil)
+    #expect(context.editor.searchPaletteConflictMessage == nil)
+}
+
+@Test @MainActor
+func phasedUpEdgeAfterTheDownEdgeEndedTheSessionIsHarmless() {
+    // The real wiring ends the session on the rerouted down edge, so the
+    // matching up edge arrives with the gate already off and flows to the
+    // arbiter as an unmatched release — no dispatch, no crash.
+    let context = makeContext(shortcuts: [safariShortcut(holdAction: .windowPicker)])
+    context.manager.onRecordingSessionKeyPress = { [weak editor = context.editor] in
+        editor?.handleRecordingSessionKeyPress($0)
+    }
+
+    context.editor.isRecordingShortcut = true
+    context.standardProvider.emitPhased(safariKeyPress(), .down)
+    #expect(!context.editor.isRecordingShortcut)
+
+    context.standardProvider.emitPhased(safariKeyPress(), .up)
+
+    #expect(context.editor.recordedShortcut == RecordedShortcut(keyEquivalent: "s", modifierFlags: ["shift", "command"]))
+    #expect(context.appSwitcher.toggledBundleIdentifiers.isEmpty)
+}
+
+// MARK: - KeyPress → RecordedShortcut conversion
+
+@Test @MainActor
+func keyPressConversionPreservesHyperIdentityAndRecorderModifierOrder() {
+    let recorded = RecordedShortcut(keyPress: KeyPress(
+        keyCode: UInt16(kVK_ANSI_F),
+        modifiers: [.command, .shift, .option, .control]
+    ))
+
+    #expect(recorded == RecordedShortcut(keyEquivalent: "f", modifierFlags: ["control", "option", "shift", "command"]))
+    #expect(recorded?.isHyper == true)
+}
+
+@Test @MainActor
+func keyPressConversionRejectsUnmappableAndModifierlessPresses() {
+    #expect(RecordedShortcut(keyPress: KeyPress(keyCode: 0xFFFF, modifiers: [.command])) == nil)
+    #expect(RecordedShortcut(keyPress: KeyPress(keyCode: UInt16(kVK_ANSI_F), modifiers: [])) == nil)
+}
+
+@Test @MainActor
+func keyPressConversionCarriesTheFunctionModifierForFnFRowChords() {
+    let recorded = RecordedShortcut(keyPress: KeyPress(keyCode: UInt16(kVK_F5), modifiers: [.function]))
+
+    #expect(recorded?.modifierFlags == ["function"])
 }
 
 // MARK: - Editor wiring: the recording flags drive the gate


### PR DESCRIPTION
Fixes #419

## Summary
- Since #418's dispatch gate, an already-bound chord pressed while a Settings recorder is live was consumed silently — no toggle (correct), but no feedback either: both capture routes (Carbon `EventHotKey`, the Hyper tap) consume the press upstream of AppKit, so the recorder's `NSEvent` monitor can never see it.
- The recording gate now reroutes instead of dropping: `ShortcutManager.onRecordingSessionKeyPress` forwards the matched `KeyPress` (wired by AppController) to `ShortcutEditorState.handleRecordingSessionKeyPress`, which converts it via a new failable `RecordedShortcut(keyPress:)` — same modifier order as `RecorderField.normalizedModifiers`, nil for unmappable/modifierless presses — and feeds whichever recorder is live. The palette recorder commits, surfacing its conflict message immediately (or cleanly re-recording its own trigger in place — the validator excludes the candidate's own id); the composer fills its draft, with conflicts surfacing on Add exactly like a monitor-captured chord.
- Phased chords bypass `handleKeyPress` entirely, so the phased-observer gate reroutes the down edge the same way; up edges are dropped (no capturable chord) and gestures never enter the arbiter mid-recording.
- A bound modified-Escape (persisted/imported ⌘⎋-style bindings are legal per `KeyMatcher`) cancels the session exactly like the monitor path — keyCode 53 is checked before any mapping, regardless of modifiers (local Codex pre-push finding, medium).
- `RecordingSessionGateTests` grows to 19: manager-level reroute (standard + phased down/up, plus the wired down-ends-session→up-is-harmless sequence), palette conflict / clean self-re-record / composer draft via a fully wired editor, bound-Escape cancellation, stale-gate no-op, unmappable-key session survival, and `RecordedShortcut(keyPress:)` conversion fidelity (Hyper identity + recorder modifier order, `.function` carry, nil cases).

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

`swift test`: 762 tests / 56 suites pass. On-device validation (packaged signed build, macOS 15.7.5, zh-Hans dark, real F19 Hyper route + Carbon standard route):
1. Composer recording + bound `F19+F` (Finder) → chord captured and rendered as `^⌥⇧⌘F` keycaps, Finder NOT activated, Wink stays frontmost.
2. Palette recording + bound `F19+F` → immediate red conflict line 「冲突：Finder 已使用 control+option+shift+command+F」, recorder back to idle, nothing committed.
3. Standard route: bound `⌃⌥⌘9` (palette trigger) pressed while the composer records → captured as `^⌥⌘9`, palette HUD NOT opened.
4. `shortcuts.json` byte-equivalent after the full pass; production Wink restored.

Pre-push Layer 1: local Codex deep review over the full branch diff. Four focus areas CLEAN (stale-gate reroute, provider-stack reentrancy, double-delivery via failed registrations, Hyper/Fn conversion fidelity); the medium Escape-semantics finding is fixed in this PR; the low deferred-cancel hypothesis (pre-existing mechanism from #418's teardown) is tracked as #420.

## Validation Status
- [ ] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [x] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
