### PR TITLE
fix: guard the recorder's deferred teardown cancel with a session generation

### DIFF
--- a/Sources/Wink/Services/ShortcutEditorState.swift
+++ b/Sources/Wink/Services/ShortcutEditorState.swift
@@ -74,8 +74,20 @@ final class ShortcutEditorState {
     var selectedBundleIdentifier: String = ""
     var recordedShortcut: RecordedShortcut?
     var isRecordingShortcut: Bool = false {
-        didSet { syncRecordingSessionGate() }
+        didSet {
+            if isRecordingShortcut, !oldValue { shortcutRecordingGeneration &+= 1 }
+            syncRecordingSessionGate()
+        }
     }
+    /// #420: identifies each composer recording session. The recorder's
+    /// teardown-deferred cancel snapshots this at teardown and skips its
+    /// flag write when a successor session bumped it before the deferred
+    /// block drained — an unconditional stale cancel would end the new
+    /// session on arrival ("clicked record, instantly back to idle").
+    /// Per-lane on purpose: a single shared counter would let a session
+    /// starting in the OTHER lane suppress this lane's still-needed cancel
+    /// and leave the #417 dispatch gate latched.
+    @ObservationIgnored private(set) var shortcutRecordingGeneration: UInt64 = 0
     var conflictMessage: String?
     var saveErrorMessage: String?
     /// Recording state for the #356 search-palette trigger's dedicated
@@ -84,8 +96,14 @@ final class ShortcutEditorState {
     /// an in-progress draft in the other.
     var recordedSearchPaletteShortcut: RecordedShortcut?
     var isRecordingSearchPaletteShortcut: Bool = false {
-        didSet { syncRecordingSessionGate() }
+        didSet {
+            if isRecordingSearchPaletteShortcut, !oldValue { searchPaletteRecordingGeneration &+= 1 }
+            syncRecordingSessionGate()
+        }
     }
+    /// #420: the search-palette lane's counterpart to
+    /// `shortcutRecordingGeneration` — see that property for the contract.
+    @ObservationIgnored private(set) var searchPaletteRecordingGeneration: UInt64 = 0
     var searchPaletteConflictMessage: String?
     /// Palette-scoped mirror of `saveErrorMessage` — the General tab's card
     /// shows this instead of the shared property so a persistence failure

--- a/Sources/Wink/UI/GeneralTabView.swift
+++ b/Sources/Wink/UI/GeneralTabView.swift
@@ -388,7 +388,8 @@ struct GeneralTabView: View {
                         }
                     }
                 ),
-                isRecording: $editor.isRecordingSearchPaletteShortcut
+                isRecording: $editor.isRecordingSearchPaletteShortcut,
+                sessionGeneration: { editor.searchPaletteRecordingGeneration }
             )
             .frame(height: 28)
         } else {

--- a/Sources/Wink/UI/ShortcutRecorderView.swift
+++ b/Sources/Wink/UI/ShortcutRecorderView.swift
@@ -10,6 +10,10 @@ struct ShortcutRecorderView: View {
 
     @Binding var recordedShortcut: RecordedShortcut?
     @Binding var isRecording: Bool
+    /// #420: reports the current recording-session generation for this
+    /// recorder's lane (see ShortcutEditorState). nil (previews, tests)
+    /// keeps the teardown cancel unconditional.
+    var sessionGeneration: (() -> UInt64)? = nil
 
     @State private var liveModifierLabels: [String] = []
     @State private var errorMessage: String?
@@ -66,7 +70,8 @@ struct ShortcutRecorderView: View {
                 },
                 onErrorChange: { message in
                     errorMessage = message
-                }
+                },
+                sessionGeneration: sessionGeneration
             )
         )
     }
