### PR TITLE
fix: keep background system processes out of suggested shortcuts

### DIFF
--- a/Sources/Wink/Services/AppActivationRecorder.swift
+++ b/Sources/Wink/Services/AppActivationRecorder.swift
@@ -2,9 +2,10 @@ import AppKit
 
 /// Counts foreground app activations (local-only) to power the Insights
 /// "Suggested shortcuts" card. Purely observational: one workspace
-/// notification, no TCC, no polling. Wink itself is never recorded;
-/// bound-vs-unbound filtering happens at query time because binding
-/// state changes over time.
+/// notification, no TCC, no polling. Wink itself is never recorded, and
+/// `AppSuggestionEligibility` drops non-.regular processes that aren't
+/// installed apps; bound-vs-unbound filtering happens at query time because
+/// binding state changes over time.
 @MainActor
 final class AppActivationRecorder {
     private let onActivation: @MainActor (String) -> Void
@@ -18,10 +19,21 @@ final class AppActivationRecorder {
         isEnabled = enabled
     }
 
-    func handleActivation(bundleIdentifier: String?) {
+    func handleActivation(
+        bundleIdentifier: String?,
+        activationPolicy: NSApplication.ActivationPolicy,
+        bundleURL: URL?
+    ) {
         guard isEnabled,
               let bundleIdentifier,
-              bundleIdentifier != Bundle.main.bundleIdentifier else { return }
+              bundleIdentifier != Bundle.main.bundleIdentifier,
+              // System dialogs and background agents (universalAccessAuthWarn,
+              // loginwindow-class helpers) fire didActivate too; recording
+              // them turns the Suggested-shortcuts card into a process list.
+              AppSuggestionEligibility.shouldRecordActivation(
+                  activationPolicy: activationPolicy,
+                  bundleURL: bundleURL
+              ) else { return }
         onActivation(bundleIdentifier)
     }
 
@@ -41,9 +53,19 @@ final class AppActivationRecorder {
             object: nil,
             queue: .main
         ) { [weak self] notification in
-            let bundle = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?.bundleIdentifier
+            let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+            let bundle = app?.bundleIdentifier
+            // Snapshot policy and URL on the main queue alongside the id —
+            // NSRunningApplication's time-varying properties are only
+            // consistent within the current main run loop turn.
+            let policy = app?.activationPolicy ?? .regular
+            let bundleURL = app?.bundleURL
             MainActor.assumeIsolated { [weak self] in
-                self?.handleActivation(bundleIdentifier: bundle)
+                self?.handleActivation(
+                    bundleIdentifier: bundle,
+                    activationPolicy: policy,
+                    bundleURL: bundleURL
+                )
             }
         }
     }

--- a/Sources/Wink/Services/AppListProvider.swift
+++ b/Sources/Wink/Services/AppListProvider.swift
@@ -155,11 +155,9 @@ final class AppListProvider {
     }
 
     nonisolated private static func scanInstalledApps() -> [AppEntry] {
-        let searchDirs = [
-            URL(fileURLWithPath: "/Applications"),
-            URL(fileURLWithPath: "/System/Applications"),
-            URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Applications"),
-        ]
+        // Shared with AppSuggestionEligibility: the suggestion policy's
+        // "installed app" exception must mean the same roots this scan uses.
+        let searchDirs = StandardApplicationDirectories.roots
 
         var seen = Set<String>()
         var entries: [AppEntry] = []

--- a/Sources/Wink/Services/AppSuggestionEligibility.swift
+++ b/Sources/Wink/Services/AppSuggestionEligibility.swift
@@ -1,0 +1,78 @@
+import AppKit
+
+/// The app-scan roots shared by `AppListProvider.scanInstalledApps` and the
+/// suggestion eligibility policy below. One source of truth: the #384
+/// trade-off ("a non-.regular process is legitimate only when it resolves
+/// to an installed app") is only coherent while both sides agree on what
+/// "installed" means.
+enum StandardApplicationDirectories {
+    static let roots: [URL] = [
+        URL(fileURLWithPath: "/Applications"),
+        URL(fileURLWithPath: "/System/Applications"),
+        URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Applications"),
+    ]
+
+    /// Component-wise containment (a plain string-prefix check would accept
+    /// "/ApplicationsFake/X.app"), additionally rejecting bundles nested
+    /// inside another .app: an embedded helper at
+    /// /Applications/X.app/Contents/.../Helper.app is not an installed app,
+    /// and the AppListProvider scan never descends into .app bundles either.
+    static func contains(_ url: URL) -> Bool {
+        let components = url.standardizedFileURL.pathComponents
+        guard let bundleName = components.last, bundleName.hasSuffix(".app"),
+              components.dropLast().allSatisfy({ !$0.hasSuffix(".app") }) else {
+            return false
+        }
+        return roots.contains { root in
+            let rootComponents = root.standardizedFileURL.pathComponents
+            return components.count > rootComponents.count
+                && Array(components.prefix(rootComponents.count)) == rootComponents
+        }
+    }
+}
+
+/// Which app activations deserve recording and surfacing in the Insights
+/// "Suggested shortcuts" card. Non-.regular processes are background
+/// agents, transient system dialogs (universalAccessAuthWarn — the
+/// Accessibility auth warning briefly becomes the active app), and embedded
+/// helpers — never suggestion material — UNLESS installed in a standard
+/// application directory: a real app running menu-bar-only or with a
+/// hidden Dock icon reports .accessory while remaining a legitimate switch
+/// target (the Settings picker lists it via the disk scan, and the toggle
+/// engine supports windowless .accessory targets).
+enum AppSuggestionEligibility {
+    /// Record-time gate, where the live activation policy is available.
+    static func shouldRecordActivation(
+        activationPolicy: NSApplication.ActivationPolicy,
+        bundleURL: URL?
+    ) -> Bool {
+        if activationPolicy == .regular { return true }
+        guard let bundleURL else { return false }
+        return StandardApplicationDirectories.contains(bundleURL)
+    }
+
+    /// Query-time gate for rows recorded before the record-time filter
+    /// existed (they persist until the user toggles collection off — there
+    /// is no age-out for app_activations). The process is usually gone by
+    /// query time, so LSUIElement/LSBackgroundOnly stand in for the live
+    /// activation policy; an unreadable Info.plist keeps the app, matching
+    /// the record-time default of trusting .regular.
+    static func isSuggestable(appURL: URL) -> Bool {
+        if StandardApplicationDirectories.contains(appURL) { return true }
+        return !declaresBackgroundUI(at: appURL)
+    }
+
+    private static func declaresBackgroundUI(at url: URL) -> Bool {
+        guard let info = Bundle(url: url)?.infoDictionary else { return false }
+        return boolValue(info["LSUIElement"]) || boolValue(info["LSBackgroundOnly"])
+    }
+
+    /// Info.plist booleans appear as <true/>, <integer>1</integer>, or
+    /// <string>1</string> depending on the bundle's era —
+    /// universalAccessAuthWarn itself ships the numeric form.
+    private static func boolValue(_ value: Any?) -> Bool {
+        if let number = value as? NSNumber { return number.boolValue }
+        if let string = value as? String { return (string as NSString).boolValue }
+        return false
+    }
+}

--- a/Sources/Wink/Services/AppSuggestionEligibility.swift
+++ b/Sources/Wink/Services/AppSuggestionEligibility.swift
@@ -17,17 +17,47 @@ enum StandardApplicationDirectories {
     /// inside another .app: an embedded helper at
     /// /Applications/X.app/Contents/.../Helper.app is not an installed app,
     /// and the AppListProvider scan never descends into .app bundles either.
+    ///
+    /// Both sides are normalized the way LaunchAtLoginService's
+    /// installed-in-Applications check normalizes (standardize + resolve
+    /// symlinks), plus two spellings symlink resolution cannot collapse:
+    /// the APFS firmlink alias /System/Volumes/Data/Applications, and
+    /// case variants on the default case-insensitive volume. The candidate
+    /// is tried both WITH and WITHOUT symlink resolution — resolution alone
+    /// would evict cryptex-backed apps (/Applications/Safari.app is a
+    /// symlink into /System/Cryptexes and must still count as installed),
+    /// while no resolution would miss a symlink that points INTO a root.
     static func contains(_ url: URL) -> Bool {
-        let components = url.standardizedFileURL.pathComponents
-        guard let bundleName = components.last, bundleName.hasSuffix(".app"),
-              components.dropLast().allSatisfy({ !$0.hasSuffix(".app") }) else {
-            return false
+        let standardized = url.standardizedFileURL
+        var candidates = [normalizedComponents(of: standardized)]
+        let resolved = normalizedComponents(of: standardized.resolvingSymlinksInPath())
+        if resolved != candidates[0] { candidates.append(resolved) }
+        return candidates.contains { components in
+            guard let bundleName = components.last, bundleName.lowercased().hasSuffix(".app"),
+                  components.dropLast().allSatisfy({ !$0.lowercased().hasSuffix(".app") }) else {
+                return false
+            }
+            return normalizedRoots.contains { root in
+                components.count > root.count
+                    && zip(root, components).allSatisfy { $0.caseInsensitiveCompare($1) == .orderedSame }
+            }
         }
-        return roots.contains { root in
-            let rootComponents = root.standardizedFileURL.pathComponents
-            return components.count > rootComponents.count
-                && Array(components.prefix(rootComponents.count)) == rootComponents
+    }
+
+    private static let normalizedRoots: [[String]] = roots.map {
+        normalizedComponents(of: $0.standardizedFileURL.resolvingSymlinksInPath())
+    }
+
+    private static func normalizedComponents(of url: URL) -> [String] {
+        var components = url.pathComponents
+        // /System/Volumes/Data/Applications is the same directory as
+        // /Applications through an APFS firmlink, which is not a symlink —
+        // no URL API collapses it, so strip the alias prefix by hand.
+        if components.count > 4, components[0] == "/",
+           components[1] == "System", components[2] == "Volumes", components[3] == "Data" {
+            components = ["/"] + components.dropFirst(4)
         }
+        return components
     }
 }
 

--- a/Sources/Wink/UI/InsightsViewModel.swift
+++ b/Sources/Wink/UI/InsightsViewModel.swift
@@ -89,17 +89,24 @@ final class InsightsViewModel {
     private let usageTracker: (any UsageTracking)?
     private let shortcutStore: ShortcutStore
     private let nowProvider: @Sendable () -> Date
+    private let appURLResolver: (String) -> URL?
     @ObservationIgnored private var refreshTask: Task<Void, Never>?
     @ObservationIgnored private var refreshGeneration: UInt64 = 0
 
+    // appURLResolver defaults to nil and resolves in the body — CI's Swift
+    // 6.1.2 SILGen crashes on non-trivial init default arguments.
     init(
         usageTracker: (any UsageTracking)?,
         shortcutStore: ShortcutStore,
-        nowProvider: @escaping @Sendable () -> Date = Date.init
+        nowProvider: @escaping @Sendable () -> Date = Date.init,
+        appURLResolver: ((String) -> URL?)? = nil
     ) {
         self.usageTracker = usageTracker
         self.shortcutStore = shortcutStore
         self.nowProvider = nowProvider
+        self.appURLResolver = appURLResolver ?? { bundleIdentifier in
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+        }
     }
 
     func scheduleRefresh() {
@@ -162,8 +169,15 @@ final class InsightsViewModel {
         let suggestions: [SuggestedApp] = Array(activationTotals
             .filter { !boundBundles.contains($0.bundleIdentifier) }
             .compactMap { entry -> SuggestedApp? in
-                guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: entry.bundleIdentifier) else {
+                guard let url = appURLResolver(entry.bundleIdentifier) else {
                     // Uninstalled or un-resolvable apps make poor suggestions.
+                    return nil
+                }
+                guard AppSuggestionEligibility.isSuggestable(appURL: url) else {
+                    // Rows recorded before the record-time policy gate (or
+                    // by an older build) can name system dialogs like
+                    // universalAccessAuthWarn; app_activations has no
+                    // age-out, so they must be dropped here.
                     return nil
                 }
                 return SuggestedApp(

--- a/Sources/Wink/UI/InsightsViewModel.swift
+++ b/Sources/Wink/UI/InsightsViewModel.swift
@@ -164,29 +164,38 @@ final class InsightsViewModel {
 
         let boundBundles = Set(shortcutStore.shortcuts.map(\.bundleIdentifier))
         let activationTotals = await usageTracker.appActivationTotals(days: days, relativeTo: now)
-        // Resolve BEFORE limiting: an uninstalled app in the top three must
-        // yield its slot to the next resolvable one, not shrink the card.
-        let suggestions: [SuggestedApp] = Array(activationTotals
-            .filter { !boundBundles.contains($0.bundleIdentifier) }
-            .compactMap { entry -> SuggestedApp? in
-                guard let url = appURLResolver(entry.bundleIdentifier) else {
-                    // Uninstalled or un-resolvable apps make poor suggestions.
-                    return nil
-                }
-                guard AppSuggestionEligibility.isSuggestable(appURL: url) else {
-                    // Rows recorded before the record-time policy gate (or
-                    // by an older build) can name system dialogs like
-                    // universalAccessAuthWarn; app_activations has no
-                    // age-out, so they must be dropped here.
-                    return nil
-                }
-                return SuggestedApp(
-                    bundleIdentifier: entry.bundleIdentifier,
-                    name: url.deletingPathExtension().lastPathComponent,
-                    count: entry.count
-                )
+        // A superseded refresh resuming from the await above must not grind
+        // through resolution on the main actor before its late-guard exit.
+        guard !Task.isCancelled, generation == refreshGeneration else { return }
+
+        // Resolve BEFORE limiting: an uninstalled or ineligible app in the
+        // top three must yield its slot to the next resolvable one, not
+        // shrink the card. An explicit loop (not a lazy chain — lazy
+        // collections re-run their closures during index math) so
+        // resolution and Info.plist reads run exactly once per visited row
+        // and stop at the third eligible suggestion instead of visiting
+        // every historical row (app_activations has no age-out).
+        var suggestions: [SuggestedApp] = []
+        for entry in activationTotals {
+            if suggestions.count == 3 { break }
+            guard !boundBundles.contains(entry.bundleIdentifier) else { continue }
+            guard let url = appURLResolver(entry.bundleIdentifier) else {
+                // Uninstalled or un-resolvable apps make poor suggestions.
+                continue
             }
-            .prefix(3))
+            guard AppSuggestionEligibility.isSuggestable(appURL: url) else {
+                // Rows recorded before the record-time policy gate (or by
+                // an older build) can name system dialogs like
+                // universalAccessAuthWarn; app_activations has no age-out,
+                // so they must be dropped here.
+                continue
+            }
+            suggestions.append(SuggestedApp(
+                bundleIdentifier: entry.bundleIdentifier,
+                name: url.deletingPathExtension().lastPathComponent,
+                count: entry.count
+            ))
+        }
 
         let reportingTimeZone = snapshot.timeZone
         let dailyCounts = snapshot.dailyCounts

--- a/Tests/WinkTests/AppSuggestionEligibilityTests.swift
+++ b/Tests/WinkTests/AppSuggestionEligibilityTests.swift
@@ -45,6 +45,28 @@ struct StandardApplicationDirectoriesTests {
     }
 
     @Test
+    func acceptsFilesystemSpellingsOfTheSameDirectory() throws {
+        // APFS firmlink alias — the same directory as /Applications, but
+        // not a symlink, so no URL API collapses it.
+        #expect(StandardApplicationDirectories.contains(
+            URL(fileURLWithPath: "/System/Volumes/Data/Applications/Firmlinked.app")))
+        // Case variant on the default case-insensitive volume.
+        #expect(StandardApplicationDirectories.contains(
+            URL(fileURLWithPath: "/applications/CaseVariant.app")))
+        // A symlink whose target lives in a standard root resolves through
+        // resolvingSymlinksInPath before comparison.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wink-symlink-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let link = root.appendingPathComponent("CalcLink.app")
+        try FileManager.default.createSymbolicLink(
+            at: link,
+            withDestinationURL: URL(fileURLWithPath: "/System/Applications/Calculator.app")
+        )
+        #expect(StandardApplicationDirectories.contains(link))
+    }
+
+    @Test
     func rejectsLookalikePrefixesNestedHelpersAndSystemPaths() {
         // String-prefix lookalike, not the real root.
         #expect(!StandardApplicationDirectories.contains(

--- a/Tests/WinkTests/AppSuggestionEligibilityTests.swift
+++ b/Tests/WinkTests/AppSuggestionEligibilityTests.swift
@@ -1,0 +1,202 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Wink
+
+// MARK: - Fixtures
+
+/// Builds a throwaway on-disk .app skeleton (Contents/Info.plist only) so
+/// the plist-proxy path of `isSuggestable` runs against a real Bundle read.
+/// Unique per call: Bundle caches instances by path.
+private func makeAppFixture(
+    named name: String,
+    infoPlist: [String: Any]?
+) throws -> URL {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wink-eligibility-\(UUID().uuidString)")
+    let appURL = root.appendingPathComponent("\(name).app")
+    let contents = appURL.appendingPathComponent("Contents")
+    try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+    if let infoPlist {
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: infoPlist,
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: contents.appendingPathComponent("Info.plist"))
+    }
+    return appURL
+}
+
+// MARK: - StandardApplicationDirectories
+
+@Suite("StandardApplicationDirectories containment")
+struct StandardApplicationDirectoriesTests {
+    @Test
+    func acceptsAppsInsideEveryStandardRoot() {
+        #expect(StandardApplicationDirectories.contains(
+            URL(fileURLWithPath: "/Applications/Safari.app")))
+        #expect(StandardApplicationDirectories.contains(
+            URL(fileURLWithPath: "/Applications/Utilities/Some Tool.app")))
+        #expect(StandardApplicationDirectories.contains(
+            URL(fileURLWithPath: "/System/Applications/Utilities/Terminal.app")))
+        #expect(StandardApplicationDirectories.contains(
+            URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Applications/Local.app")))
+    }
+
+    @Test
+    func rejectsLookalikePrefixesNestedHelpersAndSystemPaths() {
+        // String-prefix lookalike, not the real root.
+        #expect(!StandardApplicationDirectories.contains(
+            URL(fileURLWithPath: "/ApplicationsFake/Evil.app")))
+        // Embedded helper inside another bundle: the installed-app scan
+        // never descends into .app bundles, so neither may this check.
+        #expect(!StandardApplicationDirectories.contains(
+            URL(fileURLWithPath: "/Applications/Teams.app/Contents/Frameworks/Helper.app")))
+        // The motivating case: the Accessibility auth-warning dialog.
+        #expect(!StandardApplicationDirectories.contains(
+            URL(fileURLWithPath: "/System/Library/PrivateFrameworks/UniversalAccess.framework/Versions/A/Resources/universalAccessAuthWarn.app")))
+        // Not an .app bundle at all.
+        #expect(!StandardApplicationDirectories.contains(
+            URL(fileURLWithPath: "/Applications/readme.txt")))
+        #expect(!StandardApplicationDirectories.contains(
+            URL(fileURLWithPath: "/Applications")))
+    }
+}
+
+// MARK: - AppSuggestionEligibility
+
+@Suite("AppSuggestionEligibility record-time gate")
+struct AppSuggestionEligibilityRecordTests {
+    @Test
+    func regularAppsAlwaysRecord() {
+        #expect(AppSuggestionEligibility.shouldRecordActivation(
+            activationPolicy: .regular, bundleURL: nil))
+        #expect(AppSuggestionEligibility.shouldRecordActivation(
+            activationPolicy: .regular,
+            bundleURL: URL(fileURLWithPath: "/opt/somewhere/Odd.app")))
+    }
+
+    @Test
+    func nonRegularAppsRecordOnlyWhenInstalledInStandardRoots() {
+        // A real app the user runs menu-bar-only / with a hidden Dock icon.
+        #expect(AppSuggestionEligibility.shouldRecordActivation(
+            activationPolicy: .accessory,
+            bundleURL: URL(fileURLWithPath: "/Applications/Ice.app")))
+        // System dialog outside every root — the reported bug.
+        #expect(!AppSuggestionEligibility.shouldRecordActivation(
+            activationPolicy: .accessory,
+            bundleURL: URL(fileURLWithPath: "/System/Library/PrivateFrameworks/UniversalAccess.framework/Versions/A/Resources/universalAccessAuthWarn.app")))
+        #expect(!AppSuggestionEligibility.shouldRecordActivation(
+            activationPolicy: .accessory, bundleURL: nil))
+        #expect(!AppSuggestionEligibility.shouldRecordActivation(
+            activationPolicy: .prohibited,
+            bundleURL: URL(fileURLWithPath: "/System/Library/CoreServices/loginwindow.app")))
+    }
+}
+
+@Suite("AppSuggestionEligibility query-time gate")
+struct AppSuggestionEligibilityQueryTests {
+    @Test
+    func standardLocationShortCircuitsWithoutTouchingDisk() {
+        // Nonexistent on purpose: the standard-dir branch is pure path logic.
+        #expect(AppSuggestionEligibility.isSuggestable(
+            appURL: URL(fileURLWithPath: "/Applications/DoesNotExist-\(UUID().uuidString).app")))
+    }
+
+    @Test
+    func backgroundUIMarkersDisqualifyOutsideStandardRoots() throws {
+        // universalAccessAuthWarn ships the numeric form; cover the bool and
+        // string spellings too — all three appear in the wild.
+        for marker: [String: Any] in [
+            ["LSUIElement": true],
+            ["LSUIElement": 1],
+            ["LSUIElement": "1"],
+            ["LSBackgroundOnly": true],
+        ] {
+            let fixture = try makeAppFixture(named: "AgentFixture", infoPlist: marker)
+            #expect(!AppSuggestionEligibility.isSuggestable(appURL: fixture))
+        }
+    }
+
+    @Test
+    func plainAppsOutsideStandardRootsStaySuggestable() throws {
+        let regular = try makeAppFixture(
+            named: "RegularFixture",
+            infoPlist: ["CFBundleIdentifier": "com.example.regular"]
+        )
+        #expect(AppSuggestionEligibility.isSuggestable(appURL: regular))
+
+        let markerOff = try makeAppFixture(
+            named: "MarkerOffFixture",
+            infoPlist: ["LSUIElement": false]
+        )
+        #expect(AppSuggestionEligibility.isSuggestable(appURL: markerOff))
+
+        // Unreadable Info.plist keeps the app, mirroring the record-time
+        // default of trusting .regular.
+        let bare = try makeAppFixture(named: "BareFixture", infoPlist: nil)
+        #expect(AppSuggestionEligibility.isSuggestable(appURL: bare))
+    }
+}
+
+// MARK: - AppActivationRecorder
+
+@Suite("AppActivationRecorder policy gate")
+@MainActor
+struct AppActivationRecorderTests {
+    @Test
+    func recordsRegularAppsWhenEnabled() {
+        var recorded: [String] = []
+        let recorder = AppActivationRecorder(onActivation: { recorded.append($0) })
+        recorder.setEnabled(true)
+
+        recorder.handleActivation(
+            bundleIdentifier: "com.example.editor",
+            activationPolicy: .regular,
+            bundleURL: nil
+        )
+
+        #expect(recorded == ["com.example.editor"])
+    }
+
+    @Test
+    func dropsSystemDialogsButKeepsInstalledAccessoryApps() {
+        var recorded: [String] = []
+        let recorder = AppActivationRecorder(onActivation: { recorded.append($0) })
+        recorder.setEnabled(true)
+
+        recorder.handleActivation(
+            bundleIdentifier: "com.apple.accessibility.universalAccessAuthWarn",
+            activationPolicy: .accessory,
+            bundleURL: URL(fileURLWithPath: "/System/Library/PrivateFrameworks/UniversalAccess.framework/Versions/A/Resources/universalAccessAuthWarn.app")
+        )
+        recorder.handleActivation(
+            bundleIdentifier: "com.example.menubar",
+            activationPolicy: .accessory,
+            bundleURL: URL(fileURLWithPath: "/Applications/MenuBarThing.app")
+        )
+
+        #expect(recorded == ["com.example.menubar"])
+    }
+
+    @Test
+    func staysSilentWhenDisabledOrWithoutIdentity() {
+        var recorded: [String] = []
+        let recorder = AppActivationRecorder(onActivation: { recorded.append($0) })
+
+        recorder.handleActivation(
+            bundleIdentifier: "com.example.editor",
+            activationPolicy: .regular,
+            bundleURL: nil
+        )
+        recorder.setEnabled(true)
+        recorder.handleActivation(
+            bundleIdentifier: nil,
+            activationPolicy: .regular,
+            bundleURL: nil
+        )
+
+        #expect(recorded.isEmpty)
+    }
+}

