### PR TITLE
chore: release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ Newest first. One `## X.Y.Z` section per release, written by hand **before** run
 `scripts/bump-version.sh X.Y.Z`. `scripts/release-notes.sh X.Y.Z` extracts a section as the
 GitHub Release body; the release workflow fails if the tagged version has no section here.
 
+## 0.7.2
+
+The recorder actually records.
+
+- **Shortcut recording works** — clicking Record in Settings captured
+  nothing: the invisible capture field never received keyboard focus, on
+  either the Search Palette card or the New Shortcut composer. Capture no
+  longer depends on focus at all — click Record, press your chord, done.
+  Escape cancels, clicking elsewhere cancels, and leaving Settings in any
+  way (tab switch, window close, Cmd-Tab, lock screen) ends the session
+  cleanly instead of leaving it stuck.
+- **Recording can't misfire your shortcuts** — pressing an already-bound
+  chord while recording used to trigger it: the bound app switched in
+  front of the Settings window mid-recording. Bound chords are now
+  consumed for the whole recording session and shown in the recorder
+  instead — the Search Palette card surfaces its conflict immediately
+  ("Finder already uses …"), the composer captures the chord and reports
+  the conflict on Add. Re-recording the palette's own trigger still
+  commits cleanly, and a bound ⌘⎋-style chord still cancels like plain
+  Escape.
+
 ## 0.7.1
 
 Three sharp edges off the window-switching release.

--- a/Sources/Wink/Resources/Info.plist
+++ b/Sources/Wink/Resources/Info.plist
@@ -26,7 +26,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.7.1</string>
+	<string>0.7.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -39,7 +39,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
Fixes #422

Release prep for v0.7.2, following #414's precedent.

## Summary
- CHANGELOG 0.7.2 section: the shortcut-recorder repair wave — recording no longer depends on keyboard focus and every session exit path releases cleanly (#417 via #418), and already-bound chords pressed mid-recording surface in the live recorder (palette conflicts immediately, composer on Add) instead of triggering their targets or vanishing silently (#419 via #421)
- `scripts/bump-version.sh 0.7.2`: CFBundleShortVersionString 0.7.1 → 0.7.2, CFBundleVersion 11 → 12
- Known omission carried forward from #395/#413, deliberate: still no WhatsNewCatalog entry — patch releases stay out of the showcase panel; it remains with the next feature-release author.

## Test plan
- [x] `swift test` — 762/762 passing
- [x] `SPARKLE_PUBLIC_BASE_URL=<live R2 base> scripts/verify-release-feed.sh --mode release` — feed gate passed: 12 > 11

## Validation Status
- [ ] Not runtime-sensitive
- [x] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Keep exactly one `Validation Status` checkbox selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