@@ -79,6 +84,7 @@ private struct RecorderKeyCaptureRepresentable: NSViewRepresentable {
     let onCancel: () -> Void
     let onLiveModifiersChange: ([String]) -> Void
     let onErrorChange: (String?) -> Void
+    let sessionGeneration: (() -> UInt64)?
 
     func makeNSView(context: Context) -> RecorderField {
         let field = RecorderField()
@@ -106,6 +112,7 @@ private struct RecorderKeyCaptureRepresentable: NSViewRepresentable {
         field.onCancel = onCancel
         field.onLiveModifiersChange = onLiveModifiersChange
         field.onErrorChange = onErrorChange
+        field.sessionGenerationProvider = sessionGeneration
     }
 }
 
@@ -126,6 +133,11 @@ final class RecorderField: NSView {
     var onCancel: (() -> Void)?
     var onLiveModifiersChange: (([String]) -> Void)?
     var onErrorChange: ((String?) -> Void)?
+    /// #420: current session generation for this field's lane. The
+    /// teardown-deferred cancel snapshots it and skips its write when a
+    /// successor session bumped it before the deferred block drained.
+    /// nil keeps the cancel unconditional.
+    var sessionGenerationProvider: (() -> UInt64)?
 
     private let keySymbolMapper = KeySymbolMapper()
     private var isRecording = false
@@ -184,7 +196,19 @@ final class RecorderField: NSView {
         // flips synchronously so no late observer double-cancels.
         isRecording = false
         let cancel = onCancel
+        let generationProvider = sessionGenerationProvider
+        let generationAtTeardown = generationProvider?()
         DispatchQueue.main.async {
+            // #420: if a successor session started in this lane before this
+            // block drained (flag back to true bumps the generation), the
+            // stale cancel must not clobber it. Runloop ordering between an
+            // already-queued NSEvent and this block is not contractual, so
+            // "a re-click can't get in first" is not a safe assumption.
+            // Only this deferred path is guarded — live cancels (escape,
+            // outside click, key-window resignation) stay unconditional.
+            if let generationProvider, generationProvider() != generationAtTeardown {
+                return
+            }
             cancel?()
         }
     }

--- a/Sources/Wink/UI/ShortcutsTabView.swift
+++ b/Sources/Wink/UI/ShortcutsTabView.swift
@@ -420,7 +420,8 @@ struct ShortcutsTabView: View {
                             if editor.isRecordingShortcut {
                                 ShortcutRecorderView(
                                     recordedShortcut: $editor.recordedShortcut,
-                                    isRecording: $editor.isRecordingShortcut
+                                    isRecording: $editor.isRecordingShortcut,
+                                    sessionGeneration: { editor.shortcutRecordingGeneration }
                                 )
                                 .frame(height: 28)
                             } else {

--- a/Tests/WinkTests/LayoutRegressionTests.swift
+++ b/Tests/WinkTests/LayoutRegressionTests.swift
@@ -794,6 +794,79 @@ struct LayoutRegressionTests {
         #expect(minimizeButton.frame.origin.isWithinHalfPoint(of: appKitOwnedOrigins[minimizeButton]))
         #expect(zoomButton.frame.origin.isWithinHalfPoint(of: appKitOwnedOrigins[zoomButton]))
     }
+
+    @Test @MainActor
+    func composerRecorderFieldIsWiredToTheComposerLaneGeneration() {
+        // #420: the teardown-cancel generation guard is only as good as the
+        // lane wiring in the PRODUCTION view body — a composer recorder
+        // reading the palette counter would revive the stale-cancel clobber
+        // while every unit test (which injects its own getter) stays green.
+        // Rendered through the real ShortcutsTabView to pin the pairing.
+        let context = ShortcutsTabLayoutContext(shortcutCount: 1)
+        defer { context.harness.cleanup() }
+        context.editor.isRecordingShortcut = true
+
+        let hostingView = makeHostingView(
+            ShortcutsTabView(
+                editor: context.editor,
+                preferences: context.preferences,
+                appListProvider: context.appListProvider,
+                shortcutStatusProvider: context.shortcutStatusProvider
+            ),
+            size: NSSize(width: 700, height: 430)
+        )
+        let field = descendants(in: hostingView).compactMap { $0 as? RecorderField }.first
+        // Synchronous monitor uninstall — no deferred cancel left behind.
+        defer { field?.updateRecordingState(isRecording: false) }
+
+        let provider = field?.sessionGenerationProvider
+        let baseline = provider?()
+        #expect(baseline != nil)
+        #expect(baseline == context.editor.shortcutRecordingGeneration)
+
+        // The OTHER lane's session must not advance this recorder's lane…
+        context.editor.isRecordingSearchPaletteShortcut = true
+        #expect(provider?() == baseline)
+        context.editor.isRecordingSearchPaletteShortcut = false
+
+        // …while a same-lane successor session must.
+        context.editor.isRecordingShortcut = false
+        context.editor.isRecordingShortcut = true
+        #expect(provider?() == baseline.map { $0 &+ 1 })
+        context.editor.isRecordingShortcut = false
+    }
+
+    @Test @MainActor
+    func paletteRecorderFieldIsWiredToThePaletteLaneGeneration() {
+        // Symmetric wiring pin for the General tab's palette recorder.
+        let context = SettingsViewLayoutContext()
+        defer { context.harness.cleanup() }
+        context.editor.isRecordingSearchPaletteShortcut = true
+
+        // 900pt viewport: the palette card sits below keyboardCard in a
+        // LazyVStack that only materializes rows near the viewport (see
+        // generalKeyboardCardMatchesDesignRowDensity).
+        let hostingView = makeHostingView(
+            GeneralTabView(preferences: context.preferences, editor: context.editor),
+            size: NSSize(width: 700, height: 900)
+        )
+        let field = descendants(in: hostingView).compactMap { $0 as? RecorderField }.first
+        defer { field?.updateRecordingState(isRecording: false) }
+
+        let provider = field?.sessionGenerationProvider
+        let baseline = provider?()
+        #expect(baseline != nil)
+        #expect(baseline == context.editor.searchPaletteRecordingGeneration)
+
+        context.editor.isRecordingShortcut = true
+        #expect(provider?() == baseline)
+        context.editor.isRecordingShortcut = false
+
+        context.editor.isRecordingSearchPaletteShortcut = false
+        context.editor.isRecordingSearchPaletteShortcut = true
+        #expect(provider?() == baseline.map { $0 &+ 1 })
+        context.editor.isRecordingSearchPaletteShortcut = false
+    }
 }
 
 private extension NSPoint {

--- a/Tests/WinkTests/ShortcutEditorStateTests.swift
+++ b/Tests/WinkTests/ShortcutEditorStateTests.swift
@@ -1346,3 +1346,29 @@ func captureStatusReflectsSecureInputProbeAndPollNotifiesOnChange() {
     manager.checkPermissionChange()
     #expect(statusChangeNotifications == 2)
 }
+
+@Test @MainActor
+func recordingGenerationsBumpPerLaneOnlyOnStartTransitions() {
+    // #420: the generations identify recording sessions for the recorder's
+    // teardown-deferred cancel guard. Only a false→true transition is a new
+    // session; redundant true writes and stops must not advance them, and
+    // the two lanes must stay independent (a shared counter would let a
+    // palette session suppress the composer lane's still-needed cancel).
+    let (editor, _, _, _, _) = makeEditorContext()
+
+    #expect(editor.shortcutRecordingGeneration == 0)
+    #expect(editor.searchPaletteRecordingGeneration == 0)
+
+    editor.isRecordingShortcut = true
+    #expect(editor.shortcutRecordingGeneration == 1)
+    editor.isRecordingShortcut = true
+    #expect(editor.shortcutRecordingGeneration == 1)
+    editor.isRecordingShortcut = false
+    #expect(editor.shortcutRecordingGeneration == 1)
+    editor.isRecordingShortcut = true
+    #expect(editor.shortcutRecordingGeneration == 2)
+
+    editor.isRecordingSearchPaletteShortcut = true
+    #expect(editor.searchPaletteRecordingGeneration == 1)
+    #expect(editor.shortcutRecordingGeneration == 2)
+}

--- a/Tests/WinkTests/ShortcutRecorderFieldTests.swift
+++ b/Tests/WinkTests/ShortcutRecorderFieldTests.swift
@@ -279,4 +279,66 @@ struct ShortcutRecorderFieldTests {
         harness.field.updateRecordingState(isRecording: false)
         #expect(!harness.field.isMonitoringForTesting)
     }
+
+    @Test @MainActor
+    func staleTeardownCancelIsSuppressedWhenASuccessorSessionStarts() async {
+        // #420: the teardown cancel is queued a tick out and writes the
+        // shared lane flag unconditionally. If a successor session starts
+        // in the same lane before the block drains (generation bump), the
+        // stale cancel must not end it on arrival.
+        var cancelCount = 0
+        var generation: UInt64 = 1
+        let field = RecorderField()
+        field.onCancel = { cancelCount += 1 }
+        field.sessionGenerationProvider = { generation }
+        field.updateRecordingState(isRecording: true)
+
+        field.endSessionForTeardown()
+        // Successor session starts before the deferred cancel drains.
+        generation = 2
+
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+        #expect(cancelCount == 0)
+    }
+
+    @Test @MainActor
+    func teardownCancelStillFiresWhenNoSuccessorStarts() async {
+        // The #418 contract stands: with no successor session, the deferred
+        // cancel must land — a skipped cancel here leaves the #417 dispatch
+        // gate latched with no live recorder.
+        var cancelCount = 0
+        let generation: UInt64 = 7
+        let field = RecorderField()
+        field.onCancel = { cancelCount += 1 }
+        field.sessionGenerationProvider = { generation }
+        field.updateRecordingState(isRecording: true)
+
+        field.endSessionForTeardown()
+
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+        #expect(cancelCount == 1)
+    }
+
+    @Test @MainActor
+    func liveCancelIgnoresGenerationMismatch() {
+        // Only the deferred teardown path is generation-guarded. A live
+        // cancel (escape here; outside click and key-window resignation
+        // share the same direct onCancel call) reflects a real user action
+        // against the CURRENT session and must never be suppressed.
+        var cancelCount = 0
+        var generation: UInt64 = 1
+        let field = RecorderField()
+        field.onCancel = { cancelCount += 1 }
+        field.sessionGenerationProvider = { generation }
+        field.updateRecordingState(isRecording: true)
+        generation = 99
+
+        _ = field.handleMonitoredEvent(Self.keyEvent(keyCode: 53))
+
+        #expect(cancelCount == 1)
+    }
 }


### PR DESCRIPTION
Fixes #420

## Summary
- `RecorderField.endSessionForTeardown()` queues its cancel one main-queue turn out, and the closure writes the shared lane recording flag unconditionally. Runloop source ordering between an already-queued `NSEvent` and a just-enqueued main block is not contractual, so a successor recording session starting in the same lane before the block drains could be ended on arrival ("clicked record, instantly back to idle"). #420's alternative — proving the state unreachable — is therefore not available, so this implements the suggested generation guard.
- Per-lane session generations on `ShortcutEditorState` (`shortcutRecordingGeneration` for the Shortcuts-tab composer, `searchPaletteRecordingGeneration` for the General-tab palette trigger), bumped only on `false→true` transitions of the corresponding flag. The recorder plumbs an optional `sessionGeneration` closure down to `RecorderField`; the teardown-deferred cancel snapshots it and skips its flag write on mismatch.
- Per-lane on purpose: a single shared counter would let a session starting in the *other* lane suppress this lane's still-needed cancel and leave the #417 dispatch gate latched with no live recorder.
- Live cancels (escape, outside click, key-window resignation) stay unconditional — they act on the current session. A nil provider (previews, tests without plumbing) keeps the #418 unconditional-cancel contract.

## Testing
- [x] `swift test`
- [x] Additional validation noted below when needed

780 tests pass, 6 new: field-level guard behavior (stale cancel suppressed on generation mismatch, still fires when stable, live escape-cancel ignores the generation entirely), editor-state generation semantics (bump only on start transitions, lanes independent), and — after a pre-push local Codex review flagged the gap (P3, its only finding) — two production-wiring tests that render the real `ShortcutsTabView` / `GeneralTabView`, extract the live `RecorderField` from the hosted tree, and pin each recorder to exactly its own lane's counter, so a composer↔palette mix-up in the view bodies can no longer stay green.

## Validation Status
- [x] Not runtime-sensitive
- [ ] macOS runtime validation pending
- [ ] macOS runtime validation complete

## Docs Sync Check (issue #230)
- [x] If this PR touches toggle / activation / event tap / persistence behavior, the relevant `AGENTS.md` and `docs/architecture.md` sections still describe the new behavior accurately (or have been updated in this PR).
- [x] No new references to `docs/archive/` as a current source of truth.

## Notes
- The #418 teardown contract (cancel must survive field release, unlatch the #417 gate) is unchanged for every case except a same-lane successor already owning the flag — exactly the case where writing `false` would be wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