--- a/Tests/WinkTests/InsightsViewModelTests.swift
+++ b/Tests/WinkTests/InsightsViewModelTests.swift
@@ -437,6 +437,7 @@ func suggestionsDropIneligibleAppsAndBackfillFreedSlots() async throws {
         "com.example.third": URL(fileURLWithPath: "/Applications/Third.app"),
         "com.example.fourth": URL(fileURLWithPath: "/Applications/Fourth.app"),
     ]
+    var resolvedBundleIDs: [String] = []
     let viewModel = InsightsViewModel(
         usageTracker: ActivationTotalsUsageTracker(totals: [
             (bundleIdentifier: "com.example.bound", count: 40),
@@ -448,7 +449,10 @@ func suggestionsDropIneligibleAppsAndBackfillFreedSlots() async throws {
             (bundleIdentifier: "com.example.fourth", count: 2),
         ]),
         shortcutStore: store,
-        appURLResolver: { urls[$0] }
+        appURLResolver: { bundleIdentifier in
+            resolvedBundleIDs.append(bundleIdentifier)
+            return urls[bundleIdentifier]
+        }
     )
     await viewModel.refresh(for: .week)
 
@@ -461,4 +465,16 @@ func suggestionsDropIneligibleAppsAndBackfillFreedSlots() async throws {
     ])
     #expect(viewModel.suggestedApps.map(\.name) == ["First", "Second", "Third"])
     #expect(viewModel.suggestedApps.map(\.count) == [30, 10, 5])
+
+    // The lazy pipeline stops at the third eligible suggestion: the bound
+    // entry is filtered without resolving, ineligible rows are visited on
+    // the way, and everything past "third" is never touched — the table has
+    // no age-out, so a long history must not be resolved wholesale.
+    #expect(resolvedBundleIDs == [
+        "com.example.first",
+        "com.example.dialog",
+        "com.example.uninstalled",
+        "com.example.second",
+        "com.example.third",
+    ])
 }

--- a/Tests/WinkTests/InsightsViewModelTests.swift
+++ b/Tests/WinkTests/InsightsViewModelTests.swift
@@ -378,3 +378,87 @@ private func timeZoneDistinctFromCurrent(relativeTo now: Date) -> TimeZone {
     }) ?? TimeZone(secondsFromGMT: 0)!
 }
 
+
+// MARK: - Suggested shortcuts
+
+/// Serves a fixed activation-totals list; every other tracking read is inert.
+private actor ActivationTotalsUsageTracker: UsageTracking {
+    let totals: [(bundleIdentifier: String, count: Int)]
+
+    init(totals: [(bundleIdentifier: String, count: Int)]) {
+        self.totals = totals
+    }
+
+    func appActivationTotals(days: Int, relativeTo now: Date) async -> [(bundleIdentifier: String, count: Int)] {
+        totals
+    }
+    func deleteUsage(shortcutId: UUID) {}
+    func usageCounts(days: Int, relativeTo now: Date) async -> [UUID: Int] { [:] }
+    func dailyCounts(days: Int, relativeTo now: Date) async -> [String: [(date: String, count: Int)]] { [:] }
+    func totalSwitches(days: Int, relativeTo now: Date) async -> Int { 0 }
+    func hourlyCounts(days: Int, relativeTo now: Date) async -> [HourlyUsageBucket] { [] }
+    func previousPeriodTotal(days: Int, relativeTo now: Date) async -> Int { 0 }
+    func streakDays(relativeTo now: Date) async -> Int { 0 }
+    func usageTimeZone() async -> TimeZone { .current }
+}
+
+/// Historical `app_activations` rows can name background-only system
+/// processes recorded before the record-time gate existed (the reported
+/// case: universalAccessAuthWarn, the Accessibility auth-warning dialog).
+/// The query side must drop them AND let the next resolvable app take the
+/// freed suggestion slot, alongside the existing bound/unresolvable drops.
+@Test @MainActor
+func suggestionsDropIneligibleAppsAndBackfillFreedSlots() async throws {
+    let boundShortcut = AppShortcut(
+        appName: "Bound",
+        bundleIdentifier: "com.example.bound",
+        keyEquivalent: "b",
+        modifierFlags: ["command"]
+    )
+    let store = ShortcutStore()
+    store.replaceAll(with: [boundShortcut])
+
+    let dialogFixtureRoot = FileManager.default.temporaryDirectory
+        .appendingPathComponent("wink-insights-\(UUID().uuidString)")
+    let dialogApp = dialogFixtureRoot.appendingPathComponent("authWarnFixture.app")
+    let contents = dialogApp.appendingPathComponent("Contents")
+    try FileManager.default.createDirectory(at: contents, withIntermediateDirectories: true)
+    try PropertyListSerialization.data(
+        fromPropertyList: ["LSUIElement": 1],
+        format: .xml,
+        options: 0
+    ).write(to: contents.appendingPathComponent("Info.plist"))
+
+    let urls: [String: URL] = [
+        "com.example.bound": URL(fileURLWithPath: "/Applications/Bound.app"),
+        "com.example.first": URL(fileURLWithPath: "/Applications/First.app"),
+        "com.example.dialog": dialogApp,
+        "com.example.second": URL(fileURLWithPath: "/Applications/Second.app"),
+        "com.example.third": URL(fileURLWithPath: "/Applications/Third.app"),
+        "com.example.fourth": URL(fileURLWithPath: "/Applications/Fourth.app"),
+    ]
+    let viewModel = InsightsViewModel(
+        usageTracker: ActivationTotalsUsageTracker(totals: [
+            (bundleIdentifier: "com.example.bound", count: 40),
+            (bundleIdentifier: "com.example.first", count: 30),
+            (bundleIdentifier: "com.example.dialog", count: 20),
+            (bundleIdentifier: "com.example.uninstalled", count: 15),
+            (bundleIdentifier: "com.example.second", count: 10),
+            (bundleIdentifier: "com.example.third", count: 5),
+            (bundleIdentifier: "com.example.fourth", count: 2),
+        ]),
+        shortcutStore: store,
+        appURLResolver: { urls[$0] }
+    )
+    await viewModel.refresh(for: .week)
+
+    // bound → already has a shortcut; dialog → LSUIElement fixture;
+    // uninstalled → unresolvable. Each freed slot backfills in count order.
+    #expect(viewModel.suggestedApps.map(\.bundleIdentifier) == [
+        "com.example.first",
+        "com.example.second",
+        "com.example.third",
+    ])
+    #expect(viewModel.suggestedApps.map(\.name) == ["First", "Second", "Third"])
+    #expect(viewModel.suggestedApps.map(\.count) == [30, 10, 5])
+}


### PR DESCRIPTION
Fixes #424

## Summary
- The Insights "Suggested shortcuts" card no longer surfaces background system processes. The reported case: `universalAccessAuthWarn` (macOS's LSUIElement Accessibility auth-warning dialog under `/System/Library/PrivateFrameworks`) appeared as a suggestion with a blank icon after briefly taking focus.
- Root cause: `AppActivationRecorder` recorded every `didActivateApplicationNotification` with no activation-policy check, and the query side only dropped bound + unresolvable bundles — LaunchServices resolves system helpers fine, and `app_activations` rows never age out.
- New shared policy `AppSuggestionEligibility`, mirroring the #384 `AppListProvider` rule: a non-`.regular` process is not suggestion material **unless** it resolves to an app installed in a standard application directory (menu-bar-only / hidden-Dock-icon apps report `.accessory` but stay legitimate).
  - **Record time**: drops non-`.regular` apps outside `/Applications`, `/System/Applications`, `~/Applications` (component-wise path match; bundles nested inside another `.app` are embedded helpers and rejected).
  - **Query time**: `LSUIElement`/`LSBackgroundOnly` in the resolved bundle's Info.plist stand in for the live policy, so rows already recorded by older builds stop surfacing; a freed top-3 slot backfills with the next resolvable app (resolve-before-limit invariant preserved).
- `AppListProvider.scanInstalledApps` now reads the same shared `StandardApplicationDirectories.roots`, so the #384 "installed app" exception and this policy can't drift apart.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

774 tests pass, including 12 new ones: path-policy cases (lookalike prefixes, nested-helper `.app` bundles, all three standard roots, the `/System/Volumes/Data` firmlink alias, case variants, symlinks in both directions — a cryptex-backed `/Applications/Safari.app` must count, a temp symlink into `/System/Applications` must too), Info.plist marker forms (`<true/>`, `<integer>1</integer>`, `<string>1</string>` — universalAccessAuthWarn ships the numeric form), recorder enable/policy gates, and an `InsightsViewModel` suggestion-pipeline test through the new `appURLResolver` seam (nil-defaulted init param per the CI SILGen rule) that also asserts resolver-call bounds: exactly one resolution per visited row, stopping at the third eligible suggestion.

A pre-push local Codex deep review (per the repo review protocol) surfaced two findings, both fixed in the second commit: the eager suggestion pipeline could grind through the full no-age-out history on the main actor after a superseded refresh resumed (now an explicit capped loop plus an early cancellation guard), and the path predicate diverged from `LaunchAtLoginService`'s filesystem-aware containment (now normalizes both spellings — symlink-resolved and not — since resolution alone would evict cryptex-backed apps).

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- Passive observation only — no change to event taps, activation, TCC, or the usage.db schema (strictly fewer rows recorded).
- Known trade-off (same as #384): a legitimate `.accessory` app running from outside every standard root is knowingly excluded at record time.
- Historical bogus rows are not purged; the query-time filter covers display, and the rows vanish with the existing collection-toggle purge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
